### PR TITLE
feat: widen DAT match badge to raw disc images with bounded hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,8 @@ The Web UI communicates with a REST API that can also be used directly. Interact
 | `MAX_QUEUE_DEPTH` | `0` | Max queued+processing conversion jobs before create endpoints return `429` (0 disables) |
 | `MAX_VERIFY_CONCURRENCY` | `1` | Maximum concurrent verify workloads across CHD/Dolphin/3DS verify endpoints |
 | `MAX_METADATA_SCAN_CONCURRENCY` | `1` | Maximum concurrent metadata scan tasks |
+| `MAX_MATCH_CONCURRENCY` | `1` | Maximum concurrent DAT hash-matching operations. Raise only if your storage can handle parallel full-file reads (matching a raw Wii ISO is a full-file SHA1). |
+| `MATCH_MAX_FILE_SIZE` | `0` | Skip DAT hash-matching for files larger than this many bytes (0 disables the cap). Set e.g. `2147483648` on slow storage to keep 8 GB ISOs from blocking the browse-triggered matcher. |
 | `MAX_JOB_HISTORY` | `500` | Maximum completed jobs to retain in history |
 | `CHD_CHDMAN_NICE` | `10` | Nice level for chdman (0-19, higher = lower priority) |
 | `CHD_CHDMAN_IOPRIO_CLASS` | `2` | I/O priority class (`1` realtime, `2` best-effort, `3` idle) |

--- a/app/config.py
+++ b/app/config.py
@@ -66,6 +66,23 @@ class Settings(BaseSettings):
         alias="MAX_METADATA_SCAN_CONCURRENCY",
         description="Maximum concurrent metadata scan tasks",
     )
+    max_match_concurrency: int = Field(
+        default=1,
+        alias="MAX_MATCH_CONCURRENCY",
+        description=(
+            "Maximum concurrent DAT-match hashing operations. Matching a raw "
+            "ISO/WBFS requires full-file SHA1; bound this to protect "
+            "disk/CPU when many uncached files are browsed at once."
+        ),
+    )
+    match_max_file_size: int = Field(
+        default=0,
+        alias="MATCH_MAX_FILE_SIZE",
+        description=(
+            "If non-zero, skip DAT hash-matching for files larger than this "
+            "many bytes. 0 disables the cap (match any size)."
+        ),
+    )
     concurrency_lock_dir: str | None = Field(
         default=None,
         alias="CHD_CONCURRENCY_LOCK_DIR",

--- a/app/routes/dat.py
+++ b/app/routes/dat.py
@@ -9,8 +9,10 @@ from fastapi import APIRouter, HTTPException, Request, UploadFile, File
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel
 
+from config import settings
 from services.dat_store import dat_store
 from services.file_hasher import compute_file_sha1
+from services.workload_limiter import workload_limiter
 from utils.path_utils import is_within_configured_volumes
 
 router = APIRouter()
@@ -302,9 +304,28 @@ async def _match_single_file(file_path: str) -> dict:
         if match:
             return match
 
-    # File-level SHA1 (works for any format)
+    # Defense-in-depth: respect the operator-configured size cap so
+    # browsing a folder of 8 GB Wii ISOs doesn't stampede the hasher.
+    size_cap = max(0, int(getattr(settings, "match_max_file_size", 0) or 0))
+    if size_cap > 0:
+        try:
+            size_bytes = await run_in_threadpool(os.path.getsize, file_path)
+        except OSError:
+            size_bytes = 0
+        if size_bytes > size_cap:
+            return {
+                **base_result,
+                "reason": "file too large",
+                "file_size": size_bytes,
+            }
+
+    # File-level SHA1 (works for any format). Gate under the "match"
+    # workload lane so ``MAX_MATCH_CONCURRENCY`` bounds how many full-
+    # file hashes run at once when a directory of uncached files is
+    # browsed.
     try:
-        file_sha1 = await compute_file_sha1(file_path)
+        async with await workload_limiter.acquire("match"):
+            file_sha1 = await compute_file_sha1(file_path)
     except OSError as exc:
         logger.warning("Failed to hash %s: %s", file_path, exc)
         return base_result

--- a/app/routes/dat.py
+++ b/app/routes/dat.py
@@ -188,7 +188,11 @@ async def match_batch(request: MatchBatchRequest):
             # a stale negative entry would not be cleared by prune_missing.
         else:
             result = await _match_single_file(normalized_path)
-            new_matches[normalized_path] = result
+            # Don't cache size-cap skips: the result is configuration-dependent.
+            # If MATCH_MAX_FILE_SIZE is later raised or disabled the file must
+            # be re-hashed rather than being served a stale "too large" entry.
+            if result.get("reason") != "file too large":
+                new_matches[normalized_path] = result
         for original_path in normalized_to_originals[normalized_path]:
             results[original_path] = result
 

--- a/app/services/workload_limiter.py
+++ b/app/services/workload_limiter.py
@@ -26,7 +26,12 @@ class WorkloadToken:
 
 
 class WorkloadLimiter:
-    """Simple lane-based concurrency limiter with best-effort non-blocking acquire."""
+    """Simple lane-based concurrency limiter.
+
+    ``acquire()`` blocks until a slot is available in the requested lane.
+    ``try_acquire()`` is the best-effort, non-blocking variant: it returns
+    ``None`` immediately if no slot is free within the configured timeout.
+    """
 
     def __init__(
         self,

--- a/app/services/workload_limiter.py
+++ b/app/services/workload_limiter.py
@@ -28,10 +28,17 @@ class WorkloadToken:
 class WorkloadLimiter:
     """Simple lane-based concurrency limiter with best-effort non-blocking acquire."""
 
-    def __init__(self, *, verify_limit: int, metadata_scan_limit: int):
+    def __init__(
+        self,
+        *,
+        verify_limit: int,
+        metadata_scan_limit: int,
+        match_limit: int = 1,
+    ):
         self._limits = {
             "verify": max(1, int(verify_limit)),
             "metadata_scan": max(1, int(metadata_scan_limit)),
+            "match": max(1, int(match_limit)),
         }
         self._semaphores = {
             lane: asyncio.Semaphore(limit)
@@ -76,4 +83,5 @@ class WorkloadLimiter:
 workload_limiter = WorkloadLimiter(
     verify_limit=settings.max_verify_concurrency,
     metadata_scan_limit=settings.max_metadata_scan_concurrency,
+    match_limit=settings.max_match_concurrency,
 )

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -478,6 +478,14 @@ header h1 span {
     opacity: 0.7;
 }
 
+.file-item .status.dat-error {
+    /* Failed hash/network request. Shown until automatic retry fires. */
+    background: transparent;
+    border: 1px dashed var(--error);
+    color: var(--error);
+    opacity: 0.8;
+}
+
 .file-item .status.iso-handling {
     background: var(--warning);
     color: var(--bg-primary);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -469,6 +469,15 @@ header h1 span {
     color: white;
 }
 
+.file-item .status.dat-pending {
+    /* In-flight hash computation. Muted so it doesn't compete with
+       the green "Verified" / blue "DAT ✓" confirmations. */
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px dashed var(--text-secondary);
+    opacity: 0.7;
+}
+
 .file-item .status.iso-handling {
     background: var(--warning);
     color: var(--bg-primary);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2833,6 +2833,7 @@ function App() {
     const queuedJobUpdatesRef = useRef(new Map()); // jobId -> latest SSE payload
     const jobUpdateFlushTimeoutRef = useRef(null);
     const completionRefreshTimeoutRef = useRef(null);
+    const datMatchRetryTimerRef = useRef(null);
     const preSearchViewRef = useRef(null); // List/archive view snapshot before Search All
     const deferJobUiUpdatesRef = useRef(false); // Pause job-driven rerenders during active select interactions
 
@@ -3429,7 +3430,11 @@ function App() {
                     }
                     return next;
                 });
-                setTimeout(() => {
+                // Clear any previously-scheduled retry before setting a new one
+                // so that repeated failures don't accumulate dangling timers.
+                clearTimeout(datMatchRetryTimerRef.current);
+                datMatchRetryTimerRef.current = setTimeout(() => {
+                    datMatchRetryTimerRef.current = null;
                     setDatMatches(prev => {
                         const next = new Map(prev);
                         for (const p of paths) {
@@ -3439,6 +3444,13 @@ function App() {
                     });
                 }, RETRY_MS);
             });
+
+        return () => {
+            // Cancel any pending retry timer when the effect re-runs or the
+            // component unmounts so stale setDatMatches calls don't fire.
+            clearTimeout(datMatchRetryTimerRef.current);
+            datMatchRetryTimerRef.current = null;
+        };
     }, [displayedEntries, datsImported, datMatches]);
 
     // Load app version on mount

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3353,10 +3353,11 @@ function App() {
     // Fetch DAT match status for visible files.
     //
     // Extensions covered:
-    //   .chd .rvz .wia .gcz .wbfs — container formats (cheap: CHD hashes
-    //                                live in the header; others are
-    //                                small or already cached on the
-    //                                server via the header fast-path).
+    //   .chd                      — CHD containers (hashes can be read
+    //                                from CHD metadata/header data).
+    //   .rvz .wia .gcz .wbfs      — supported container formats for DAT
+    //                                matching; backend cost may still
+    //                                involve full-file hashing.
     //   .iso .bin                 — raw disc images (requires full SHA1;
     //                                backend gates concurrency via
     //                                MAX_MATCH_CONCURRENCY).
@@ -3403,12 +3404,14 @@ function App() {
                 }
             })
             .catch(() => {
-                // Clear pending state on failure so the user isn't stuck
-                // with a perma-spinner.
+                // Replace the pending sentinel with an error sentinel so the
+                // user isn't stuck with a perma-spinner. Using { error: true }
+                // instead of deleting the entry prevents the effect from
+                // re-firing on datMatches change and hammering the backend.
                 setDatMatches(prev => {
                     const next = new Map(prev);
                     for (const p of paths) {
-                        if (next.get(p)?.pending) next.delete(p);
+                        if (next.get(p)?.pending) next.set(p, { error: true });
                     }
                     return next;
                 });

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -897,7 +897,7 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
                                 return html`<span class="status dat-match" title="${m.dat_name}: ${m.game_name}">DAT ✓</span>`;
                             }
                             if (m.request_error === true) {
-                                return html`<span class="status dat-error" title="DAT match failed — will retry">DAT !</span>`;
+                                return html`<span class="status dat-error" title="DAT match failed — retrying in ~30 s">DAT !</span>`;
                             }
                             if (typeof m.error === 'string' && m.error) {
                                 return html`<span class="status dat-error" title="${`DAT match failed — ${m.error}`}">DAT !</span>`;
@@ -3380,18 +3380,16 @@ function App() {
             '.iso', '.bin',
             '.3ds', '.cci', '.cia',
         ]);
+        // Must be defined before the filter so the .catch() setTimeout can use it.
+        const RETRY_MS = 30_000;
         const paths = displayedEntries
             .filter(e => matchableExts.has(e.extension?.toLowerCase()))
             .map(e => e.path)
-            .filter(p => {
-                const m = datMatches.get(p);
-                if (!m) return true;
-                // Re-submit if the last network request failed more than 30 s ago.
-                // Only request_error (set by the catch handler) is retryable;
-                // backend-provided string errors (m.error) are not.
-                const RETRY_MS = 30_000;
-                return m.request_error === true && Date.now() - m.ts >= RETRY_MS;
-            });
+            // Exclude paths that already have any datMatches entry (pending,
+            // matched, backend error, or retryable error waiting for its timer).
+            // The only way back into this list after a request_error is for the
+            // catch-handler's setTimeout to clear the sentinel.
+            .filter(p => !datMatches.has(p));
         if (paths.length === 0) return;
 
         // Mark all submitted paths as pending so the UI shows "DAT …"
@@ -3418,19 +3416,28 @@ function App() {
                 }
             })
             .catch(() => {
-                // Replace the pending sentinel with a retryable error sentinel so
-                // the user sees "DAT !" instead of a perma-spinner.  Using a
-                // dedicated `request_error` field (not `error`) avoids colliding
-                // with the string `error` field that backend responses can carry.
-                // Storing the timestamp (ts) lets the effect re-submit after 30 s.
-                const now = Date.now();
+                // Store error sentinels to block re-submission while the retry
+                // timer is pending.  Using a dedicated `request_error` field
+                // avoids colliding with the backend's string `error` field.
+                // After RETRY_MS the timer clears the sentinels, triggering a
+                // setDatMatches that causes the effect to re-run and re-submit
+                // the now-absent paths.
                 setDatMatches(prev => {
                     const next = new Map(prev);
                     for (const p of paths) {
-                        if (next.get(p)?.pending) next.set(p, { request_error: true, ts: now });
+                        if (next.get(p)?.pending) next.set(p, { request_error: true });
                     }
                     return next;
                 });
+                setTimeout(() => {
+                    setDatMatches(prev => {
+                        const next = new Map(prev);
+                        for (const p of paths) {
+                            if (next.get(p)?.request_error === true) next.delete(p);
+                        }
+                        return next;
+                    });
+                }, RETRY_MS);
             });
     }, [displayedEntries, datsImported, datMatches]);
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -887,9 +887,17 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
                         ${isVerified(entry) && html`
                             <span class="status verified" title="Integrity verified">✓ Verified</span>
                         `}
-                        ${datMatches.get(entry.path)?.matched && html`
-                            <span class="status dat-match" title="${datMatches.get(entry.path).dat_name}: ${datMatches.get(entry.path).game_name}">DAT ✓</span>
-                        `}
+                        ${(() => {
+                            const m = datMatches.get(entry.path);
+                            if (!m) return null;
+                            if (m.pending) {
+                                return html`<span class="status dat-pending" title="Hashing for DAT match...">DAT …</span>`;
+                            }
+                            if (m.matched) {
+                                return html`<span class="status dat-match" title="${m.dat_name}: ${m.game_name}">DAT ✓</span>`;
+                            }
+                            return null;
+                        })()}
                         ${isVerifying && html`
                             <span class="status convertible" title="Verifying integrity">
                                 ${(() => {
@@ -3342,15 +3350,46 @@ function App() {
             .catch(err => console.warn('Failed to fetch CHD metadata:', err)); // Silently fail - badges are optional
     }, [displayedEntries, forceRescanRunning, jobs, creatingJobs]);
 
-    // Fetch DAT match status for visible files
+    // Fetch DAT match status for visible files.
+    //
+    // Extensions covered:
+    //   .chd .rvz .wia .gcz .wbfs — container formats (cheap: CHD hashes
+    //                                live in the header; others are
+    //                                small or already cached on the
+    //                                server via the header fast-path).
+    //   .iso .bin                 — raw disc images (requires full SHA1;
+    //                                backend gates concurrency via
+    //                                MAX_MATCH_CONCURRENCY).
+    //   .3ds .cci .cia            — 3DS formats.
+    //
+    // Intentionally excluded: .cue, .gdi. Those are text manifests;
+    // hashing them matches nothing in a Redump DAT (the DAT matches the
+    // track data, not the manifest), so showing "DAT ✗" next to them
+    // would be misleading.
     useEffect(() => {
         if (!datsImported) return;
-        const matchableExts = new Set(['.chd', '.rvz', '.wia', '.gcz']);
+        const matchableExts = new Set([
+            '.chd', '.rvz', '.wia', '.gcz', '.wbfs',
+            '.iso', '.bin',
+            '.3ds', '.cci', '.cia',
+        ]);
         const paths = displayedEntries
             .filter(e => matchableExts.has(e.extension?.toLowerCase()))
             .map(e => e.path)
             .filter(p => !datMatches.has(p));
         if (paths.length === 0) return;
+
+        // Mark all submitted paths as pending so the UI shows "DAT …"
+        // while the (potentially slow) backend hashing runs. Without
+        // this the badge cell is just empty and the user can't tell
+        // whether matching is in-flight or the file is genuinely
+        // unknown.
+        setDatMatches(prev => {
+            const next = new Map(prev);
+            for (const p of paths) next.set(p, { pending: true });
+            return next;
+        });
+
         api.matchBatch(paths)
             .then(data => {
                 if (data.results) {
@@ -3363,7 +3402,17 @@ function App() {
                     });
                 }
             })
-            .catch(() => {});
+            .catch(() => {
+                // Clear pending state on failure so the user isn't stuck
+                // with a perma-spinner.
+                setDatMatches(prev => {
+                    const next = new Map(prev);
+                    for (const p of paths) {
+                        if (next.get(p)?.pending) next.delete(p);
+                    }
+                    return next;
+                });
+            });
     }, [displayedEntries, datsImported, datMatches]);
 
     // Load app version on mount

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -896,8 +896,11 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
                             if (m.matched) {
                                 return html`<span class="status dat-match" title="${m.dat_name}: ${m.game_name}">DAT ✓</span>`;
                             }
-                            if (m.error) {
+                            if (m.request_error === true) {
                                 return html`<span class="status dat-error" title="DAT match failed — will retry">DAT !</span>`;
+                            }
+                            if (typeof m.error === 'string' && m.error) {
+                                return html`<span class="status dat-error" title="${`DAT match failed — ${m.error}`}">DAT !</span>`;
                             }
                             return null;
                         })()}
@@ -3383,9 +3386,11 @@ function App() {
             .filter(p => {
                 const m = datMatches.get(p);
                 if (!m) return true;
-                // Re-submit if the last request errored out more than 30 s ago.
+                // Re-submit if the last network request failed more than 30 s ago.
+                // Only request_error (set by the catch handler) is retryable;
+                // backend-provided string errors (m.error) are not.
                 const RETRY_MS = 30_000;
-                return m.error && Date.now() - m.ts >= RETRY_MS;
+                return m.request_error === true && Date.now() - m.ts >= RETRY_MS;
             });
         if (paths.length === 0) return;
 
@@ -3413,14 +3418,16 @@ function App() {
                 }
             })
             .catch(() => {
-                // Replace the pending sentinel with an error sentinel so the
-                // user sees "DAT !" instead of a perma-spinner. Storing the
-                // timestamp (ts) lets the effect re-submit after a 30 s delay.
+                // Replace the pending sentinel with a retryable error sentinel so
+                // the user sees "DAT !" instead of a perma-spinner.  Using a
+                // dedicated `request_error` field (not `error`) avoids colliding
+                // with the string `error` field that backend responses can carry.
+                // Storing the timestamp (ts) lets the effect re-submit after 30 s.
                 const now = Date.now();
                 setDatMatches(prev => {
                     const next = new Map(prev);
                     for (const p of paths) {
-                        if (next.get(p)?.pending) next.set(p, { error: true, ts: now });
+                        if (next.get(p)?.pending) next.set(p, { request_error: true, ts: now });
                     }
                     return next;
                 });

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -896,6 +896,9 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
                             if (m.matched) {
                                 return html`<span class="status dat-match" title="${m.dat_name}: ${m.game_name}">DAT ✓</span>`;
                             }
+                            if (m.error) {
+                                return html`<span class="status dat-error" title="DAT match failed — will retry">DAT !</span>`;
+                            }
                             return null;
                         })()}
                         ${isVerifying && html`
@@ -3377,7 +3380,13 @@ function App() {
         const paths = displayedEntries
             .filter(e => matchableExts.has(e.extension?.toLowerCase()))
             .map(e => e.path)
-            .filter(p => !datMatches.has(p));
+            .filter(p => {
+                const m = datMatches.get(p);
+                if (!m) return true;
+                // Re-submit if the last request errored out more than 30 s ago.
+                const RETRY_MS = 30_000;
+                return m.error && Date.now() - m.ts >= RETRY_MS;
+            });
         if (paths.length === 0) return;
 
         // Mark all submitted paths as pending so the UI shows "DAT …"
@@ -3405,13 +3414,13 @@ function App() {
             })
             .catch(() => {
                 // Replace the pending sentinel with an error sentinel so the
-                // user isn't stuck with a perma-spinner. Using { error: true }
-                // instead of deleting the entry prevents the effect from
-                // re-firing on datMatches change and hammering the backend.
+                // user sees "DAT !" instead of a perma-spinner. Storing the
+                // timestamp (ts) lets the effect re-submit after a 30 s delay.
+                const now = Date.now();
                 setDatMatches(prev => {
                     const next = new Map(prev);
                     for (const p of paths) {
-                        if (next.get(p)?.pending) next.set(p, { error: true });
+                        if (next.get(p)?.pending) next.set(p, { error: true, ts: now });
                     }
                     return next;
                 });

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3445,13 +3445,18 @@ function App() {
                 }, RETRY_MS);
             });
 
+    }, [displayedEntries, datsImported, datMatches]);
+
+    // Cancel any pending DAT-match retry timer on unmount only.
+    // This must be a separate effect with empty deps so the cleanup doesn't
+    // fire on dependency-driven reruns — that would cancel the just-scheduled
+    // retry timer before it ever has a chance to fire.
+    useEffect(() => {
         return () => {
-            // Cancel any pending retry timer when the effect re-runs or the
-            // component unmounts so stale setDatMatches calls don't fire.
             clearTimeout(datMatchRetryTimerRef.current);
             datMatchRetryTimerRef.current = null;
         };
-    }, [displayedEntries, datsImported, datMatches]);
+    }, []);
 
     // Load app version on mount
     useEffect(() => {

--- a/tests/test_dat_routes.py
+++ b/tests/test_dat_routes.py
@@ -636,7 +636,6 @@ async def test_sync_mameredump_passes_tag(monkeypatch):
         request=dat_routes.SyncRequest(tag="0.285"),
     )
     # Give the background task a chance to start
-    import asyncio
     await asyncio.sleep(0)
     mock_svc.sync.assert_called_once_with(tag="0.285")
 

--- a/tests/test_dat_routes.py
+++ b/tests/test_dat_routes.py
@@ -638,3 +638,114 @@ async def test_sync_mameredump_passes_tag(monkeypatch):
     import asyncio
     await asyncio.sleep(0)
     mock_svc.sync.assert_called_once_with(tag="0.285")
+
+
+# ---------------------------------------------------------------------------
+# Match concurrency + size cap (Deliverable 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_match_skips_oversized_file(tmp_path, isolated_dat_store, monkeypatch):
+    """When MATCH_MAX_FILE_SIZE is set, files larger than the cap are
+    reported as unmatched *without* running the SHA1 hasher."""
+    upload = _make_upload_file(SAMPLE_DAT_XML)
+    await dat_routes.import_dat(file=upload)
+
+    huge = tmp_path / "huge.iso"
+    huge.write_bytes(b"x" * 1024)
+
+    monkeypatch.setattr(dat_routes, "is_within_configured_volumes", lambda p: True)
+    # Tiny cap (10 bytes) guarantees the 1 KB file trips it.
+    monkeypatch.setattr(dat_routes.settings, "match_max_file_size", 10)
+
+    hash_mock = AsyncMock(return_value="dead" * 10)
+    monkeypatch.setattr(dat_routes, "compute_file_sha1", hash_mock)
+
+    request = dat_routes.MatchRequest(path=str(huge))
+    result = await dat_routes.match_file(request)
+
+    assert result["matched"] is False
+    assert result.get("reason") == "file too large"
+    # Critical: the hasher must NOT have been invoked.
+    hash_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_match_respects_concurrency_cap(tmp_path, isolated_dat_store, monkeypatch):
+    """With MAX_MATCH_CONCURRENCY=1, simultaneous match_file calls
+    execute compute_file_sha1 serially (never two at once)."""
+    import asyncio as _asyncio
+
+    from app.services import workload_limiter as _wl
+
+    upload = _make_upload_file(SAMPLE_DAT_XML)
+    await dat_routes.import_dat(file=upload)
+
+    # Rebuild the workload_limiter with match_limit=1 for this test.
+    # (Default is already 1, but we set it explicitly so the test is
+    # self-documenting and robust to future default changes.)
+    original_limiter = dat_routes.workload_limiter
+    new_limiter = _wl.WorkloadLimiter(
+        verify_limit=1, metadata_scan_limit=1, match_limit=1,
+    )
+    monkeypatch.setattr(dat_routes, "workload_limiter", new_limiter)
+    _ = original_limiter  # silence lint; restoration handled by monkeypatch
+
+    active = 0
+    peak = 0
+    barrier = _asyncio.Event()
+
+    async def _fake_hash(path):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        try:
+            # Wait until all callers are in-flight before returning, so
+            # if the limiter is NOT serialising we'd observe peak > 1.
+            await _asyncio.wait_for(barrier.wait(), timeout=0.2)
+        except _asyncio.TimeoutError:
+            # Expected: under serial execution, only one caller ever
+            # enters this function at a time, so the barrier is never
+            # set by anyone else.
+            pass
+        active -= 1
+        return "a" * 40  # a sha1 that is NOT in the loaded DAT
+
+    monkeypatch.setattr(dat_routes, "compute_file_sha1", _fake_hash)
+    monkeypatch.setattr(dat_routes, "is_within_configured_volumes", lambda p: True)
+
+    paths = []
+    for i in range(5):
+        p = tmp_path / f"f{i}.iso"
+        p.write_bytes(b"x")
+        paths.append(p)
+
+    requests = [
+        dat_routes.match_file(dat_routes.MatchRequest(path=str(p)))
+        for p in paths
+    ]
+    await _asyncio.gather(*requests)
+
+    # Under match_limit=1 the hasher runs strictly one at a time.
+    assert peak == 1, f"concurrency cap breached: peak={peak}"
+
+
+@pytest.mark.asyncio
+async def test_match_file_hit_respects_size_cap_off(tmp_path, isolated_dat_store, monkeypatch):
+    """With MATCH_MAX_FILE_SIZE=0 (disabled), any file is hashed and matched."""
+    upload = _make_upload_file(SAMPLE_DAT_XML)
+    await dat_routes.import_dat(file=upload)
+
+    target_sha1 = "aabbccddaabbccddaabbccddaabbccddaabbccdd"
+    iso = tmp_path / "any-size.iso"
+    iso.write_bytes(b"whatever")
+
+    monkeypatch.setattr(dat_routes, "is_within_configured_volumes", lambda p: True)
+    monkeypatch.setattr(dat_routes.settings, "match_max_file_size", 0)
+    monkeypatch.setattr(dat_routes, "compute_file_sha1", AsyncMock(return_value=target_sha1))
+
+    request = dat_routes.MatchRequest(path=str(iso))
+    result = await dat_routes.match_file(request)
+
+    assert result["matched"] is True

--- a/tests/test_dat_routes.py
+++ b/tests/test_dat_routes.py
@@ -1,5 +1,6 @@
 """Tests for MAME Redump DAT file management routes."""
 
+import asyncio
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -675,26 +676,23 @@ async def test_match_skips_oversized_file(tmp_path, isolated_dat_store, monkeypa
 async def test_match_respects_concurrency_cap(tmp_path, isolated_dat_store, monkeypatch):
     """With MAX_MATCH_CONCURRENCY=1, simultaneous match_file calls
     execute compute_file_sha1 serially (never two at once)."""
-    import asyncio as _asyncio
-
-    from app.services import workload_limiter as _wl
-
     upload = _make_upload_file(SAMPLE_DAT_XML)
     await dat_routes.import_dat(file=upload)
 
     # Rebuild the workload_limiter with match_limit=1 for this test.
     # (Default is already 1, but we set it explicitly so the test is
     # self-documenting and robust to future default changes.)
-    original_limiter = dat_routes.workload_limiter
-    new_limiter = _wl.WorkloadLimiter(
+    # Use __class__ to reuse the exact class already loaded by dat_routes,
+    # avoiding any duplicate module-singleton risk from a separate import.
+    WorkloadLimiter = dat_routes.workload_limiter.__class__
+    new_limiter = WorkloadLimiter(
         verify_limit=1, metadata_scan_limit=1, match_limit=1,
     )
     monkeypatch.setattr(dat_routes, "workload_limiter", new_limiter)
-    _ = original_limiter  # silence lint; restoration handled by monkeypatch
 
     active = 0
     peak = 0
-    barrier = _asyncio.Event()
+    barrier = asyncio.Event()
 
     async def _fake_hash(path):
         nonlocal active, peak
@@ -703,8 +701,8 @@ async def test_match_respects_concurrency_cap(tmp_path, isolated_dat_store, monk
         try:
             # Wait until all callers are in-flight before returning, so
             # if the limiter is NOT serialising we'd observe peak > 1.
-            await _asyncio.wait_for(barrier.wait(), timeout=0.2)
-        except _asyncio.TimeoutError:
+            await asyncio.wait_for(barrier.wait(), timeout=0.2)
+        except asyncio.TimeoutError:
             # Expected: under serial execution, only one caller ever
             # enters this function at a time, so the barrier is never
             # set by anyone else.
@@ -717,15 +715,15 @@ async def test_match_respects_concurrency_cap(tmp_path, isolated_dat_store, monk
 
     paths = []
     for i in range(5):
-        p = tmp_path / f"f{i}.iso"
-        p.write_bytes(b"x")
-        paths.append(p)
+        iso_path = tmp_path / f"f{i}.iso"
+        iso_path.write_bytes(b"x")
+        paths.append(iso_path)
 
     requests = [
-        dat_routes.match_file(dat_routes.MatchRequest(path=str(p)))
-        for p in paths
+        dat_routes.match_file(dat_routes.MatchRequest(path=str(path)))
+        for path in paths
     ]
-    await _asyncio.gather(*requests)
+    await asyncio.gather(*requests)
 
     # Under match_limit=1 the hasher runs strictly one at a time.
     assert peak == 1, f"concurrency cap breached: peak={peak}"


### PR DESCRIPTION
## Summary

Stacked on top of #45. Extends the frontend DAT match filter from `.chd/.rvz/.wia/.gcz` to include `.wbfs/.iso/.bin/.3ds/.cci/.cia` so raw disc images display the \"DAT ✓\" badge. Safe to ship because:

- **Backend concurrency gate** — new `MAX_MATCH_CONCURRENCY` (default `1`) wired into the existing `workload_limiter` under a new \"match\" lane. Full-file SHA1s now serialise, so browsing 50 raw ISOs no longer stampedes the disk.
- **File-size cap (defense-in-depth)** — new `MATCH_MAX_FILE_SIZE` (default `0` = disabled). Operators on slow storage can set e.g. 2 GiB so 8 GB Wii ISOs short-circuit to `matched: false, reason: \"file too large\"` without the hasher ever running.
- **Pending badge state** — rows under active hashing show a muted \"DAT …\" placeholder so users can tell matching is in-flight rather than empty.
- **`.cue` / `.gdi` intentionally excluded** — those are tiny text manifests; hashing them matches nothing in a Redump DAT (the DAT targets track data), so including them would just surface misleading \"DAT ✗\".

## Test plan

- [x] Full suite: 233 passed (230 baseline + 3 new)
- [x] `test_match_skips_oversized_file` — cap short-circuits without invoking the hasher
- [x] `test_match_respects_concurrency_cap` — simultaneous `match_file` calls observe peak concurrency of 1 under `match_limit=1`
- [x] `test_match_file_hit_respects_size_cap_off` — regression guard for cap=0 (any size still hashed)
- [ ] Manual: populate DATs, browse a folder of raw ISOs, verify badges appear serially without UI freeze

## Merge order

Merge #45 first, then rebase this onto `latest` and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)