### PR TITLE
fix: add least-privilege permissions to workflow jobs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,8 @@ jobs:
   lint:
     name: Lint Dockerfile
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -175,6 +177,8 @@ jobs:
     needs: build
     if: ${{ !github.event.release.prerelease }}
     continue-on-error: true
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -194,6 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, scan]
     if: always()
+    permissions: {}
 
     steps:
       - name: Generate summary


### PR DESCRIPTION
## Summary

Resolves 3 open CodeQL alerts ([#146](https://github.com/pacnpal/compressatorium/security/code-scanning/146), [#147](https://github.com/pacnpal/compressatorium/security/code-scanning/147), [#148](https://github.com/pacnpal/compressatorium/security/code-scanning/148)) for `actions/missing-workflow-permissions` in the Docker build workflow.

### Changes

Added explicit least-privilege `permissions` to the three jobs that were missing them:

| Job | Permissions Added | Rationale |
|-----|-------------------|-----------|
| `lint` | `contents: read` | Only checks out code and runs Hadolint |
| `update-dockerhub-readme` | `contents: read` | Only checks out code and pushes README to Docker Hub via secrets |
| `summary` | `permissions: {}` (none) | Only writes to `GITHUB_STEP_SUMMARY` which requires no token permissions |

The `build` and `scan` jobs already had explicit permissions and are unchanged.

### Why this matters

Without explicit permissions, jobs inherit the workflow's default token permissions, which may include write access to contents, packages, and other scopes. Declaring least-privilege permissions per job limits the blast radius if a third-party action is compromised.

## Test plan

- [x] YAML syntax validated
- [ ] Verify CodeQL alerts close after merge
- [ ] Confirm next release build succeeds with the new permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)