### PR TITLE
feat: scaffold tool plugin registry (Phase 0)

### DIFF
--- a/app/services/tools/__init__.py
+++ b/app/services/tools/__init__.py
@@ -1,0 +1,29 @@
+"""Tool plugin registry: the single place first-party tools are registered.
+
+Consumers import ``registry`` and ask it for the tool that handles a mode /
+input / verify target instead of branching on tool identity.
+"""
+from __future__ import annotations
+
+from config import settings
+
+from .base import BaseTool, ToolPlugin
+from .chdman import ChdmanTool
+from .dolphin import DolphinTool
+from .registry import ToolRegistry
+from .spec import ModeKind, ModeSpec
+from .z3ds import Z3dsTool
+
+registry = ToolRegistry()
+registry.register(ChdmanTool(settings.chdman_path))
+registry.register(DolphinTool(settings.dolphin_tool_path))
+registry.register(Z3dsTool(settings.z3ds_compressor_path))
+
+__all__ = [
+    "BaseTool",
+    "ModeKind",
+    "ModeSpec",
+    "ToolPlugin",
+    "ToolRegistry",
+    "registry",
+]

--- a/app/services/tools/base.py
+++ b/app/services/tools/base.py
@@ -1,0 +1,90 @@
+"""The plugin contract (``ToolPlugin``) and a minimal shared base.
+
+Phase 0 keeps ``BaseTool`` deliberately small: it only hoists the
+mode-lookup and derived-extension helpers that every tool needs. The shared
+``SubprocessRunner`` orchestration and the ``verify()``-wraps-``verify_stream()``
+default described in the design land in a later phase, once real logic is moved
+out of the existing service singletons.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator, Sequence
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel
+
+from .spec import ModeSpec
+
+
+@runtime_checkable
+class ToolPlugin(Protocol):
+    id: str
+    display_name: str
+    binary_path: str
+    modes: Sequence[ModeSpec]
+    input_extensions: frozenset[str]    # convertible-from
+    output_extensions: frozenset[str]   # produced (for "output exists" badges)
+    verify_extensions: frozenset[str]   # accepted by verify()
+
+    def spec(self, mode: str) -> ModeSpec: ...
+
+    def output_path(
+        self,
+        mode: str,
+        input_path: str,
+        output_dir: str | None = None,
+        *,
+        treat_as_stem: bool = False,
+    ) -> str: ...
+
+    def convert(
+        self,
+        input_path: str,
+        output_path: str,
+        mode: str,
+        *,
+        compression: str | None = None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncGenerator[dict, None]: ...
+
+    async def verify(self, path: str) -> dict: ...
+    def verify_stream(self, path: str) -> AsyncGenerator[dict, None]: ...
+    async def info(self, path: str) -> dict: ...
+    def info_model(self, raw: dict, path: str) -> BaseModel: ...
+
+    def active_pids(self) -> list[int]: ...
+
+    async def post_convert(
+        self, input_path: str, output_path: str, mode: str,
+    ) -> None: ...
+
+
+class BaseTool:
+    """Shared helpers so concrete tools stay tiny."""
+
+    id: str
+    display_name: str
+    modes: Sequence[ModeSpec] = ()
+    output_extensions: frozenset[str] = frozenset()
+    verify_extensions: frozenset[str] = frozenset()
+
+    def __init__(self, binary_path: str) -> None:
+        self.binary_path = binary_path
+
+    @property
+    def input_extensions(self) -> frozenset[str]:
+        if not self.modes:
+            return frozenset()
+        return frozenset().union(*(m.input_extensions for m in self.modes))
+
+    def spec(self, mode: str) -> ModeSpec:
+        for m in self.modes:
+            if m.mode == mode:
+                return m
+        raise KeyError(mode)
+
+    async def post_convert(
+        self, input_path: str, output_path: str, mode: str,
+    ) -> None:
+        return None

--- a/app/services/tools/base.py
+++ b/app/services/tools/base.py
@@ -27,7 +27,8 @@ class ToolPlugin(Protocol):
     output_extensions: frozenset[str]   # produced (for "output exists" badges)
     verify_extensions: frozenset[str]   # accepted by verify()
 
-    def spec(self, mode: str) -> ModeSpec: ...
+    def spec(self, mode: str) -> ModeSpec:
+        """Return the ModeSpec for a mode this tool owns."""
 
     def output_path(
         self,
@@ -36,7 +37,8 @@ class ToolPlugin(Protocol):
         output_dir: str | None = None,
         *,
         treat_as_stem: bool = False,
-    ) -> str: ...
+    ) -> str:
+        """Resolve the output path for a conversion."""
 
     def convert(
         self,
@@ -46,18 +48,28 @@ class ToolPlugin(Protocol):
         *,
         compression: str | None = None,
         cancel_event: asyncio.Event | None = None,
-    ) -> AsyncGenerator[dict, None]: ...
+    ) -> AsyncGenerator[dict, None]:
+        """Run a conversion, yielding ``{"progress", "message"}`` updates."""
 
-    async def verify(self, path: str) -> dict: ...
-    def verify_stream(self, path: str) -> AsyncGenerator[dict, None]: ...
-    async def info(self, path: str) -> dict: ...
-    def info_model(self, raw: dict, path: str) -> BaseModel: ...
+    async def verify(self, path: str) -> dict:
+        """Verify an output file; returns ``{"valid", "message"}``."""
 
-    def active_pids(self) -> list[int]: ...
+    def verify_stream(self, path: str) -> AsyncGenerator[dict, None]:
+        """Verify with streaming progress updates."""
+
+    async def info(self, path: str) -> dict:
+        """Return raw tool info for a file."""
+
+    def info_model(self, raw: dict, path: str) -> BaseModel:
+        """Map raw info into the typed API model."""
+
+    def active_pids(self) -> list[int]:
+        """Return PIDs of in-flight subprocesses for this tool."""
 
     async def post_convert(
         self, input_path: str, output_path: str, mode: str,
-    ) -> None: ...
+    ) -> None:
+        """Optional post-processing hook after a successful conversion."""
 
 
 class BaseTool:

--- a/app/services/tools/chdman.py
+++ b/app/services/tools/chdman.py
@@ -41,7 +41,8 @@ def _build_modes() -> list[ModeSpec]:
             label=label,
             group="create",
             output_ext=".chd",
-            input_extensions=CHDMAN_CONVERTIBLE_EXTENSIONS,
+            input_extensions=frozenset(CHDMAN_CONVERTIBLE_EXTENSIONS),
+            supports_compression=True,
             supports_delete_on_verify=True,
             allows_archive_input=True,
         )
@@ -68,6 +69,7 @@ def _build_modes() -> list[ModeSpec]:
             group="copy",
             output_ext=".chd",
             input_extensions=_CHD,
+            supports_compression=True,
             supports_delete_on_verify=True,
         )
     )
@@ -91,7 +93,7 @@ class ChdmanTool(BaseTool):
     # CHDMAN_CONVERTIBLE_EXTENSIONS.
     @property
     def input_extensions(self) -> frozenset[str]:
-        return CHDMAN_CONVERTIBLE_EXTENSIONS
+        return frozenset(CHDMAN_CONVERTIBLE_EXTENSIONS)
 
     def output_path(
         self,

--- a/app/services/tools/chdman.py
+++ b/app/services/tools/chdman.py
@@ -1,0 +1,153 @@
+"""ChdmanTool — thin plugin wrapper delegating to ``chdman_service``.
+
+Phase 0 moves no logic: every call forwards to the existing singleton. The
+``ModeSpec`` rows formalize the mode metadata that is currently scattered as
+prefix checks across the codebase.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+from models import CHDInfo
+from services.chdman import CHDMAN_CONVERTIBLE_EXTENSIONS, chdman_service
+
+from .base import BaseTool
+from .spec import ModeKind, ModeSpec
+
+_CREATE_MODES = {
+    "createraw": "Create Raw",
+    "createhd": "Create HD",
+    "createcd": "Create CD",
+    "createdvd": "Create DVD",
+    "createld": "Create LD",
+}
+_EXTRACT_MODES = {
+    "extractraw": ("Extract Raw", ".raw"),
+    "extracthd": ("Extract HD", ".raw"),
+    "extractcd": ("Extract CD", ".cue"),
+    "extractdvd": ("Extract DVD", ".iso"),
+    "extractld": ("Extract LD", ".avi"),
+}
+_CHD = frozenset({".chd"})
+
+
+def _build_modes() -> list[ModeSpec]:
+    modes: list[ModeSpec] = [
+        ModeSpec(
+            mode=mode,
+            tool_id="chdman",
+            kind=ModeKind.CREATE,
+            label=label,
+            group="create",
+            output_ext=".chd",
+            input_extensions=CHDMAN_CONVERTIBLE_EXTENSIONS,
+            supports_delete_on_verify=True,
+            allows_archive_input=True,
+        )
+        for mode, label in _CREATE_MODES.items()
+    ]
+    modes += [
+        ModeSpec(
+            mode=mode,
+            tool_id="chdman",
+            kind=ModeKind.EXTRACT,
+            label=label,
+            group="extract",
+            output_ext=ext,
+            input_extensions=_CHD,
+        )
+        for mode, (label, ext) in _EXTRACT_MODES.items()
+    ]
+    modes.append(
+        ModeSpec(
+            mode="copy",
+            tool_id="chdman",
+            kind=ModeKind.COPY,
+            label="Copy / Recompress",
+            group="copy",
+            output_ext=".chd",
+            input_extensions=_CHD,
+            supports_delete_on_verify=True,
+        )
+    )
+    return modes
+
+
+class ChdmanTool(BaseTool):
+    id = "chdman"
+    display_name = "CHDMAN"
+    modes = _build_modes()
+    output_extensions = frozenset({".chd"})
+    verify_extensions = frozenset({".chd"})
+
+    def __init__(self, binary_path: str) -> None:
+        super().__init__(binary_path)
+        self._service = chdman_service
+
+    # chdman's extract/copy modes take .chd input, but a .chd is not a
+    # "convertible-from" source in the file listing — only the create sources
+    # are. Override the derived union so convertible_extensions() matches
+    # CHDMAN_CONVERTIBLE_EXTENSIONS.
+    @property
+    def input_extensions(self) -> frozenset[str]:
+        return CHDMAN_CONVERTIBLE_EXTENSIONS
+
+    def output_path(
+        self,
+        mode: str,
+        input_path: str,
+        output_dir: str | None = None,
+        *,
+        treat_as_stem: bool = False,
+    ) -> str:
+        return self._service.get_output_path_for_mode(
+            mode, input_path, output_dir, treat_as_stem=treat_as_stem,
+        )
+
+    def convert(
+        self,
+        input_path: str,
+        output_path: str,
+        mode: str,
+        *,
+        compression: str | None = None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncGenerator[dict, None]:
+        return self._service.convert(
+            input_path, output_path, mode,
+            compression=compression, cancel_event=cancel_event,
+        )
+
+    async def verify(self, path: str) -> dict:
+        return await self._service.verify(path)
+
+    def verify_stream(self, path: str) -> AsyncGenerator[dict, None]:
+        return self._service.verify_stream(path)
+
+    async def info(self, path: str) -> dict:
+        return await self._service.info(path)
+
+    def info_model(self, raw: dict, path: str) -> CHDInfo:
+        return CHDInfo(
+            file=path,
+            input_file=raw.get("input_file"),
+            file_version=raw.get("file_version"),
+            logical_size=raw.get("logical_size"),
+            hunk_size=raw.get("hunk_size"),
+            total_hunks=raw.get("total_hunks"),
+            unit_size=raw.get("unit_size"),
+            total_units=raw.get("total_units"),
+            compression=raw.get("compression"),
+            chd_size=raw.get("chd_size"),
+            ratio=raw.get("ratio"),
+            sha1=raw.get("sha1"),
+            data_sha1=raw.get("data_sha1"),
+            raw_data=raw.get("raw_data", ""),
+            media_type=raw.get("media_type"),
+            game_id=raw.get("game_id"),
+            title=raw.get("title"),
+        )
+
+    def active_pids(self) -> list[int]:
+        return self._service.active_pids()

--- a/app/services/tools/chdman.py
+++ b/app/services/tools/chdman.py
@@ -80,7 +80,9 @@ class ChdmanTool(BaseTool):
     id = "chdman"
     display_name = "CHDMAN"
     modes = _build_modes()
-    output_extensions = frozenset({".chd"})
+    # All extensions chdman produces: .chd from create/copy, plus the extract
+    # targets (.cue/.iso/.raw/.avi). verify only applies to finished CHDs.
+    output_extensions = frozenset({".chd", ".cue", ".iso", ".raw", ".avi"})
     verify_extensions = frozenset({".chd"})
 
     def __init__(self, binary_path: str) -> None:

--- a/app/services/tools/dolphin.py
+++ b/app/services/tools/dolphin.py
@@ -31,7 +31,7 @@ def _build_modes() -> list[ModeSpec]:
             label=label,
             group="dolphin",
             output_ext=ext,
-            input_extensions=DOLPHIN_CONVERTIBLE_EXTENSIONS,
+            input_extensions=frozenset(DOLPHIN_CONVERTIBLE_EXTENSIONS),
             supports_compression=supports_compression,
             supports_compression_level=supports_level,
             supports_delete_on_verify=True,
@@ -46,7 +46,7 @@ class DolphinTool(BaseTool):
     display_name = "Dolphin"
     modes = _build_modes()
     output_extensions = frozenset({".rvz", ".wia", ".gcz", ".iso"})
-    verify_extensions = DOLPHIN_CONVERTIBLE_EXTENSIONS
+    verify_extensions = frozenset(DOLPHIN_CONVERTIBLE_EXTENSIONS)
 
     def __init__(self, binary_path: str) -> None:
         super().__init__(binary_path)

--- a/app/services/tools/dolphin.py
+++ b/app/services/tools/dolphin.py
@@ -1,0 +1,113 @@
+"""DolphinTool — thin plugin wrapper delegating to ``dolphin_tool_service``."""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+from models import DolphinDiscInfo
+from services.dolphin_tool import (
+    DOLPHIN_CONVERTIBLE_EXTENSIONS,
+    dolphin_tool_service,
+)
+
+from .base import BaseTool
+from .spec import ModeKind, ModeSpec
+
+# mode -> (label, output_ext, kind, supports_compression, supports_level)
+_MODES = {
+    "dolphin_rvz": ("Dolphin RVZ", ".rvz", ModeKind.COMPRESS, True, True),
+    "dolphin_wia": ("Dolphin WIA", ".wia", ModeKind.COMPRESS, True, True),
+    "dolphin_gcz": ("Dolphin GCZ", ".gcz", ModeKind.COMPRESS, False, False),
+    "dolphin_iso": ("Dolphin ISO", ".iso", ModeKind.EXTRACT, False, False),
+}
+
+
+def _build_modes() -> list[ModeSpec]:
+    return [
+        ModeSpec(
+            mode=mode,
+            tool_id="dolphin",
+            kind=kind,
+            label=label,
+            group="dolphin",
+            output_ext=ext,
+            input_extensions=DOLPHIN_CONVERTIBLE_EXTENSIONS,
+            supports_compression=supports_compression,
+            supports_compression_level=supports_level,
+            supports_delete_on_verify=True,
+        )
+        for mode, (label, ext, kind, supports_compression, supports_level)
+        in _MODES.items()
+    ]
+
+
+class DolphinTool(BaseTool):
+    id = "dolphin"
+    display_name = "Dolphin"
+    modes = _build_modes()
+    output_extensions = frozenset({".rvz", ".wia", ".gcz", ".iso"})
+    verify_extensions = DOLPHIN_CONVERTIBLE_EXTENSIONS
+
+    def __init__(self, binary_path: str) -> None:
+        super().__init__(binary_path)
+        self._service = dolphin_tool_service
+
+    def output_path(
+        self,
+        mode: str,
+        input_path: str,
+        output_dir: str | None = None,
+        *,
+        treat_as_stem: bool = False,
+    ) -> str:
+        return self._service.get_output_path_for_mode(
+            mode, input_path, output_dir, treat_as_stem=treat_as_stem,
+        )
+
+    def convert(
+        self,
+        input_path: str,
+        output_path: str,
+        mode: str,
+        *,
+        compression: str | None = None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncGenerator[dict, None]:
+        return self._service.convert(
+            input_path, output_path, mode,
+            compression=compression, cancel_event=cancel_event,
+        )
+
+    async def verify(self, path: str) -> dict:
+        return await self._service.verify(path)
+
+    def verify_stream(self, path: str) -> AsyncGenerator[dict, None]:
+        return self._service.verify_stream(path)
+
+    async def info(self, path: str) -> dict:
+        return await self._service.header(path)
+
+    def info_model(self, raw: dict, path: str) -> DolphinDiscInfo:
+        return DolphinDiscInfo(
+            file=path,
+            game_id=raw.get("game_id"),
+            game_name=(
+                raw.get("game_name")
+                or raw.get("internal_name")
+                or raw.get("name")
+            ),
+            title_id=raw.get("title_id"),
+            disc_number=raw.get("disc_number") or raw.get("disc"),
+            revision=raw.get("revision"),
+            region=raw.get("region"),
+            country=raw.get("country"),
+            format=raw.get("format"),
+            compression=raw.get("compression") or raw.get("compression_method"),
+            compression_level=raw.get("compression_level"),
+            block_size=raw.get("block_size"),
+            file_size=raw.get("file_size"),
+            raw_data=raw.get("raw_data", ""),
+        )
+
+    def active_pids(self) -> list[int]:
+        return self._service.active_pids()

--- a/app/services/tools/registry.py
+++ b/app/services/tools/registry.py
@@ -21,13 +21,20 @@ class ToolRegistry:
         self._by_mode: dict[str, ToolPlugin] = {}
 
     def register(self, tool: ToolPlugin) -> None:
-        # Validate before mutating so a duplicate can't leave the registry in
-        # a partially-registered state (future phases iterate registry.all()).
+        # Validate fully before mutating so a bad tool can't leave the registry
+        # in a partially-registered state (future phases iterate registry.all()).
         if tool.id in self._tools:
             raise ValueError(f"duplicate tool id {tool.id}")
+        seen: set[str] = set()
         for m in tool.modes:
-            if m.mode in self._by_mode:
+            if m.tool_id != tool.id:
+                raise ValueError(
+                    f"mode {m.mode} declares tool_id {m.tool_id!r} "
+                    f"but belongs to tool {tool.id!r}"
+                )
+            if m.mode in self._by_mode or m.mode in seen:
                 raise ValueError(f"duplicate mode {m.mode}")
+            seen.add(m.mode)
         self._tools[tool.id] = tool
         for m in tool.modes:
             self._by_mode[m.mode] = tool

--- a/app/services/tools/registry.py
+++ b/app/services/tools/registry.py
@@ -1,0 +1,59 @@
+"""In-process registry of first-party conversion tools.
+
+Dispatch sites (job_manager, convert/files/info routes) ask the registry for
+the tool that handles a mode / input / verify target instead of branching on
+tool identity. No dynamic or third-party plugin discovery: tools are registered
+explicitly in ``__init__.py``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base import ToolPlugin
+    from .spec import ModeSpec
+
+
+class ToolRegistry:
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolPlugin] = {}
+        self._by_mode: dict[str, ToolPlugin] = {}
+
+    def register(self, tool: ToolPlugin) -> None:
+        self._tools[tool.id] = tool
+        for m in tool.modes:
+            if m.mode in self._by_mode:
+                raise ValueError(f"duplicate mode {m.mode}")
+            self._by_mode[m.mode] = tool
+
+    def all(self) -> list[ToolPlugin]:
+        return list(self._tools.values())
+
+    def get(self, tool_id: str) -> ToolPlugin:
+        return self._tools[tool_id]
+
+    def for_mode(self, mode: str) -> ToolPlugin:
+        return self._by_mode[mode]
+
+    def spec(self, mode: str) -> ModeSpec:
+        return self.for_mode(mode).spec(mode)
+
+    def mode_specs(self) -> list[ModeSpec]:
+        return [m for t in self._tools.values() for m in t.modes]
+
+    def convertible_extensions(self) -> frozenset[str]:
+        return frozenset().union(
+            *(t.input_extensions for t in self._tools.values())
+        )
+
+    def tools_for_input(self, filename: str) -> list[ToolPlugin]:
+        ext = Path(filename).suffix.lower()
+        return [t for t in self._tools.values() if ext in t.input_extensions]
+
+    def tool_for_verify(self, path: str) -> ToolPlugin | None:
+        ext = Path(path).suffix.lower()
+        return next(
+            (t for t in self._tools.values() if ext in t.verify_extensions),
+            None,
+        )

--- a/app/services/tools/registry.py
+++ b/app/services/tools/registry.py
@@ -21,10 +21,13 @@ class ToolRegistry:
         self._by_mode: dict[str, ToolPlugin] = {}
 
     def register(self, tool: ToolPlugin) -> None:
-        self._tools[tool.id] = tool
+        # Validate before mutating so a duplicate can't leave the registry in
+        # a partially-registered state (future phases iterate registry.all()).
         for m in tool.modes:
             if m.mode in self._by_mode:
                 raise ValueError(f"duplicate mode {m.mode}")
+        self._tools[tool.id] = tool
+        for m in tool.modes:
             self._by_mode[m.mode] = tool
 
     def all(self) -> list[ToolPlugin]:

--- a/app/services/tools/registry.py
+++ b/app/services/tools/registry.py
@@ -23,6 +23,8 @@ class ToolRegistry:
     def register(self, tool: ToolPlugin) -> None:
         # Validate before mutating so a duplicate can't leave the registry in
         # a partially-registered state (future phases iterate registry.all()).
+        if tool.id in self._tools:
+            raise ValueError(f"duplicate tool id {tool.id}")
         for m in tool.modes:
             if m.mode in self._by_mode:
                 raise ValueError(f"duplicate mode {m.mode}")

--- a/app/services/tools/spec.py
+++ b/app/services/tools/spec.py
@@ -1,0 +1,32 @@
+"""Mode metadata for the tool plugin registry.
+
+A ``ModeSpec`` carries everything the dispatch sites need to know about a
+conversion mode without branching on tool identity. Each ``ModeSpec.mode``
+equals a ``ConversionMode`` value (the validated wire type in ``models.py``).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ModeKind(str, Enum):
+    CREATE = "create"      # source -> compressed container
+    EXTRACT = "extract"    # compressed container -> source
+    COPY = "copy"          # recompress in place
+    COMPRESS = "compress"  # generic one-shot compressor (z3ds-style)
+
+
+@dataclass(frozen=True)
+class ModeSpec:
+    mode: str                       # wire value, == ConversionMode value
+    tool_id: str                    # "chdman" | "dolphin" | "z3ds"
+    kind: ModeKind
+    label: str                      # UI label
+    group: str                      # UI group id
+    output_ext: str | None          # ".chd"/".rvz"/None when input-ext-mapped
+    input_extensions: frozenset[str]
+    supports_compression: bool = False
+    supports_compression_level: bool = False  # dolphin rvz/wia only
+    supports_delete_on_verify: bool = False
+    allows_archive_input: bool = False         # chdman create modes only

--- a/app/services/tools/z3ds.py
+++ b/app/services/tools/z3ds.py
@@ -34,7 +34,7 @@ class Z3dsTool(BaseTool):
             label="Compress 3DS",
             group="z3ds",
             output_ext=None,  # mapped from the input extension
-            input_extensions=Z3DS_CONVERTIBLE_EXTENSIONS,
+            input_extensions=frozenset(Z3DS_CONVERTIBLE_EXTENSIONS),
             supports_delete_on_verify=True,
         ),
     ]

--- a/app/services/tools/z3ds.py
+++ b/app/services/tools/z3ds.py
@@ -1,0 +1,95 @@
+"""Z3dsTool — thin plugin wrapper delegating to ``z3ds_compress_service``.
+
+``z3ds_compress_service.info`` is synchronous; the async contract is satisfied
+by running it in a threadpool.
+"""
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+from fastapi.concurrency import run_in_threadpool
+
+from models import Z3DSInfo
+from services.z3ds_compress import (
+    Z3DS_CONVERTIBLE_EXTENSIONS,
+    Z3DS_OUTPUT_FORMATS,
+    z3ds_compress_service,
+)
+
+from .base import BaseTool
+from .spec import ModeKind, ModeSpec
+
+_Z3DS_OUTPUTS = frozenset(Z3DS_OUTPUT_FORMATS.values())
+
+
+class Z3dsTool(BaseTool):
+    id = "z3ds"
+    display_name = "3DS"
+    modes = [
+        ModeSpec(
+            mode="z3ds_compress",
+            tool_id="z3ds",
+            kind=ModeKind.COMPRESS,
+            label="Compress 3DS",
+            group="z3ds",
+            output_ext=None,  # mapped from the input extension
+            input_extensions=Z3DS_CONVERTIBLE_EXTENSIONS,
+            supports_delete_on_verify=True,
+        ),
+    ]
+    output_extensions = _Z3DS_OUTPUTS
+    verify_extensions = _Z3DS_OUTPUTS
+
+    def __init__(self, binary_path: str) -> None:
+        super().__init__(binary_path)
+        self._service = z3ds_compress_service
+
+    def output_path(
+        self,
+        mode: str,
+        input_path: str,
+        output_dir: str | None = None,
+        *,
+        treat_as_stem: bool = False,
+    ) -> str:
+        return self._service.get_output_path_for_mode(
+            mode, input_path, output_dir, treat_as_stem=treat_as_stem,
+        )
+
+    def convert(
+        self,
+        input_path: str,
+        output_path: str,
+        mode: str,
+        *,
+        compression: str | None = None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncGenerator[dict, None]:
+        return self._service.convert(
+            input_path, output_path, mode,
+            compression=compression, cancel_event=cancel_event,
+        )
+
+    async def verify(self, path: str) -> dict:
+        return await self._service.verify(path)
+
+    def verify_stream(self, path: str) -> AsyncGenerator[dict, None]:
+        return self._service.verify_stream(path)
+
+    async def info(self, path: str) -> dict:
+        return await run_in_threadpool(self._service.info, path)
+
+    def info_model(self, raw: dict, path: str) -> Z3DSInfo:
+        return Z3DSInfo(
+            file=raw["file"],
+            size=raw["size"],
+            size_display=raw["size_display"],
+            format=raw.get("format"),
+            extension=raw["extension"],
+            compressed=raw["compressed"],
+            compression_type=raw.get("compression_type"),
+        )
+
+    def active_pids(self) -> list[int]:
+        return self._service.active_pids()

--- a/app/services/tools/z3ds.py
+++ b/app/services/tools/z3ds.py
@@ -26,7 +26,7 @@ _Z3DS_OUTPUTS = frozenset(Z3DS_OUTPUT_FORMATS.values())
 class Z3dsTool(BaseTool):
     id = "z3ds"
     display_name = "3DS"
-    modes = [
+    modes = (
         ModeSpec(
             mode="z3ds_compress",
             tool_id="z3ds",
@@ -37,7 +37,7 @@ class Z3dsTool(BaseTool):
             input_extensions=frozenset(Z3DS_CONVERTIBLE_EXTENSIONS),
             supports_delete_on_verify=True,
         ),
-    ]
+    )
     output_extensions = _Z3DS_OUTPUTS
     verify_extensions = _Z3DS_OUTPUTS
 
@@ -81,6 +81,10 @@ class Z3dsTool(BaseTool):
         return await run_in_threadpool(self._service.info, path)
 
     def info_model(self, raw: dict, path: str) -> Z3DSInfo:
+        # Direct indexing is intentional: Z3DSInfo's fields are required and
+        # z3ds_compress_service.info() always populates them (mirrors the
+        # /z3ds-info route). Unlike CHDInfo/DolphinDiscInfo (all-optional),
+        # a bare .get() here would inject None for required fields.
         return Z3DSInfo(
             file=raw["file"],
             size=raw["size"],

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -177,3 +177,17 @@ def test_duplicate_mode_registration_raises():
     fresh.register(registry.get("chdman"))
     with pytest.raises(ValueError, match="duplicate mode createcd"):
         fresh.register(_StubTool())
+
+
+def test_duplicate_tool_id_registration_raises():
+    fresh = ToolRegistry()
+    fresh.register(registry.get("chdman"))
+    with pytest.raises(ValueError, match="duplicate tool id chdman"):
+        fresh.register(registry.get("chdman"))
+
+
+@pytest.mark.parametrize("tool_id", ["chdman", "dolphin", "z3ds"])
+def test_output_extensions_cover_mode_output_exts(tool_id):
+    tool = registry.get(tool_id)
+    declared = {m.output_ext for m in tool.modes if m.output_ext is not None}
+    assert declared <= tool.output_extensions

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -186,6 +186,36 @@ def test_duplicate_tool_id_registration_raises():
         fresh.register(registry.get("chdman"))
 
 
+def _spec(mode: str, tool_id: str = "stub") -> ModeSpec:
+    return ModeSpec(
+        mode=mode,
+        tool_id=tool_id,
+        kind=ModeKind.CREATE,
+        label="Stub",
+        group="create",
+        output_ext=".x",
+        input_extensions=frozenset({".y"}),
+    )
+
+
+def test_duplicate_mode_within_single_tool_raises():
+    class _StubTool:
+        id = "stub"
+        modes = (_spec("foo"), _spec("foo"))
+
+    with pytest.raises(ValueError, match="duplicate mode foo"):
+        ToolRegistry().register(_StubTool())
+
+
+def test_mode_spec_tool_id_must_match_owner():
+    class _StubTool:
+        id = "stub"
+        modes = (_spec("foo", tool_id="other"),)
+
+    with pytest.raises(ValueError, match="tool_id 'other'"):
+        ToolRegistry().register(_StubTool())
+
+
 @pytest.mark.parametrize("tool_id", ["chdman", "dolphin", "z3ds"])
 def test_output_extensions_cover_mode_output_exts(tool_id):
     tool = registry.get(tool_id)

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -77,6 +77,33 @@ def test_kind_classification():
     assert spec("dolphin_iso").kind is ModeKind.EXTRACT
 
 
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        # chdman create/copy accept -c codec selection; extract does not.
+        ("createcd", True),
+        ("createdvd", True),
+        ("copy", True),
+        ("extractcd", False),
+        # dolphin rvz/wia take a compression codec (+ level); gcz/iso don't.
+        ("dolphin_rvz", True),
+        ("dolphin_wia", True),
+        ("dolphin_gcz", False),
+        ("dolphin_iso", False),
+        ("z3ds_compress", False),
+    ],
+)
+def test_supports_compression_matches_current_behavior(mode, expected):
+    assert registry.spec(mode).supports_compression is expected
+
+
+def test_compression_level_only_for_dolphin_rvz_wia():
+    for mode in ("dolphin_rvz", "dolphin_wia"):
+        assert registry.spec(mode).supports_compression_level is True
+    for mode in ("createcd", "copy", "dolphin_gcz", "dolphin_iso", "z3ds_compress"):
+        assert registry.spec(mode).supports_compression_level is False
+
+
 def test_convertible_extensions_match_service_constants():
     expected = (
         set(CHDMAN_CONVERTIBLE_EXTENSIONS)

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,152 @@
+"""Characterization tests for the tool plugin registry (design Phase 0).
+
+These lock the *current* behavior (mode -> tool, capability flags, output
+paths) into tests before later phases move dispatch logic onto the registry.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.models import ConversionMode
+from app.routes import convert as convert_routes
+from app.services.chdman import (
+    CHDMAN_CONVERTIBLE_EXTENSIONS,
+    chdman_service,
+)
+from app.services.dolphin_tool import (
+    DOLPHIN_CONVERTIBLE_EXTENSIONS,
+    dolphin_tool_service,
+)
+from app.services.tools import registry
+from app.services.tools.registry import ToolRegistry
+from app.services.tools.spec import ModeKind, ModeSpec
+from app.services.z3ds_compress import (
+    Z3DS_CONVERTIBLE_EXTENSIONS,
+    z3ds_compress_service,
+)
+
+# ConversionMode values that are NOT conversion modes — handled by the
+# external job API, not by any of the three conversion services.
+EXTERNAL_MODES = {ConversionMode.METADATA_SCAN, ConversionMode.DAT_MATCH}
+CONVERSION_MODES = [m for m in ConversionMode if m not in EXTERNAL_MODES]
+
+
+def _legacy_tool_for_mode(mode: str) -> str:
+    """Replicates the dispatch ladder at job_manager.py:1444."""
+    if mode.startswith("dolphin_"):
+        return "dolphin"
+    if mode == ConversionMode.Z3DS_COMPRESS.value:
+        return "z3ds"
+    return "chdman"
+
+
+def test_every_conversion_mode_resolves_to_exactly_one_tool():
+    resolved = {m.value: registry.for_mode(m.value).id for m in CONVERSION_MODES}
+    assert len(resolved) == 16
+    # Each registered mode is owned by exactly one tool (no duplicates).
+    assert sorted(s.mode for s in registry.mode_specs()) == sorted(resolved)
+
+
+def test_external_modes_are_not_registered():
+    for mode in EXTERNAL_MODES:
+        with pytest.raises(KeyError):
+            registry.for_mode(mode.value)
+
+
+@pytest.mark.parametrize("mode", [m.value for m in CONVERSION_MODES])
+def test_mode_to_tool_matches_legacy_ladder(mode):
+    assert registry.for_mode(mode).id == _legacy_tool_for_mode(mode)
+
+
+@pytest.mark.parametrize("mode", [m.value for m in CONVERSION_MODES])
+def test_supports_delete_on_verify_parity(mode):
+    assert (
+        registry.spec(mode).supports_delete_on_verify
+        == convert_routes.supports_delete_on_verify(mode)
+    )
+
+
+def test_kind_classification():
+    spec = registry.spec
+    assert spec("createcd").kind is ModeKind.CREATE
+    assert spec("extractcd").kind is ModeKind.EXTRACT
+    assert spec("copy").kind is ModeKind.COPY
+    assert spec("z3ds_compress").kind is ModeKind.COMPRESS
+    # dolphin compress vs extract
+    assert spec("dolphin_rvz").kind is ModeKind.COMPRESS
+    assert spec("dolphin_iso").kind is ModeKind.EXTRACT
+
+
+def test_convertible_extensions_match_service_constants():
+    expected = (
+        set(CHDMAN_CONVERTIBLE_EXTENSIONS)
+        | set(DOLPHIN_CONVERTIBLE_EXTENSIONS)
+        | set(Z3DS_CONVERTIBLE_EXTENSIONS)
+    )
+    assert set(registry.convertible_extensions()) == expected
+
+
+def test_tools_for_input_representative():
+    assert sorted(t.id for t in registry.tools_for_input("game.iso")) == [
+        "chdman",
+        "dolphin",
+    ]
+    assert [t.id for t in registry.tools_for_input("rom.3ds")] == ["z3ds"]
+    assert [t.id for t in registry.tools_for_input("disc.gdi")] == ["chdman"]
+    # A finished .chd is not a "convertible-from" source in the listing.
+    assert registry.tools_for_input("out.chd") == []
+
+
+def test_tool_for_verify_representative():
+    assert registry.tool_for_verify("out.chd").id == "chdman"
+    assert registry.tool_for_verify("rom.z3ds").id == "z3ds"
+    assert registry.tool_for_verify("disc.rvz").id == "dolphin"
+    assert registry.tool_for_verify("nope.txt") is None
+
+
+@pytest.mark.parametrize("output_dir", [None, "/data/out"])
+@pytest.mark.parametrize("treat_as_stem", [False, True])
+@pytest.mark.parametrize(
+    ("mode", "service", "inp"),
+    [
+        ("createcd", chdman_service, "/data/game.cue"),
+        ("createdvd", chdman_service, "/data/game.iso"),
+        ("extractcd", chdman_service, "/data/game.chd"),
+        ("extractdvd", chdman_service, "/data/game.chd"),
+        ("copy", chdman_service, "/data/game.chd"),
+        ("dolphin_rvz", dolphin_tool_service, "/data/game.iso"),
+        ("dolphin_iso", dolphin_tool_service, "/data/game.rvz"),
+        ("z3ds_compress", z3ds_compress_service, "/data/rom.3ds"),
+    ],
+)
+def test_output_path_delegation_matches_service(
+    mode, service, inp, output_dir, treat_as_stem,
+):
+    expected = service.get_output_path_for_mode(
+        mode, inp, output_dir, treat_as_stem=treat_as_stem,
+    )
+    actual = registry.for_mode(mode).output_path(
+        mode, inp, output_dir, treat_as_stem=treat_as_stem,
+    )
+    assert actual == expected
+
+
+def test_duplicate_mode_registration_raises():
+    class _StubTool:
+        id = "stub"
+        modes = (
+            ModeSpec(
+                mode="createcd",  # collides with chdman
+                tool_id="stub",
+                kind=ModeKind.CREATE,
+                label="Stub",
+                group="create",
+                output_ext=".chd",
+                input_extensions=frozenset({".iso"}),
+            ),
+        )
+
+    fresh = ToolRegistry()
+    fresh.register(registry.get("chdman"))
+    with pytest.raises(ValueError, match="duplicate mode createcd"):
+        fresh.register(_StubTool())


### PR DESCRIPTION
## Summary

Phase 0 of the tool plugin architecture from `DESIGN_tool_plugin_architecture.md`. Purely additive — **no existing file is modified**, so there is zero user-facing or behavior change.

Introduces `app/services/tools/`, an in-process registry that formalizes the implicit `chdman` / `dolphin` / `z3ds` tool contract that today lives as hardcoded `if/elif` ladders and string-prefix checks scattered across `job_manager.py`, `convert.py`, `files.py`, `info.py`, `models.py`, and the frontend.

- `spec.py` — `ModeSpec` / `ModeKind`. One `ModeSpec` row per conversion mode captures the metadata that prefix checks encode today (`kind`, `output_ext`, `input_extensions`, `supports_delete_on_verify`, `allows_archive_input`, compression flags).
- `registry.py` — `ToolRegistry` (`for_mode` / `spec` / `tools_for_input` / `tool_for_verify` / `convertible_extensions`), raises on duplicate mode.
- `base.py` — `ToolPlugin` Protocol + minimal `BaseTool` (shared mode-lookup / derived extensions; `SubprocessRunner` and the `verify()` default are deferred to a later phase).
- `chdman.py` / `dolphin.py` / `z3ds.py` — thin wrappers that **delegate** to the existing `*_service` singletons. `Z3dsTool.info` wraps the sync service call in `run_in_threadpool`; `DolphinTool.info` calls `header()`.
- `__init__.py` — builds the `registry` singleton from `settings.*_path`.

Nothing imports the registry yet; consumers are migrated one phase at a time (Phases 1–9 in the design doc).

### Note on `METADATA_SCAN` / `DAT_MATCH`
These two `ConversionMode` values are deliberately **not** registered — they are external-job modes handled by the external job API, not by any conversion service. The design doc's "every `ConversionMode` value" wording predates noticing this.

## Test plan

- [x] `ruff check app tests` — clean
- [x] `pylint app/services/tools` — 10.00/10
- [x] `pytest -q tests` — 397 passed (326 baseline + 71 new), no regressions
- [x] New `tests/test_tool_registry.py` characterization tests lock current behavior:
  - every conversion mode resolves to exactly one tool; external modes raise `KeyError`
  - mode→tool parity vs the legacy `job_manager` dispatch ladder
  - `supports_delete_on_verify` parity vs `convert.supports_delete_on_verify`
  - `convertible_extensions()` matches the union of the service constants
  - `tools_for_input` / `tool_for_verify` for representative inputs
  - output-path delegation equivalence across a mode × `output_dir` × `treat_as_stem` matrix
  - duplicate-mode registration raises `ValueError`

https://claude.ai/code/session_01AxAXHJvXEYd2a3EXAA7VMe

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxAXHJvXEYd2a3EXAA7VMe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a centralized tool management system with automatic tool discovery and selection based on input file types.
  * Standardized conversion workflows across all tools with consistent verification, information retrieval, and capability metadata.
  * Added flexible operation modes per tool with detailed capability flags including compression support and delete-on-verify options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacnpal/compressatorium/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->