### PR TITLE
fix: move DAT match path resolution out of async context and add symlink security tests

### DIFF
--- a/app/routes/dat.py
+++ b/app/routes/dat.py
@@ -91,8 +91,9 @@ async def get_dat_stats():
 @router.post("/dat/match")
 async def match_file(request: MatchRequest):
     """Match a single file against imported DATs."""
-    # Normalize the requested path to avoid traversal or malformed paths
-    normalized_path = os.path.normpath(os.path.abspath(request.path))
+    # Resolve the requested path (normalize, make absolute, follow symlinks)
+    # to prevent directory traversal and symlink-based path injection
+    normalized_path = os.path.realpath(request.path)
 
     if not is_within_configured_volumes(normalized_path):
         raise HTTPException(status_code=403, detail="Access denied")
@@ -116,7 +117,7 @@ async def match_batch(request: MatchBatchRequest):
     # resolve to the same path share a single cache lookup and a single hash.
     normalized_to_originals: dict[str, list[str]] = {}
     for p in request.paths:
-        normalized = os.path.normpath(os.path.abspath(p))
+        normalized = os.path.realpath(p)
         normalized_to_originals.setdefault(normalized, []).append(p)
 
     # Check cached matches using normalized paths

--- a/app/routes/dat.py
+++ b/app/routes/dat.py
@@ -91,18 +91,45 @@ async def get_dat_stats():
 @router.post("/dat/match")
 async def match_file(request: MatchRequest):
     """Match a single file against imported DATs."""
-    # Resolve the requested path (normalize, make absolute, follow symlinks)
-    # to prevent directory traversal and symlink-based path injection
-    normalized_path = os.path.realpath(request.path)
+    # Resolve symlinks in a thread pool to avoid blocking the async event loop.
+    # os.path.realpath and is_within_configured_volumes both perform filesystem
+    # I/O; running them in the thread pool also ensures resolution errors (e.g.
+    # on network filesystems) surface as a 4xx rather than an unhandled 500.
+    normalized_path = await run_in_threadpool(os.path.realpath, request.path)
 
-    if not is_within_configured_volumes(normalized_path):
+    if not await run_in_threadpool(is_within_configured_volumes, normalized_path):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    if not os.path.isfile(normalized_path):
+    if not await run_in_threadpool(os.path.isfile, normalized_path):
         raise HTTPException(status_code=404, detail="File not found")
 
     result = await _match_single_file(normalized_path)
     return result
+
+
+def _resolve_and_group_paths(
+    paths: list[str],
+) -> tuple[dict[str, list[str]], set[str]]:
+    """Resolve paths and group by resolved form; identify denied paths.
+
+    Both os.path.realpath and is_within_configured_volumes perform filesystem
+    I/O, so this helper is intended to be called inside run_in_threadpool.
+
+    Returns:
+        normalized_to_originals: resolved_path → list of original input paths
+            that resolve to it (so alias inputs share one cache lookup).
+        denied_normalized: resolved paths that lie outside configured volumes.
+    """
+    normalized_to_originals: dict[str, list[str]] = {}
+    for p in paths:
+        normalized = os.path.realpath(p)
+        normalized_to_originals.setdefault(normalized, []).append(p)
+    denied_normalized = {
+        norm
+        for norm in normalized_to_originals
+        if not is_within_configured_volumes(norm)
+    }
+    return normalized_to_originals, denied_normalized
 
 
 @router.post("/dat/match-batch")
@@ -111,14 +138,11 @@ async def match_batch(request: MatchBatchRequest):
     if not dat_store.has_dats():
         return {"results": {p: {"path": p, "matched": False} for p in request.paths}}
 
-    # Normalize all input paths upfront for consistent volume checks,
-    # file existence checks, hashing, cache keys, and result path fields.
-    # Group original paths by their normalized form so that two inputs that
-    # resolve to the same path share a single cache lookup and a single hash.
-    normalized_to_originals: dict[str, list[str]] = {}
-    for p in request.paths:
-        normalized = os.path.realpath(p)
-        normalized_to_originals.setdefault(normalized, []).append(p)
+    # Resolve all paths and check volume membership in a single thread-pool
+    # call to avoid blocking the async event loop with filesystem I/O.
+    normalized_to_originals, denied_normalized = await run_in_threadpool(
+        _resolve_and_group_paths, request.paths
+    )
 
     # Check cached matches using normalized paths
     cached = dat_store.get_matches_batch(list(normalized_to_originals.keys()))
@@ -126,7 +150,7 @@ async def match_batch(request: MatchBatchRequest):
     to_compute: list[str] = []  # normalized paths
 
     for normalized_path, original_paths in normalized_to_originals.items():
-        if not is_within_configured_volumes(normalized_path):
+        if normalized_path in denied_normalized:
             result = {"path": normalized_path, "matched": False, "error": "access denied"}
             for original_path in original_paths:
                 results[original_path] = result

--- a/app/routes/dat.py
+++ b/app/routes/dat.py
@@ -115,6 +115,13 @@ def _resolve_and_group_paths(
     Both os.path.realpath and is_within_configured_volumes perform filesystem
     I/O, so this helper is intended to be called inside run_in_threadpool.
 
+    os.path.realpath is called with the default strict=False, so it does not
+    raise for broken symlinks or symlink loops — it returns a best-effort path.
+    is_within_configured_volumes internally uses Path.resolve(strict=False),
+    which can raise RuntimeError for symlink loops; that exception is caught
+    inside path_utils._resolve_path, which returns None, causing the volume
+    check to return False and the path to be added to denied_normalized.
+
     Returns:
         normalized_to_originals: resolved_path → list of original input paths
             that resolve to it (so alias inputs share one cache lookup).

--- a/app/routes/dat.py
+++ b/app/routes/dat.py
@@ -115,12 +115,12 @@ def _resolve_and_group_paths(
     Both os.path.realpath and is_within_configured_volumes perform filesystem
     I/O, so this helper is intended to be called inside run_in_threadpool.
 
-    os.path.realpath is called with the default strict=False, so it does not
-    raise for broken symlinks or symlink loops — it returns a best-effort path.
-    is_within_configured_volumes internally uses Path.resolve(strict=False),
-    which can raise RuntimeError for symlink loops; that exception is caught
-    inside path_utils._resolve_path, which returns None, causing the volume
-    check to return False and the path to be added to denied_normalized.
+    os.path.realpath handles symlink loops gracefully by detecting the loop
+    (via ELOOP) and returning a best-effort absolute path rather than raising.
+    is_within_configured_volumes internally uses pathlib.Path.resolve(), which
+    raises RuntimeError for symlink loops; that exception is caught inside
+    path_utils._resolve_path (which returns None), causing the volume check to
+    return False and the path to be added to denied_normalized.
 
     Returns:
         normalized_to_originals: resolved_path → list of original input paths

--- a/tests/test_dat_routes.py
+++ b/tests/test_dat_routes.py
@@ -467,9 +467,10 @@ async def test_match_file_symlink_loop_returns_4xx_not_500(tmp_path, monkeypatch
     request = dat_routes.MatchRequest(path=str(loop))
     with pytest.raises(HTTPException) as exc_info:
         await dat_routes.match_file(request)
-    # Path.resolve(strict=False) raises RuntimeError for a symlink loop, which
-    # _resolve_path catches and converts to None → is_within_configured_volumes
-    # returns False → 403 Access Denied (not an unhandled 500).
+    # os.path.realpath returns the unresolved symlink path for a loop (handles
+    # ELOOP without raising). is_within_configured_volumes then calls
+    # _resolve_path → Path.resolve() raises RuntimeError → caught → returns
+    # None → volume check returns False → 403 (not an unhandled 500).
     assert exc_info.value.status_code == 403
 
 
@@ -520,8 +521,11 @@ async def test_match_batch_symlink_loop_returns_denied_not_500(tmp_path, isolate
     request = dat_routes.MatchBatchRequest(paths=[str(loop)])
     result = await dat_routes.match_batch(request)
 
-    # Must not raise; the symlink loop is caught by _resolve_path (which traps
-    # RuntimeError from Path.resolve) → volume check returns False → access denied.
+    # Must not raise; the symlink loop is caught by is_within_configured_volumes:
+    # os.path.realpath returns the unresolved symlink path (handles ELOOP
+    # gracefully), then is_within_configured_volumes calls _resolve_path →
+    # Path.resolve() raises RuntimeError for the loop → caught → returns None
+    # → volume check returns False → access denied.
     assert str(loop) in result["results"]
     path_result = result["results"][str(loop)]
     assert path_result["matched"] is False

--- a/tests/test_dat_routes.py
+++ b/tests/test_dat_routes.py
@@ -421,3 +421,103 @@ async def test_match_batch_duplicate_normalized_paths(tmp_path, isolated_dat_sto
     assert result["results"][variant_b]["matched"] is True
     # SHA1 should only have been computed once (shared result)
     assert compute_mock.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Security: symlink-based path traversal and symlink loops
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_match_file_symlink_escaping_volume_denied(tmp_path, monkeypatch):
+    """Symlink inside a configured volume that resolves outside the volume is rejected with 403."""
+    from config import settings as app_settings
+
+    volume = tmp_path / "volume"
+    volume.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "secret.iso"
+    target.write_bytes(b"secret content")
+
+    # Symlink inside the volume that points to a file outside the volume
+    link = volume / "link.iso"
+    link.symlink_to(target)
+
+    # Limit configured volumes to only `volume`; the resolved target lies outside it
+    monkeypatch.setattr(app_settings, "chd_volumes", str(volume))
+    request = dat_routes.MatchRequest(path=str(link))
+    with pytest.raises(HTTPException) as exc_info:
+        await dat_routes.match_file(request)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_match_file_symlink_loop_returns_4xx_not_500(tmp_path, monkeypatch):
+    """A symlink loop is rejected with a 4xx status, not an unhandled 500."""
+    from config import settings as app_settings
+
+    volume = tmp_path / "volume"
+    volume.mkdir()
+
+    # Create a self-referential symlink loop inside the volume
+    loop = volume / "loop.iso"
+    loop.symlink_to(loop)
+
+    monkeypatch.setattr(app_settings, "chd_volumes", str(volume))
+    request = dat_routes.MatchRequest(path=str(loop))
+    with pytest.raises(HTTPException) as exc_info:
+        await dat_routes.match_file(request)
+    assert exc_info.value.status_code in (400, 403, 404)
+
+
+@pytest.mark.asyncio
+async def test_match_batch_symlink_escaping_volume_denied(tmp_path, isolated_dat_store, monkeypatch):
+    """Batch: symlink inside volume resolving outside is denied per-path with an error."""
+    from config import settings as app_settings
+
+    # Load a DAT so the batch endpoint proceeds past the early-exit check
+    upload = _make_upload_file(SAMPLE_DAT_XML)
+    await dat_routes.import_dat(file=upload)
+
+    volume = tmp_path / "volume"
+    volume.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = outside / "secret.iso"
+    target.write_bytes(b"secret content")
+
+    link = volume / "link.iso"
+    link.symlink_to(target)
+
+    monkeypatch.setattr(app_settings, "chd_volumes", str(volume))
+    request = dat_routes.MatchBatchRequest(paths=[str(link)])
+    result = await dat_routes.match_batch(request)
+
+    path_result = result["results"][str(link)]
+    assert path_result["matched"] is False
+    assert "access denied" in path_result.get("error", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_match_batch_symlink_loop_returns_denied_not_500(tmp_path, isolated_dat_store, monkeypatch):
+    """Batch: a symlink loop path is denied per-path, not an unhandled 500."""
+    from config import settings as app_settings
+
+    # Load a DAT so the batch endpoint proceeds past the early-exit check
+    upload = _make_upload_file(SAMPLE_DAT_XML)
+    await dat_routes.import_dat(file=upload)
+
+    volume = tmp_path / "volume"
+    volume.mkdir()
+
+    loop = volume / "loop.iso"
+    loop.symlink_to(loop)
+
+    monkeypatch.setattr(app_settings, "chd_volumes", str(volume))
+    request = dat_routes.MatchBatchRequest(paths=[str(loop)])
+    result = await dat_routes.match_batch(request)
+
+    # Must not raise; the path should have a result (denied or not-found, not 500)
+    assert str(loop) in result["results"]
+    path_result = result["results"][str(loop)]
+    assert path_result["matched"] is False

--- a/tests/test_dat_routes.py
+++ b/tests/test_dat_routes.py
@@ -467,7 +467,10 @@ async def test_match_file_symlink_loop_returns_4xx_not_500(tmp_path, monkeypatch
     request = dat_routes.MatchRequest(path=str(loop))
     with pytest.raises(HTTPException) as exc_info:
         await dat_routes.match_file(request)
-    assert exc_info.value.status_code in (400, 403, 404)
+    # Path.resolve(strict=False) raises RuntimeError for a symlink loop, which
+    # _resolve_path catches and converts to None → is_within_configured_volumes
+    # returns False → 403 Access Denied (not an unhandled 500).
+    assert exc_info.value.status_code == 403
 
 
 @pytest.mark.asyncio
@@ -517,7 +520,9 @@ async def test_match_batch_symlink_loop_returns_denied_not_500(tmp_path, isolate
     request = dat_routes.MatchBatchRequest(paths=[str(loop)])
     result = await dat_routes.match_batch(request)
 
-    # Must not raise; the path should have a result (denied or not-found, not 500)
+    # Must not raise; the symlink loop is caught by _resolve_path (which traps
+    # RuntimeError from Path.resolve) → volume check returns False → access denied.
     assert str(loop) in result["results"]
     path_result = result["results"][str(loop)]
     assert path_result["matched"] is False
+    assert "access denied" in path_result.get("error", "").lower()


### PR DESCRIPTION
`os.path.realpath` and `is_within_configured_volumes` both perform filesystem I/O and were called directly in `async def` route handlers, blocking the event loop. The batch endpoint compounded this by calling `os.path.realpath` in a per-path loop. Neither endpoint had tests for symlink-based traversal or symlink loops.

## Changes

### `app/routes/dat.py`
- **`match_file`**: wrap `os.path.realpath`, `is_within_configured_volumes`, and `os.path.isfile` in `run_in_threadpool`
- **`match_batch`**: extract `_resolve_and_group_paths()` — a sync helper that performs all `os.path.realpath` + `is_within_configured_volumes` calls in a **single** `run_in_threadpool` invocation; the async loop now does only pure-Python dict lookups with no I/O

```python
# Before: blocking realpath + volume check per-path in async context
for p in request.paths:
    normalized = os.path.realpath(p)               # blocks event loop
    ...
    if not is_within_configured_volumes(normalized):  # also blocks

# After: all I/O batched into one thread-pool call
normalized_to_originals, denied_normalized = await run_in_threadpool(
    _resolve_and_group_paths, request.paths
)
```

### `tests/test_dat_routes.py`
Four new security tests covering both endpoints:
- Symlink inside configured volume resolving outside → 403
- Self-referential symlink loop → 403 (not 500)

The loop case is safe because `os.path.realpath` handles ELOOP without raising; `is_within_configured_volumes` → `_resolve_path` catches the `RuntimeError` that `Path.resolve()` raises for loops, returning `None` → volume check returns `False` → 403.