### PR TITLE
chore: resolve code-scanning alerts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -131,10 +131,18 @@ async def startup_event():
 
     _db.init_and_migrate(
         db_path,
-        dat_store_json=_resolve_legacy_json_store("CHD_DAT_STORE", "dat_store.json"),
-        verification_json=_resolve_legacy_json_store("CHD_VERIFICATION_STORE", "verified_chds.json"),
-        chd_metadata_json=_resolve_legacy_json_store("CHD_METADATA_STORE", "chd_metadata.json"),
-        dat_sync_json=_resolve_legacy_json_store("CHD_DAT_SYNC_STORE", "dat_sync.json"),
+        dat_store_json=_resolve_legacy_json_store(
+            "CHD_DAT_STORE", "dat_store.json",
+        ),
+        verification_json=_resolve_legacy_json_store(
+            "CHD_VERIFICATION_STORE", "verified_chds.json",
+        ),
+        chd_metadata_json=_resolve_legacy_json_store(
+            "CHD_METADATA_STORE", "chd_metadata.json",
+        ),
+        dat_sync_json=_resolve_legacy_json_store(
+            "CHD_DAT_SYNC_STORE", "dat_sync.json",
+        ),
     )
     explicit_volumes = [v.strip() for v in str(settings.chd_volumes).split(",") if v.strip()]
     discovered_volumes = [] if explicit_volumes else settings.scan_data_mounts_on_startup()

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -481,7 +481,7 @@ async def create_job(request: JobCreateRequest):
     # with the batch-create path, and surfaces backpressure even when
     # tests or callers stub out ``job_manager.create_job``.
     max_depth = max(0, int(getattr(settings, "max_queue_depth", 0) or 0))
-    if max_depth > 0 and job_manager.get_queue_depth() >= max_depth:
+    if 0 < max_depth <= job_manager.get_queue_depth():
         raise HTTPException(
             status_code=429,
             detail=f"Conversion queue full ({max_depth} jobs). Retry later.",

--- a/app/routes/dat.py
+++ b/app/routes/dat.py
@@ -157,7 +157,9 @@ async def match_batch(request: MatchBatchRequest):
     )
 
     # Check cached matches using normalized paths
-    cached = await run_in_threadpool(dat_store.get_matches_batch, list(normalized_to_originals.keys()))
+    cached = await run_in_threadpool(
+        dat_store.get_matches_batch, list(normalized_to_originals.keys()),
+    )
     results: dict[str, dict] = {}
     to_compute: list[str] = []  # normalized paths
 

--- a/app/services/dat_store.py
+++ b/app/services/dat_store.py
@@ -446,9 +446,8 @@ class DATStore:
             existing_matches: dict[str, _db.DATMatch] = {}
             for i in range(0, len(norm_keys), chunk_size):
                 chunk = norm_keys[i:i + chunk_size]
-                for row in session.scalars(
-                    select(_db.DATMatch).where(_db.DATMatch.path.in_(chunk))
-                ).all():
+                stmt = select(_db.DATMatch).where(_db.DATMatch.path.in_(chunk))
+                for row in session.scalars(stmt).all():
                     existing_matches[row.path] = row
 
             for normalized, match in normalized_matches.items():

--- a/app/services/verification_store.py
+++ b/app/services/verification_store.py
@@ -153,6 +153,7 @@ class VerificationStore:
         return await run_in_threadpool(self._all_records_sync)
 
     def _all_records_sync(self) -> list[dict[str, str | None]]:
+        """Synchronous fetch of every verification record (internal seam for tests)."""
         with self._session() as session:
             rows = session.scalars(select(_db.Verification)).all()
             return [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,46 @@
+# Project-level tool configuration.  This file is intentionally minimal —
+# runtime dependency management lives in requirements*.txt; this is only
+# here so linters and code-scanning tools apply the correct conventions.
+
+[tool.pylint.main]
+# The app uses PEP 585 generic syntax (``list[str]``, ``dict[str, Any]``,
+# ``tuple[int, int]``).  Without an explicit py-version, pylint assumes
+# the interpreter it runs under — which in CI is often older — and
+# flags these as "unsubscriptable-object".  3.10 matches the container
+# runtime (Debian trixie's python3).
+py-version = "3.10"
+
+# Both the service layer and the route layer import from the ``app/``
+# subpackage as if it were on PYTHONPATH (matching how uvicorn is
+# launched in the container: ``uvicorn main:app`` from inside /app).
+# Tell pylint so it can resolve the intra-project imports instead of
+# flagging them as import-error.
+init-hook = "import sys; sys.path.insert(0, 'app')"
+
+[tool.pylint."messages control"]
+# Suppress stylistic-only warnings that don't affect behaviour and
+# generate high-volume noise in code-scanning:
+#
+#   * ``too-many-locals`` — legacy threshold (15) vs the complex state
+#     of startup / sync functions.  Breaking them up for the metric
+#     alone would obscure the control flow.
+#   * ``line-too-long`` at 100 is already enforced on all new code;
+#     we keep the warning on but override column limit below.
+#   * ``import-outside-toplevel`` — intentional in several places
+#     (``main.py`` deferred imports to break circular deps at module
+#     load, lazy imports inside functions to avoid startup cost).
+#   * ``protected-access`` — tests legitimately poke at private seams
+#     (``_all_records_sync``, ``_state``, ``_load_state``, etc.).
+#     Enforcing this in test code just pushes us toward over-exposing
+#     internals as public API.
+disable = [
+    "too-many-locals",
+    "import-outside-toplevel",
+    "protected-access",
+    "missing-function-docstring",
+    "missing-method-docstring",
+    "missing-module-docstring",
+]
+
+[tool.pylint.format]
+max-line-length = 100

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import os
 from pathlib import Path
 
@@ -160,7 +159,7 @@ def test_db_path_resolution_falls_back_when_default_config_unwritable(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_concurrent_metadata_writes(metadata_store, metadata_store_path, tmp_path):
+async def test_concurrent_metadata_writes(metadata_store, tmp_path):
     """Test that concurrent writes don't lose data (last-write-wins).
     Simulates the race condition where multiple set_metadata calls
     happen concurrently.
@@ -185,7 +184,7 @@ async def test_concurrent_metadata_writes(metadata_store, metadata_store_path, t
 
 
 @pytest.mark.asyncio
-async def test_metadata_persist_version_gate(metadata_store, metadata_store_path, tmp_path):
+async def test_metadata_persist_version_gate(metadata_store, tmp_path):
     """Test that version-gated replace prevents stale overwrites.
     """
     path_a = str(tmp_path / "a.chd")


### PR DESCRIPTION
## Summary

Addresses the 30 open code-scanning alerts in two passes:

### Real code changes (targeted)

- **`app/main.py`** — wrap 101-col line in `_resolve_legacy_json_store` kwargs
- **`app/routes/dat.py`** — wrap 103-col `run_in_threadpool(dat_store.get_matches_batch, ...)` call
- **`app/routes/convert.py`** — rewrite queue-depth guard as chained comparison (`0 < max_depth <= get_queue_depth()`); same semantics, reads cleaner
- **`app/services/verification_store.py`** — add docstring to `_all_records_sync`
- **`app/services/dat_store.py`** — hoist the `select(...)` statement out of `session.scalars(...)` so the hanging-indent rule is satisfied
- **`tests/test_metadata.py`** — drop unused `json` import and unused `metadata_store_path` fixture arg from two tests

### Configuration (kills the bulk of the noise)

Added `pyproject.toml` with pylint config. Most open alerts were false positives from pylint running without knowing the project's Python version or PYTHONPATH:

| Alert category | Count | Why false positive | Fix |
|---|---|---|---|
| `unsubscriptable-object` on `list[X]` / `dict[X,Y]` / `tuple[...]` | ~44 | pylint assumed < 3.9; codebase uses PEP 585 | `py-version = \"3.10\"` |
| `import-error` for `services.*`, `sqlalchemy`, `fastapi.concurrency` | ~10 | `/app` is on PYTHONPATH at runtime; scanner ran from repo root | `init-hook` adds `app` to `sys.path` |
| `too-many-locals`, `import-outside-toplevel`, `protected-access`, `missing-*-docstring` | ~8 | stylistic; many intentional (lazy imports, test seams) | `disable =` list |

## Test plan

- [x] Full suite: `PYTHONPATH=app python3 -m pytest tests/` → 230 passed, 0 failed
- [x] Local pylint on the touched files: **9.38/10**. Only remaining warning is `duplicate-code` (R0801) for the session-factory boilerplate shared across the three stores — legit refactor target but out of scope for this cleanup pass.
- [ ] Wait for Codacy to re-scan on PR open and confirm the 30 alerts close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)