### PR TITLE
fix: resolve remaining Codacy code-scanning alerts

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -23,6 +23,13 @@ engines:
     # on the Code patterns UI page if you want to hide its results.
     # Project uses ESLint 9 flat config; Codacy CLI bundles ESLint 8.
     enabled: false
+  ruff:
+    # Codacy's ruff wrapper attempts to parse plain-text dependency
+    # manifests as Python, which trips "SyntaxError" alerts for every
+    # line in requirements*.txt.  Route requirements files away from
+    # ruff; Trivy still scans them for vulnerable dependencies.
+    exclude_paths:
+      - "requirements*.txt"
   pmd:
     enabled: true
     config_file: config/pmd/ruleset.xml
@@ -77,3 +84,6 @@ exclude_paths:
   - "*.log"
   - "server_*.log"
   - "recent_log.txt"
+  # Generated lockfile — not source code.  Codacy's jackson JSON parser
+  # chokes on comments / odd encoding inside large npm lockfiles.
+  - "package-lock.json"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "21 19 * * 0"
 
+# Default to read-only for any step that does not need more.  The
+# analyze job re-declares the broader scopes it actually needs.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -8,6 +8,10 @@
 name: Labeler
 on: [pull_request_target]
 
+# Default to read-only; the label job re-declares the PR write scope it needs.
+permissions:
+  contents: read
+
 jobs:
   label:
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,11 @@ on:
   schedule:
   - cron: '34 2 * * *'
 
+# Default to read-only; the stale job re-declares the issue/PR write
+# scopes it needs.
+permissions:
+  contents: read
+
 jobs:
   stale:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM debian:trixie-slim AS builder
 
 # Install build dependencies
 ENV DEBIAN_FRONTEND=noninteractive
+# hadolint ignore=DL3008
+# DL3008 (pin apt versions): build-stage uses generic packages (git,
+# build-essential, libzstd-dev) where the latest patched versions are
+# preferable to a frozen pin.  Reproducibility comes from the snapshot-
+# pinned mame-tools deb in the runtime stage, not from these build deps.
 RUN apt-get update -o Acquire::Retries=3 && \
     apt-get install -y --no-install-recommends \
     git \
@@ -37,6 +42,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install system dependencies, pinned mame-tools, create wrapper script, and prepare venv
 ENV DEBIAN_FRONTEND=noninteractive
+# hadolint ignore=DL3008
+# DL3008 (pin apt versions): mame-tools is pinned via the snapshot.debian.org
+# .deb downloaded below; the remaining packages (python3, util-linux, gosu,
+# etc.) are stable trixie security-tracked dependencies where pinning would
+# block routine CVE patches.
 RUN apt-get update -o Acquire::Retries=3 && \
     apt-get install -y --no-install-recommends \
       python3 \
@@ -137,4 +147,11 @@ RUN groupadd -r -g 999 converter && useradd -r -u 999 -g converter -s /sbin/nolo
     && mkdir -p /data/games /config \
     && chown converter:converter /data/games /config
 
+# nosemgrep: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint
+# The container deliberately starts as root so entrypoint.sh can honour the
+# PUID/PGID env vars (`usermod`/`groupmod`/`chown` require root) before
+# `exec gosu converter "$0" "$@"` drops privileges to the unprivileged
+# converter user (uid 999) for the actual application.  Adding `USER` here
+# would prevent the runtime UID/GID remap that lets the container write
+# host-correct ownership on bind-mounted volumes.
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM debian:trixie-slim AS builder
 
 # Install build dependencies
+#
+# DL3008 (pin apt versions) is intentionally ignored: build-stage uses
+# generic packages (git, build-essential, libzstd-dev) where the latest
+# patched versions are preferable to a frozen pin.  Reproducibility comes
+# from the snapshot-pinned mame-tools deb in the runtime stage below, not
+# from these build deps.
 ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3008
-# DL3008 (pin apt versions): build-stage uses generic packages (git,
-# build-essential, libzstd-dev) where the latest patched versions are
-# preferable to a frozen pin.  Reproducibility comes from the snapshot-
-# pinned mame-tools deb in the runtime stage, not from these build deps.
 RUN apt-get update -o Acquire::Retries=3 && \
     apt-get install -y --no-install-recommends \
     git \
@@ -41,12 +43,13 @@ ARG MAME_TOOLS_SHA256_ARM64="6388bff0f6242dfd3a09c63c6e25ab94e0a64fe7cf2b3b0170f
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install system dependencies, pinned mame-tools, create wrapper script, and prepare venv
+#
+# DL3008 (pin apt versions) is intentionally ignored: mame-tools is pinned via
+# the snapshot.debian.org .deb downloaded inside the RUN below; the remaining
+# packages (python3, util-linux, gosu, etc.) are stable trixie security-tracked
+# dependencies where pinning would block routine CVE patches.
 ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3008
-# DL3008 (pin apt versions): mame-tools is pinned via the snapshot.debian.org
-# .deb downloaded below; the remaining packages (python3, util-linux, gosu,
-# etc.) are stable trixie security-tracked dependencies where pinning would
-# block routine CVE patches.
 RUN apt-get update -o Acquire::Retries=3 && \
     apt-get install -y --no-install-recommends \
       python3 \

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1110,7 +1110,7 @@ function CHDInfoModal({ path, onClose, infoMode, useDolphin }) {
         if (infoMode === 'dolphin' || infoMode === 'z3ds' || infoMode === 'chd') {
             return infoMode;
         }
-        if (Boolean(useDolphin) || (path ? isDolphinFile(path) : false)) {
+        if (useDolphin || (path ? isDolphinFile(path) : false)) {
             return 'dolphin';
         }
         if (path ? is3dsFile(path) : false) {
@@ -4127,7 +4127,7 @@ function App() {
 
             setSelectedFiles(prev => {
                 const next = new Map(prev);
-                range.forEach(e => next.set(e.path, e));
+                range.forEach(e => { next.set(e.path, e); });
                 return next;
             });
         } else {

--- a/tests/test_db_engine_pragmas.py
+++ b/tests/test_db_engine_pragmas.py
@@ -12,7 +12,6 @@ inserts.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
 from sqlalchemy import text

--- a/tests/test_db_store_operations.py
+++ b/tests/test_db_store_operations.py
@@ -10,10 +10,9 @@ upsert idempotency, chunked-upsert boundaries against SQLite's
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
-from sqlalchemy import delete, select
+from sqlalchemy import delete
 
 from services import db as _db
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,5 +1,12 @@
 """Tests for LOGLEVEL/LOG_PATH settings and legacy CHD_DEBUG/CHD_DEBUG_LOG_PATH compat."""
 
+import io
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
 from app.config import Settings
 
 
@@ -83,13 +90,6 @@ def test_log_path_takes_precedence_over_legacy(monkeypatch):
 # LOG_COLOR / ColorFormatter
 # ---------------------------------------------------------------------------
 
-
-import io
-import logging
-import re
-from pathlib import Path
-
-import pytest
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 


### PR DESCRIPTION
## Summary

Cleans up the Codacy/CodeQL alerts that PR #77 didn't cover:

- **`.codacy.yml`**: route `requirements*.txt` away from Codacy's ruff wrapper (which mis-parses pip manifests as Python) and exclude `package-lock.json` from the jackson JSON scanner. Closes the 11 `Ruff_None_` SyntaxError alerts and the lone `jackson_parse-error`.
- **`Dockerfile`**: add `# hadolint ignore=DL3008` directly above each `apt-get` RUN (verified with hadolint locally) with rationale comments above. Add `# nosemgrep: dockerfile.security.missing-user-entrypoint.missing-user-entrypoint` above the `ENTRYPOINT` explaining why the container deliberately starts as root for the PUID/PGID remap before `exec gosu converter` drops privileges. Closes the 2 DL3008 + 1 Semgrep alerts.
- **`.github/workflows`**: add explicit top-level `permissions: contents: read` to `codeql`, `label`, and `stale` (Checkov `CKV2_GHA_1`). Job-level scopes already declare the broader write permissions they actually use, so this only restricts the default for the rest of the workflow. Closes 3 alerts.
- **`static/js/app.js`**: fix the real `useIterableCallbackReturn` at line 4130 (forEach callback was implicitly returning Map.set's return value) and a redundant `Boolean(useDolphin)` cast biome flagged on the way through. Most of the other Biome/ESLint alerts in the Codacy dashboard are stale — `eslint` and `biome` both run clean on the current `static/js/*.js` and the alerts will close on the next Codacy re-scan.

The remaining Pylint clusters (W1514, R1732, R0917, E0606, W0602, E5110) were all resolved by PR #77.

## Test plan

- [x] `ruff check app/` — all checks passed
- [x] `npx eslint static/js/api.js static/js/app.js` — exit 0
- [x] `npx @biomejs/biome lint static/js/` — no errors
- [x] `python3 -m pylint app/routes/info.py app/routes/dat.py app/services/concurrency_manager.py` — 10.00/10
- [x] `docker run --rm -i hadolint/hadolint < Dockerfile` — no findings
- [x] YAML syntax of the three workflows validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/configuration to avoid mis-parsing of lock/requirements files and to tighten default workflow permissions.
  * Enhanced Dockerfile documentation and linting/security suppressions.

* **Refactor**
  * Minor clarity/formatting improvements in client-side modal and range-selection logic.

* **Tests**
  * Cleaned up and simplified several test imports; no behavioral changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacnpal/compressatorium/pull/80)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->