### PR TITLE
feat: route output-path resolution through the tool registry (Phase 2)

### DIFF
--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -19,9 +19,6 @@ from models import (
     JobStatus,
 )
 from services.archive import archive_service
-from services.chdman import chdman_service
-from services.dolphin_tool import dolphin_tool_service
-from services.z3ds_compress import z3ds_compress_service
 from services.job_manager import QueueBackpressureError, job_manager
 from services.lock_manager import lock_manager
 from services.tools import ModeKind, registry
@@ -89,20 +86,8 @@ def supports_delete_on_verify(mode: str) -> bool:
         return False
 
 
-def _is_dolphin_mode(mode: str) -> bool:
-    return mode.startswith("dolphin_")
-
-
 def _get_output_path(mode, input_path, output_dir, *, treat_as_stem=False):
-    if _is_dolphin_mode(mode):
-        return dolphin_tool_service.get_output_path_for_mode(
-            mode, input_path, output_dir, treat_as_stem=treat_as_stem,
-        )
-    if mode == ConversionMode.Z3DS_COMPRESS.value:
-        return z3ds_compress_service.get_output_path_for_mode(
-            mode, input_path, output_dir, treat_as_stem=treat_as_stem,
-        )
-    return chdman_service.get_output_path_for_mode(
+    return registry.for_mode(mode).output_path(
         mode, input_path, output_dir, treat_as_stem=treat_as_stem,
     )
 

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -23,6 +23,7 @@ from services.disc_id import embed_in_chd as disc_id_embed
 from services.disc_id import extract_from_source as disc_id_from_source
 from services.dolphin_tool import dolphin_tool_service
 from services.lock_manager import lock_manager
+from services.tools import registry
 from services.verification_store import verification_store
 from services.z3ds_compress import z3ds_compress_service
 from utils.delete_plan import build_delete_plan
@@ -137,10 +138,9 @@ class JobManager:
 
         # Determine output path - use explicit path if provided, otherwise calculate
         if output_path is None:
-            if mode == ConversionMode.Z3DS_COMPRESS:
-                output_path = z3ds_compress_service.get_output_path(file_path, output_dir)
-            else:
-                output_path = chdman_service.get_chd_path(file_path, output_dir)
+            output_path = registry.for_mode(mode.value).output_path(
+                mode.value, file_path, output_dir,
+            )
 
         job = ConversionJob(
             id=job_id,

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -25,7 +25,7 @@ from services.dolphin_tool import dolphin_tool_service
 from services.lock_manager import lock_manager
 from services.tools import registry
 from services.verification_store import verification_store
-from services.z3ds_compress import z3ds_compress_service
+from services.z3ds_compress import Z3DS_OUTPUT_FORMATS, z3ds_compress_service
 from utils.delete_plan import build_delete_plan
 from utils.path_utils import is_within_configured_volumes, strip_archive_path
 
@@ -40,6 +40,13 @@ _EXTERNAL_JOB_MODES = frozenset({
     ConversionMode.METADATA_SCAN,
     ConversionMode.DAT_MATCH,
 })
+
+
+def _paths_collide(path_a: str, path_b: str) -> bool:
+    try:
+        return os.path.realpath(path_a) == os.path.realpath(path_b)
+    except OSError:
+        return False
 
 
 class QueueBackpressureError(RuntimeError):
@@ -141,6 +148,19 @@ class JobManager:
             output_path = registry.for_mode(mode.value).output_path(
                 mode.value, file_path, output_dir,
             )
+            # The HTTP routes validate inputs before passing an explicit
+            # output_path; direct service callers reach this fallback, so
+            # re-assert the guards the legacy per-tool fallback enforced.
+            if mode == ConversionMode.Z3DS_COMPRESS:
+                ext = Path(file_path).suffix.lower()
+                if ext not in Z3DS_OUTPUT_FORMATS:
+                    raise ValueError(f"Unsupported file extension: {ext}")
+            elif mode.value.startswith("dolphin_") and _paths_collide(
+                output_path, file_path,
+            ):
+                raise ValueError(
+                    "Output path matches input; refusing to overwrite source"
+                )
 
         job = ConversionJob(
             id=job_id,

--- a/tests/test_output_path_routing.py
+++ b/tests/test_output_path_routing.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import pytest
 
+from app.models import ConversionMode
 from app.services.chdman import chdman_service
 from app.services.dolphin_tool import dolphin_tool_service
+from app.services.job_manager import JobManager
 from app.services.tools import registry
 from app.services.z3ds_compress import z3ds_compress_service
 
@@ -93,3 +95,39 @@ def test_archive_stem_keeps_full_name_as_stem():
         "createcd", "disc.cue", None, treat_as_stem=True,
     )
     assert routed == "disc.cue.chd"
+
+
+# Guards on the _queue_job_locked output_path fallback for direct service
+# callers (the HTTP routes always pass an explicit output_path). These
+# preserve rejections the legacy per-tool fallback enforced.
+
+
+@pytest.mark.asyncio
+async def test_z3ds_fallback_rejects_unsupported_extension():
+    manager = JobManager()
+    with pytest.raises(ValueError, match="Unsupported file extension"):
+        await manager.create_job("/data/not-a-rom.txt", ConversionMode.Z3DS_COMPRESS)
+
+
+@pytest.mark.asyncio
+async def test_z3ds_fallback_accepts_supported_extension():
+    manager = JobManager()
+    job = await manager.create_job("/data/rom.cci", ConversionMode.Z3DS_COMPRESS)
+    assert job.output_path == "/data/rom.zcci"
+
+
+@pytest.mark.asyncio
+async def test_dolphin_fallback_rejects_output_colliding_with_source():
+    # dolphin_iso on a .iso source resolves to the same path; refuse it
+    # rather than let dolphin-tool overwrite the source.
+    manager = JobManager()
+    with pytest.raises(ValueError, match="Output path matches input"):
+        await manager.create_job("/data/game.iso", ConversionMode.DOLPHIN_ISO)
+
+
+@pytest.mark.asyncio
+async def test_dolphin_fallback_allows_distinct_output():
+    # dolphin_rvz on a .iso source yields a distinct .rvz path; allowed.
+    manager = JobManager()
+    job = await manager.create_job("/data/game.iso", ConversionMode.DOLPHIN_RVZ)
+    assert job.output_path == "/data/game.rvz"

--- a/tests/test_output_path_routing.py
+++ b/tests/test_output_path_routing.py
@@ -1,0 +1,95 @@
+"""Old-vs-new equivalence tests for Phase 2 output-path routing.
+
+Phase 2 routes the two hardcoded output-path resolution sites
+(``convert._get_output_path`` and ``job_manager._queue_job_locked``) through
+``registry.for_mode(mode).output_path(...)``. These tests lock the
+substitution as behavior-preserving for every path reachable via the HTTP API.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.chdman import chdman_service
+from app.services.dolphin_tool import dolphin_tool_service
+from app.services.tools import registry
+from app.services.z3ds_compress import z3ds_compress_service
+
+# mode -> (legacy service used by the old _get_output_path ladder, sample input).
+# Inputs are chosen so extract modes carry a .chd source (so the .chd-stripping
+# branch fires) and dolphin/z3ds modes carry a real convertible extension.
+ROUTE_MATRIX = [
+    ("createcd", chdman_service, "/data/game.cue"),
+    ("createdvd", chdman_service, "/data/game.iso"),
+    ("createhd", chdman_service, "/data/game.img"),
+    ("createraw", chdman_service, "/data/game.img"),
+    ("createld", chdman_service, "/data/game.raw"),
+    ("extractcd", chdman_service, "/data/game.chd"),
+    ("extractdvd", chdman_service, "/data/game.chd"),
+    ("extractraw", chdman_service, "/data/game.chd"),
+    ("extracthd", chdman_service, "/data/game.chd"),
+    ("extractld", chdman_service, "/data/game.chd"),
+    ("copy", chdman_service, "/data/game.chd"),
+    ("dolphin_rvz", dolphin_tool_service, "/data/game.iso"),
+    ("dolphin_iso", dolphin_tool_service, "/data/game.rvz"),
+    ("dolphin_wia", dolphin_tool_service, "/data/game.iso"),
+    ("dolphin_gcz", dolphin_tool_service, "/data/game.iso"),
+    ("z3ds_compress", z3ds_compress_service, "/data/rom.3ds"),
+]
+
+
+@pytest.mark.parametrize("output_dir", [None, "/data/out"])
+@pytest.mark.parametrize("treat_as_stem", [False, True])
+@pytest.mark.parametrize(("mode", "service", "inp"), ROUTE_MATRIX)
+def test_route_output_path_matches_legacy_ladder(
+    mode, service, inp, output_dir, treat_as_stem,
+):
+    # Old convert._get_output_path ladder dispatched to the per-tool
+    # service.get_output_path_for_mode(...); the registry must match it.
+    legacy = service.get_output_path_for_mode(
+        mode, inp, output_dir, treat_as_stem=treat_as_stem,
+    )
+    routed = registry.for_mode(mode).output_path(
+        mode, inp, output_dir, treat_as_stem=treat_as_stem,
+    )
+    assert routed == legacy
+
+
+@pytest.mark.parametrize("output_dir", [None, "/data/out"])
+def test_job_manager_chdman_fallback_equivalence(output_dir):
+    # Legacy _queue_job_locked fallback for non-z3ds modes called
+    # chdman_service.get_chd_path(...). For create/copy modes the registry's
+    # output_path must produce the same .chd path.
+    inp = "/data/game.cue"
+    legacy = chdman_service.get_chd_path(inp, output_dir)
+    routed = registry.for_mode("createcd").output_path("createcd", inp, output_dir)
+    assert routed == legacy
+
+
+@pytest.mark.parametrize("output_dir", [None, "/data/out"])
+def test_job_manager_z3ds_fallback_equivalence(output_dir):
+    # Legacy _queue_job_locked fallback for z3ds_compress called
+    # z3ds_compress_service.get_output_path(...); the registry must match it.
+    inp = "/data/rom.cci"
+    legacy = z3ds_compress_service.get_output_path(inp, output_dir)
+    routed = registry.for_mode("z3ds_compress").output_path(
+        "z3ds_compress", inp, output_dir,
+    )
+    assert routed == legacy
+
+
+@pytest.mark.parametrize("output_dir", [None, "/data/out"])
+def test_extractcd_emits_cue_not_bin(output_dir):
+    # Documented edge case: extractcd resolves to a .cue sidecar path.
+    routed = registry.for_mode("extractcd").output_path(
+        "extractcd", "/data/game.chd", output_dir,
+    )
+    assert routed.endswith("game.cue")
+
+
+def test_archive_stem_keeps_full_name_as_stem():
+    # Documented edge case: treat_as_stem=True keeps the member's full name
+    # (no extension stripping) as the output stem.
+    routed = registry.for_mode("createcd").output_path(
+        "createcd", "disc.cue", None, treat_as_stem=True,
+    )
+    assert routed == "disc.cue.chd"


### PR DESCRIPTION
## Phase 2 — output-path resolution → registry

Behavior-preserving substitution of the two remaining hardcoded output-path resolution sites with a single `registry.for_mode(mode).output_path(...)` call. No Phase 3/4 work, no wire-API changes.

### Re-routed sites

1. **`app/routes/convert.py:_get_output_path`** — replaced the `dolphin_/z3ds/chdman` branching ladder with a single registry call. All five call sites (`check_duplicates`, `create_job` ×2, `create_batch_jobs` ×2) live in handlers that reject `METADATA_SCAN`/`DAT_MATCH` at the top, so `for_mode` never `KeyError`s there. `delete_plan` does not call it.
   - Removed the now-dead `_is_dolphin_mode` helper and the three unused service imports (`chdman_service`, `dolphin_tool_service`, `z3ds_compress_service`), grep-confirmed unused. Kept `archive_service` (used by `_output_stem_for_member`) and `ConversionMode` (external-mode guards).

2. **`app/services/job_manager.py:_queue_job_locked`** — replaced the `output_path is None` fallback (`z3ds_compress_service.get_output_path` / `chdman_service.get_chd_path`) with `registry.for_mode(mode.value).output_path(...)`. Added `from services.tools import registry`. The other three service singletons remain imported — still used by the Phase 3 dispatch ladder and verify branches, which are left untouched.

### Equivalence test (`tests/test_output_path_routing.py`)

Old-vs-new assertions across the matrix: 16 modes (`createcd/dvd/hd/raw/ld`, `extractcd→.cue`, `extractdvd→.iso`, `extractraw/hd`, `extractld`, `copy`, `dolphin_rvz/iso/wia/gcz`, `z3ds_compress`) × `output_dir ∈ {None, "/data/out"}` × `treat_as_stem ∈ {False, True}`, comparing each tool's legacy `get_output_path_for_mode(...)` to the registry call. Plus explicit `job_manager`-fallback cases:
- `chdman_service.get_chd_path(f, d) == registry.for_mode("createcd").output_path("createcd", f, d)`
- `z3ds_compress_service.get_output_path(f, d) == registry.for_mode("z3ds_compress").output_path("z3ds_compress", f, d)`
- plus the documented `extractcd` `.cue` and archive-stem (`treat_as_stem=True`) edge cases.

### Decision on the dolphin + `output_path is None` fallback edge

The legacy `else` branch sent **any** non-z3ds mode (including dolphin modes) through `chdman.get_chd_path` → a `.chd` path. I **routed it through the registry**, which gives dolphin modes their real dolphin output path — the more-correct behavior, and arguably a latent-bug fix. This is only reachable via direct `job_manager.create_job(...)`/`create_jobs_atomic(...)` calls that omit `output_path` for a dolphin mode; **the HTTP routes always pass an explicit `output_path`, so this fallback never fires for dolphin via the API.** I grepped the test suite: every `create_job`/`create_jobs_atomic` call passes an explicit `output_path` (CREATECD/Z3DS_COMPRESS), so nothing relied on the old chdman fallback. For create/copy/z3ds modes the registry result is byte-identical to the legacy fallback (covered by the equivalence test).

### Scope / safety

- `METADATA_SCAN`/`DAT_MATCH` are unregistered and never reach an added `for_mode` call: convert handlers reject them up front; `_queue_job_locked` is only invoked by `create_job`/`create_jobs_atomic`, while external modes go through the separate `create_external_job` path.
- **No behavior change for any path reachable via the HTTP API.**

### Verification

- `PYTHONPATH=app python -m pytest tests -q` → 486 passed.
- `ruff check app tests` clean; `pylint` 10.00/10 on `convert.py`, `job_manager.py`, and the new test file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnfuduVyT845GvGF6dUABb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output path handling to prevent file overwrites when source and destination paths would collide in conversion operations.

* **Tests**
  * Added comprehensive test coverage for output path routing equivalence and fallback validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacnpal/compressatorium/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->