### PR TITLE
Enable archive delete-on-verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ In the Web UI, you can specify a custom output directory for converted CHD files
 - Real-time progress tracking via Server-Sent Events
 - Duplicate detection with options to skip, rename, or overwrite
 - Optional delete-on-verify with a preflight confirmation list (includes `.cue`/`.gdi` track files)
+- Archive conversions can delete the entire archive after verify (explicit warning in the delete plan)
 
 **Bulk Operations**
 - **Bulk Delete**: Delete multiple selected files at once

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unreleased
+
+### ✨ New Features
+
+- **Archive delete-on-verify** - Archive inputs can now delete the entire archive after a successful conversion + verification, with an explicit warning in the delete plan.
+
 ## v1.2.1 - Archive Safety Limits & Timeout Controls
 
 ### ✨ New Features

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import re
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Set
 
 from fastapi import APIRouter, HTTPException
 from fastapi.concurrency import run_in_threadpool
@@ -57,12 +57,8 @@ def supports_delete_on_verify(mode: str) -> bool:
     return mode.startswith("create") or mode == "copy"
 
 
-def get_disallowed_archive_paths(file_paths: List[str]) -> set:
-    """Get archive paths that have multiple files selected from them.
-    
-    Returns a set of archive paths that should not allow delete-on-verify
-    because multiple files from the same archive are selected.
-    """
+def get_disallowed_archive_paths(file_paths: List[str]) -> Set[str]:
+    """Get archive paths that should not allow delete-on-verify due to multiple selections."""
     archive_counts = {}
     for file_path in file_paths:
         if "::" not in file_path:

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -169,21 +169,25 @@ async def delete_plan(request: DeletePlanRequest) -> dict:
             detail="Delete-on-verify is only supported for create/copy modes",
         )
 
+    archive_counts = {}
+    for file_path in request.file_paths:
+        if "::" not in file_path:
+            continue
+        archive_path = file_path.split("::", 1)[0]
+        archive_counts[archive_path] = archive_counts.get(archive_path, 0) + 1
+    disallowed_archives = {
+        archive_path
+        for archive_path, count in archive_counts.items()
+        if count > 1
+    }
+
     items = []
     blocked = False
     total_delete_count = 0
 
     for file_path in request.file_paths:
         item = None
-        if "::" in file_path:
-            item = {
-                "source_path": file_path,
-                "delete_paths": [],
-                "missing_paths": [],
-                "unsafe_paths": ["Archive inputs are not supported for delete-on-verify"],
-                "errors": [],
-            }
-        elif not is_within_configured_volumes(file_path, treat_archives=False):
+        if not is_within_configured_volumes(file_path):
             item = {
                 "source_path": file_path,
                 "delete_paths": [],
@@ -193,6 +197,13 @@ async def delete_plan(request: DeletePlanRequest) -> dict:
             }
         else:
             item = await run_in_threadpool(build_delete_plan, file_path)
+
+        if "::" in file_path:
+            archive_path = file_path.split("::", 1)[0]
+            if archive_path in disallowed_archives:
+                item.setdefault("errors", []).append(
+                    "Delete-on-verify is not supported for multiple selections from the same archive"
+                )
 
         items.append(item)
         total_delete_count += len(item.get("delete_paths", []))
@@ -222,11 +233,21 @@ async def create_job(request: JobCreateRequest):
             status_code=400,
             detail="Delete-on-verify is only supported for create/copy modes",
         )
-    if request.delete_on_verify and "::" in request.file_path:
-        raise HTTPException(
-            status_code=400,
-            detail="Delete-on-verify is not supported for archive inputs",
-        )
+    if request.delete_on_verify:
+        archive_counts = {}
+        for file_path in [request.file_path]:
+            if "::" not in file_path:
+                continue
+            archive_path = file_path.split("::", 1)[0]
+            archive_counts[archive_path] = archive_counts.get(archive_path, 0) + 1
+        if any(count > 1 for count in archive_counts.values()):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Delete-on-verify is not supported for multiple selections from the "
+                    "same archive"
+                ),
+            )
     if not is_within_configured_volumes(request.file_path):
         raise HTTPException(
             status_code=403,
@@ -372,11 +393,21 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
             status_code=400,
             detail="Delete-on-verify is only supported for create/copy modes",
         )
-    if request.delete_on_verify and any("::" in path for path in request.file_paths):
-        raise HTTPException(
-            status_code=400,
-            detail="Delete-on-verify is not supported for archive inputs",
-        )
+    if request.delete_on_verify:
+        archive_counts = {}
+        for file_path in request.file_paths:
+            if "::" not in file_path:
+                continue
+            archive_path = file_path.split("::", 1)[0]
+            archive_counts[archive_path] = archive_counts.get(archive_path, 0) + 1
+        if any(count > 1 for count in archive_counts.values()):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Delete-on-verify is not supported for multiple selections from the "
+                    "same archive"
+                ),
+            )
     for file_path in request.file_paths:
         if not is_within_configured_volumes(file_path):
             raise HTTPException(

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -57,6 +57,25 @@ def supports_delete_on_verify(mode: str) -> bool:
     return mode.startswith("create") or mode == "copy"
 
 
+def get_disallowed_archive_paths(file_paths: List[str]) -> set:
+    """Get archive paths that have multiple files selected from them.
+    
+    Returns a set of archive paths that should not allow delete-on-verify
+    because multiple files from the same archive are selected.
+    """
+    archive_counts = {}
+    for file_path in file_paths:
+        if "::" not in file_path:
+            continue
+        archive_path = file_path.split("::", 1)[0]
+        archive_counts[archive_path] = archive_counts.get(archive_path, 0) + 1
+    return {
+        archive_path
+        for archive_path, count in archive_counts.items()
+        if count > 1
+    }
+
+
 def get_unique_output_path(base_path: str) -> str:
     """Generate a unique output path by appending a number if the file exists."""
     file_exists, is_locked = lock_manager.check_file_status(base_path)
@@ -169,17 +188,7 @@ async def delete_plan(request: DeletePlanRequest) -> dict:
             detail="Delete-on-verify is only supported for create/copy modes",
         )
 
-    archive_counts = {}
-    for file_path in request.file_paths:
-        if "::" not in file_path:
-            continue
-        archive_path = file_path.split("::", 1)[0]
-        archive_counts[archive_path] = archive_counts.get(archive_path, 0) + 1
-    disallowed_archives = {
-        archive_path
-        for archive_path, count in archive_counts.items()
-        if count > 1
-    }
+    disallowed_archives = get_disallowed_archive_paths(request.file_paths)
 
     items = []
     blocked = False
@@ -233,21 +242,6 @@ async def create_job(request: JobCreateRequest):
             status_code=400,
             detail="Delete-on-verify is only supported for create/copy modes",
         )
-    if request.delete_on_verify:
-        archive_counts = {}
-        for file_path in [request.file_path]:
-            if "::" not in file_path:
-                continue
-            archive_path = file_path.split("::", 1)[0]
-            archive_counts[archive_path] = archive_counts.get(archive_path, 0) + 1
-        if any(count > 1 for count in archive_counts.values()):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "Delete-on-verify is not supported for multiple selections from the "
-                    "same archive"
-                ),
-            )
     if not is_within_configured_volumes(request.file_path):
         raise HTTPException(
             status_code=403,
@@ -394,13 +388,8 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
             detail="Delete-on-verify is only supported for create/copy modes",
         )
     if request.delete_on_verify:
-        archive_counts = {}
-        for file_path in request.file_paths:
-            if "::" not in file_path:
-                continue
-            archive_path = file_path.split("::", 1)[0]
-            archive_counts[archive_path] = archive_counts.get(archive_path, 0) + 1
-        if any(count > 1 for count in archive_counts.values()):
+        disallowed_archives = get_disallowed_archive_paths(request.file_paths)
+        if disallowed_archives:
             raise HTTPException(
                 status_code=400,
                 detail=(

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -21,7 +21,7 @@ from services.chd_metadata_store import chd_metadata_store
 from services.archive import archive_service
 from fastapi.concurrency import run_in_threadpool
 from config import settings
-from utils.path_utils import is_within_configured_volumes
+from utils.path_utils import is_within_configured_volumes, strip_archive_path
 from utils.delete_plan import build_delete_plan
 
 
@@ -900,10 +900,6 @@ class JobManager:
                         raise RuntimeError(
                             "Delete-on-verify is only supported for create/copy modes"
                         )
-                    if "::" in job.file_path:
-                        raise RuntimeError(
-                            "Delete-on-verify is not supported for archive inputs"
-                        )
                     if cancel_event.is_set():
                         raise ConversionCancelled("Conversion cancelled")
 
@@ -941,7 +937,14 @@ class JobManager:
                             },
                         )
                     else:
-                        job.message = "Verification complete. Deleting source..."
+                        delete_label = (
+                            "source archive"
+                            if "::" in job.file_path
+                            else "source"
+                        )
+                        job.message = (
+                            f"Verification complete. Deleting {delete_label}..."
+                        )
                         await self._notify_subscribers(
                             job_id,
                             {
@@ -980,7 +983,12 @@ class JobManager:
                             )
 
                         output_real = os.path.realpath(job.output_path)
-                        source_real = os.path.realpath(job.file_path)
+                        source_for_delete = (
+                            strip_archive_path(job.file_path)
+                            if "::" in job.file_path
+                            else job.file_path
+                        )
+                        source_real = os.path.realpath(source_for_delete)
                         delete_order = [
                             p
                             for p in expected_paths

--- a/app/utils/delete_plan.py
+++ b/app/utils/delete_plan.py
@@ -4,6 +4,8 @@ import shlex
 from pathlib import Path
 from typing import Dict, List, Set
 
+from utils.path_utils import strip_archive_path
+
 
 _WIN_ABS_RE = re.compile(r"^[a-zA-Z]:[\\/]")
 
@@ -89,13 +91,17 @@ def _parse_gdi_tracks(gdi_path: Path) -> List[str]:
 
 
 def build_delete_plan(source_path: str) -> Dict[str, object]:
-    source = Path(source_path)
+    original_source = source_path
+    is_archive_member = "::" in source_path
+    plan_source = strip_archive_path(source_path) if is_archive_member else source_path
+    source = Path(plan_source)
     base_dir = source.parent
     resolved: Set[str] = set()
     delete_paths: List[str] = []
     missing_paths: List[str] = []
     unsafe_paths: List[str] = []
     errors: List[str] = []
+    warnings: List[str] = []
 
     def _add_path(path: Path) -> None:
         path_str = str(path)
@@ -113,6 +119,18 @@ def build_delete_plan(source_path: str) -> Dict[str, object]:
 
     try:
         _add_path(source)
+        if is_archive_member:
+            warnings.append(
+                "Archive input detected; delete-on-verify will remove the entire archive"
+            )
+            return {
+                "source_path": original_source,
+                "delete_paths": delete_paths,
+                "missing_paths": missing_paths,
+                "unsafe_paths": unsafe_paths,
+                "errors": errors,
+                "warnings": warnings,
+            }
         ext = source.suffix.lower()
         track_refs: List[str] = []
         if ext == ".cue":
@@ -133,11 +151,12 @@ def build_delete_plan(source_path: str) -> Dict[str, object]:
         errors.append(str(exc))
 
     return {
-        "source_path": str(source),
+        "source_path": original_source,
         "delete_paths": delete_paths,
         "missing_paths": missing_paths,
         "unsafe_paths": unsafe_paths,
         "errors": errors,
+        "warnings": warnings,
     }
 
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -658,6 +658,11 @@ function DeletePlanModal({ plan, onConfirm, onClose }) {
                                 ${(item.delete_paths || []).map(p => html`
                                     <div style="font-size: 0.8rem; color: var(--text-secondary);">${p}</div>
                                 `)}
+                                ${item.warnings && item.warnings.length > 0 && html`
+                                    <div style="font-size: 0.8rem; color: var(--warning); margin-top: 4px;">
+                                        ${item.warnings.join('; ')}
+                                    </div>
+                                `}
                                 ${item.missing_paths && item.missing_paths.length > 0 && html`
                                     <div style="font-size: 0.8rem; color: var(--warning); margin-top: 4px;">
                                         Missing: ${item.missing_paths.map(getBaseName).join(', ')}
@@ -2579,14 +2584,14 @@ function App() {
         return false;
     }, [selectedFiles]);
     const deleteOnVerifySupported = isCreateMode || isCopyMode;
-    const deleteOnVerifyDisabled = !deleteOnVerifySupported || hasArchiveSelection;
+    const deleteOnVerifyDisabled = !deleteOnVerifySupported;
     const deleteOnVerifyLabel = isCopyMode
         ? 'Delete original CHD after copy + verify'
         : 'Delete source after convert + verify';
     const deleteOnVerifyNote = !deleteOnVerifySupported
         ? 'Available only for create/copy modes.'
         : hasArchiveSelection
-            ? 'Disabled while archive items are selected.'
+            ? 'Archive inputs will delete the entire archive after verification.'
             : isCopyMode
                 ? 'Warning: this deletes the original CHD after the copy verifies.'
                 : 'Runs CHD verification and deletes the original source (including .cue/.gdi track files) if it passes.';


### PR DESCRIPTION
## Summary
- allow delete-on-verify for archive inputs with warnings
- block delete-on-verify for multiple selections from the same archive
- adjust delete plan handling for archive sources and surface UI warning

## Testing
- Not run (logic/docs changes only)