### PR TITLE
feat: route convert.py mode checks through the tool registry (Phase 1)

### DIFF
--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -20,13 +20,11 @@ from models import (
 )
 from services.archive import archive_service
 from services.chdman import chdman_service
-from services.dolphin_tool import (
-    DOLPHIN_CONVERTIBLE_EXTENSIONS,
-    dolphin_tool_service,
-)
-from services.z3ds_compress import Z3DS_CONVERTIBLE_EXTENSIONS, z3ds_compress_service
+from services.dolphin_tool import dolphin_tool_service
+from services.z3ds_compress import z3ds_compress_service
 from services.job_manager import QueueBackpressureError, job_manager
 from services.lock_manager import lock_manager
+from services.tools import ModeKind, registry
 from sse_starlette.sse import EventSourceResponse
 from utils.delete_plan import build_delete_plan, build_delete_snapshot
 from utils.path_utils import is_within_configured_volumes
@@ -85,12 +83,10 @@ def normalize_compression(value: str | None) -> str | None:
 
 
 def supports_delete_on_verify(mode: str) -> bool:
-    return (
-        mode.startswith("create")
-        or mode == "copy"
-        or mode.startswith("dolphin_")
-        or mode == ConversionMode.Z3DS_COMPRESS.value
-    )
+    try:
+        return registry.spec(mode).supports_delete_on_verify
+    except KeyError:
+        return False
 
 
 def _is_dolphin_mode(mode: str) -> bool:
@@ -300,9 +296,10 @@ async def create_job(request: JobCreateRequest):
     compression = normalize_compression(request.compression)
     mode = request.mode.value
     output_dir = normalize_output_dir(request.output_dir)
-    is_dolphin = _is_dolphin_mode(mode)
-    is_z3ds = mode == ConversionMode.Z3DS_COMPRESS.value
-    if compression and mode.startswith("extract"):
+    spec = registry.spec(mode)
+    is_dolphin = spec.tool_id == "dolphin"
+    is_z3ds = spec.tool_id == "z3ds"
+    if compression and spec.tool_id == "chdman" and spec.kind == ModeKind.EXTRACT:
         raise HTTPException(
             status_code=400,
             detail="Compression is only supported for CHD creation/copy",
@@ -327,7 +324,7 @@ async def create_job(request: JobCreateRequest):
             status_code=400,
             detail="Dolphin compression supports only one codec at a time",
         )
-    if request.delete_on_verify and not supports_delete_on_verify(mode):
+    if request.delete_on_verify and not spec.supports_delete_on_verify:
         raise HTTPException(
             status_code=400,
             detail="Delete-on-verify is only supported for create/copy/Dolphin/3DS modes",
@@ -354,7 +351,7 @@ async def create_job(request: JobCreateRequest):
     display_filename = None
 
     if "::" in request.file_path:
-        if mode.startswith("extract") or mode == "copy" or is_dolphin or is_z3ds:
+        if not spec.allows_archive_input:
             raise HTTPException(
                 status_code=400,
                 detail=(
@@ -398,20 +395,20 @@ async def create_job(request: JobCreateRequest):
         raise HTTPException(status_code=404, detail="File not found")
 
     if (
-        mode.startswith("extract") or mode == "copy"
+        spec.tool_id == "chdman" and spec.kind in (ModeKind.EXTRACT, ModeKind.COPY)
     ) and not file_path.lower().endswith(".chd"):
         raise HTTPException(
             status_code=400, detail="Extract/copy modes require .chd input files",
         )
 
-    if mode.startswith("create") and file_path.lower().endswith(".chd"):
+    if spec.kind == ModeKind.CREATE and file_path.lower().endswith(".chd"):
         raise HTTPException(
             status_code=400, detail="Create modes require non-CHD input files",
         )
 
     if is_dolphin:
         ext = Path(file_path).suffix.lower()
-        if ext not in DOLPHIN_CONVERTIBLE_EXTENSIONS:
+        if ext not in spec.input_extensions:
             raise HTTPException(
                 status_code=400,
                 detail="Dolphin modes require GameCube/Wii disc images "
@@ -420,7 +417,7 @@ async def create_job(request: JobCreateRequest):
 
     if is_z3ds:
         ext = Path(file_path).suffix.lower()
-        if ext not in Z3DS_CONVERTIBLE_EXTENSIONS:
+        if ext not in spec.input_extensions:
             raise HTTPException(
                 status_code=400,
                 detail="z3ds_compress mode requires Nintendo 3DS ROM files (.cci, .cia, .3ds)",
@@ -518,10 +515,11 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
         )
     compression = normalize_compression(request.compression)
     mode = request.mode.value
-    is_dolphin = _is_dolphin_mode(mode)
-    is_z3ds = mode == ConversionMode.Z3DS_COMPRESS.value
+    spec = registry.spec(mode)
+    is_dolphin = spec.tool_id == "dolphin"
+    is_z3ds = spec.tool_id == "z3ds"
     output_dir = normalize_output_dir(request.output_dir)
-    if compression and mode.startswith("extract"):
+    if compression and spec.tool_id == "chdman" and spec.kind == ModeKind.EXTRACT:
         raise HTTPException(
             status_code=400,
             detail="Compression is only supported for CHD creation/copy",
@@ -546,7 +544,7 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
             status_code=400,
             detail="Dolphin compression supports only one codec at a time",
         )
-    if request.delete_on_verify and not supports_delete_on_verify(mode):
+    if request.delete_on_verify and not spec.supports_delete_on_verify:
         raise HTTPException(
             status_code=400,
             detail="Delete-on-verify is only supported for create/copy/Dolphin/3DS modes",
@@ -603,7 +601,7 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
 
         # Handle archive files
         if "::" in file_path:
-            if mode.startswith("extract") or mode == "copy" or is_dolphin or is_z3ds:
+            if not spec.allows_archive_input:
                 skipped.append(file_path)
                 continue
             archive_path, internal_path = file_path.split("::", 1)
@@ -644,24 +642,24 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
             continue
 
         if (
-            mode.startswith("extract") or mode == "copy"
+            spec.tool_id == "chdman" and spec.kind in (ModeKind.EXTRACT, ModeKind.COPY)
         ) and not file_path.lower().endswith(".chd"):
             skipped.append(file_path)
             continue
 
-        if mode.startswith("create") and file_path.lower().endswith(".chd"):
+        if spec.kind == ModeKind.CREATE and file_path.lower().endswith(".chd"):
             skipped.append(file_path)
             continue
 
         if is_dolphin:
             ext = Path(file_path).suffix.lower()
-            if ext not in DOLPHIN_CONVERTIBLE_EXTENSIONS:
+            if ext not in spec.input_extensions:
                 skipped.append(file_path)
                 continue
 
         if is_z3ds:
             ext = Path(file_path).suffix.lower()
-            if ext not in Z3DS_CONVERTIBLE_EXTENSIONS:
+            if ext not in spec.input_extensions:
                 skipped.append(file_path)
                 continue
 

--- a/tests/test_mode_parity_fixes.py
+++ b/tests/test_mode_parity_fixes.py
@@ -124,6 +124,20 @@ async def test_delete_on_verify_error_messages_include_dolphin_and_3ds():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode", [ConversionMode.METADATA_SCAN, ConversionMode.DAT_MATCH],
+)
+async def test_delete_plan_rejects_external_modes_without_crashing(mode):
+    """External (non-conversion) modes are unregistered; delete-plan must still
+    return a clean 400 rather than surfacing a registry KeyError as a 500."""
+    request = DeletePlanRequest(file_paths=["/tmp/any.chd"], mode=mode)
+    with pytest.raises(HTTPException) as exc_info:
+        await convert_routes.delete_plan(request)
+    assert exc_info.value.status_code == 400
+    assert "create/copy/Dolphin/3DS" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_create_job_returns_429_when_queue_is_full(tmp_path: Path, monkeypatch):
     """Single-job submissions should apply queue backpressure with HTTP 429."""
     source_path = tmp_path / "disc.iso"


### PR DESCRIPTION
## Phase 1 — drive `convert.py` predicates off the tool registry

Replaces the hardcoded `mode.startswith(...)` / `== "z3ds_compress"` string checks and the body of `supports_delete_on_verify()` in `app/routes/convert.py` with reads off `registry.spec(mode)` (Phase 0 API). Pure, behavior-preserving substitution — no wire-API changes, no new endpoints. Phase 2 (`_get_output_path`) and Phase 4 (single/batch merge) are intentionally left untouched; the duplicated single vs. batch structure is preserved.

### Substitutions (applied in both `create_job` and `create_batch_jobs`)
`spec = registry.spec(mode)` is fetched once per handler after the existing `METADATA_SCAN`/`DAT_MATCH` guard, then reused:

| Old check | New |
| --- | --- |
| `_is_dolphin_mode(mode)` flag | `spec.tool_id == "dolphin"` |
| `mode == ConversionMode.Z3DS_COMPRESS.value` flag | `spec.tool_id == "z3ds"` |
| `mode.startswith("create")` (rejects `.chd` input) | `spec.kind == ModeKind.CREATE` |
| archive-input deny guard | `not spec.allows_archive_input` |
| dolphin / z3ds extension validation | `Path(file_path).suffix.lower() in spec.input_extensions` |
| `mode.startswith("extract")` (compression check) | `spec.tool_id == "chdman" and spec.kind == ModeKind.EXTRACT` |
| `mode.startswith("extract") or mode == "copy"` (requires `.chd`) | `spec.tool_id == "chdman" and spec.kind in (ModeKind.EXTRACT, ModeKind.COPY)` |

The two chdman-qualified forms are deliberate: bare `spec.kind == ModeKind.EXTRACT` would also match `dolphin_iso` (kind `EXTRACT`), which the old prefix check never did — qualifying with `tool_id == "chdman"` keeps the exact set of 16 modes that each predicate matched before.

### Behavior-preservation notes
- The `dolphin_iso` / `dolphin_gcz` "compression not applicable" / "GCZ fixed compression" checks and the dolphin colon-level check are left as their original mode-literal / `is_dolphin` forms. Collapsing them to `not spec.supports_compression` / `spec.supports_compression_level` (per the design table) would have (a) merged two distinct user-facing error messages and (b) started rejecting `z3ds_compress` + compression, which the current code accepts — i.e. a behavior change. `is_dolphin` is now registry-derived, so these still read off the spec indirectly.
- Removed the now-unused `DOLPHIN_CONVERTIBLE_EXTENSIONS` / `Z3DS_CONVERTIBLE_EXTENSIONS` imports; the service singletons are still imported for `_get_output_path` (Phase 2).

### `supports_delete_on_verify` decision
Kept as a one-line shim returning `registry.spec(mode).supports_delete_on_verify`, **wrapped in a `try/except KeyError` returning `False`**. The Phase 0 parity test (`test_tool_registry.py`) imports and calls this helper, so it stays. The guard is required because `delete_plan` does **not** pre-reject `METADATA_SCAN`/`DAT_MATCH` (those are unregistered → `registry.spec` raises `KeyError`); the old helper returned `False` for any unknown mode, and the guard preserves that exact 400 response rather than surfacing a 500. Internal call sites in `create_job`/`create_batch_jobs` read `spec.supports_delete_on_verify` directly (the upfront guard already excludes external modes there).

### Tests
- All existing tests pass unchanged (`PYTHONPATH=app pytest tests -q` → green).
- Added `test_delete_plan_rejects_external_modes_without_crashing` locking in that `delete_plan` with `METADATA_SCAN`/`DAT_MATCH` still returns a clean 400 (not a registry `KeyError`/500).
- `ruff check app tests` clean; `pylint` 10.00/10 on both touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_016sAHocZMqFhoJNveaP1wpZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed endpoint error responses when using delete-on-verify with unsupported conversion modes, now returning proper error codes instead of failures.

* **Tests**
  * Added regression test for endpoint validation with unsupported conversion modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacnpal/compressatorium/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->