### PR TITLE
fix: add missing python-multipart dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pydantic-settings>=2.1.0
 py7zr>=0.20.1
 rarfile>=4.1
 defusedxml>=0.7.1
+python-multipart>=0.0.7
 


### PR DESCRIPTION
## Summary
- Adds `python-multipart>=0.0.7` to `requirements.txt`
- Required by FastAPI for `UploadFile` / form data handling (used in `/dat/import`)
- Without it, the app fails to start with `RuntimeError: Form data requires "python-multipart" to be installed`

## Test plan
- [ ] Rebuild Docker image and verify app starts without errors
- [ ] Test DAT file import endpoint works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)