### PR TITLE
feat: route convert/verify dispatch through the tool registry (Phase 3)

### DIFF
--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -21,11 +21,10 @@ from services.chdman import ConversionCancelled, chdman_service
 from services.concurrency_manager import concurrency_manager
 from services.disc_id import embed_in_chd as disc_id_embed
 from services.disc_id import extract_from_source as disc_id_from_source
-from services.dolphin_tool import dolphin_tool_service
 from services.lock_manager import lock_manager
 from services.tools import registry
 from services.verification_store import verification_store
-from services.z3ds_compress import Z3DS_OUTPUT_FORMATS, z3ds_compress_service
+from services.z3ds_compress import Z3DS_OUTPUT_FORMATS
 from utils.delete_plan import build_delete_plan
 from utils.path_utils import is_within_configured_volumes, strip_archive_path
 
@@ -1461,13 +1460,7 @@ class JobManager:
                     if os.path.isfile(bin_path):
                         os.remove(bin_path)
 
-            _convert_service = (
-                dolphin_tool_service
-                if job.mode.value.startswith("dolphin_")
-                else z3ds_compress_service
-                if job.mode == ConversionMode.Z3DS_COMPRESS
-                else chdman_service
-            )
+            _convert_service = registry.for_mode(job.mode.value)
             async for update in _convert_service.convert(
                 input_path,
                 job.output_path,
@@ -1573,58 +1566,33 @@ class JobManager:
                         raise ConversionCancelled("Conversion cancelled")
 
                     verified = False
-                    if job.mode.value == "z3ds_compress":
-                        job.message = "Verifying output (zstd -t)..."
-                        await self._notify_subscribers(
-                            job_id,
-                            {
-                                "type": "progress",
-                                "job_id": job_id,
-                                "progress": job.progress,
-                                "message": job.message,
-                            },
+                    job.message = (
+                        "Verifying output (zstd -t)..."
+                        if job.mode.value == "z3ds_compress"
+                        else "Verifying output..."
+                    )
+                    await self._notify_subscribers(
+                        job_id,
+                        {
+                            "type": "progress",
+                            "job_id": job_id,
+                            "progress": job.progress,
+                            "message": job.message,
+                        },
+                    )
+
+                    verify_result = await registry.for_mode(job.mode.value).verify(
+                        job.output_path
+                    )
+                    if not verify_result.get("valid"):
+                        raise RuntimeError(
+                            f"Verification failed: {verify_result.get('message')}"
                         )
 
-                        verify_result = await z3ds_compress_service.verify(job.output_path)
-                        if not verify_result.get("valid"):
-                            raise RuntimeError(
-                                f"Verification failed: {verify_result.get('message')}"
-                            )
-
-                        verified = True
-                        await verification_store.mark_verified(
-                            job.output_path, source_path=job.file_path
-                        )
-
-                    else:
-                        job.message = "Verifying output..."
-                        await self._notify_subscribers(
-                            job_id,
-                            {
-                                "type": "progress",
-                                "job_id": job_id,
-                                "progress": job.progress,
-                                "message": job.message,
-                            },
-                        )
-
-                        _verify_service = (
-                            dolphin_tool_service
-                            if job.mode.value.startswith("dolphin_")
-                            else chdman_service
-                        )
-                        verify_result = await _verify_service.verify(
-                            job.output_path
-                        )
-                        if not verify_result.get("valid"):
-                            raise RuntimeError(
-                                f"Verification failed: {verify_result.get('message')}"
-                            )
-
-                        verified = True
-                        await verification_store.mark_verified(
-                            job.output_path, source_path=job.file_path
-                        )
+                    verified = True
+                    await verification_store.mark_verified(
+                        job.output_path, source_path=job.file_path
+                    )
 
                     if cancel_event.is_set():
                         job.message = "Verification complete. Delete skipped (cancelled)."

--- a/tests/test_dispatch_routing.py
+++ b/tests/test_dispatch_routing.py
@@ -1,0 +1,94 @@
+"""Delegation-parity tests for the convert/verify dispatch routed through the
+tool registry in ``job_manager._process_job`` (design Phase 3).
+
+The real CLIs cannot run in the sandbox, so these assert that the *selection*
+is correct: ``registry.for_mode(mode).convert`` / ``.verify`` reach the same
+underlying service the legacy dispatch ladders would have chosen.  Each tool
+delegates to its service via the wrapper's ``_service`` attribute, so patching
+``_service`` there observes exactly what ``_process_job`` would dispatch to.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.models import ConversionMode
+from app.services.tools import registry
+
+EXTERNAL_MODES = {ConversionMode.METADATA_SCAN, ConversionMode.DAT_MATCH}
+CONVERSION_MODES = [m.value for m in ConversionMode if m not in EXTERNAL_MODES]
+
+
+def _legacy_dispatch_id(mode: str) -> str:
+    """Replicates the convert/verify dispatch ladders formerly in
+    ``_process_job`` (job_manager.py:1464 / :1576 / :1611).  Both ladders make
+    the same tool selection, differing only in the progress message."""
+    if mode.startswith("dolphin_"):
+        return "dolphin"
+    if mode == ConversionMode.Z3DS_COMPRESS.value:
+        return "z3ds"
+    return "chdman"
+
+
+@pytest.mark.parametrize("mode", CONVERSION_MODES)
+def test_verify_dispatch_matches_legacy_ladder(mode, monkeypatch):
+    called: dict[str, str] = {}
+
+    def _record(tool_id):
+        async def _verify(path):
+            called["id"] = tool_id
+            return {"valid": True, "message": "ok"}
+
+        return _verify
+
+    for tool_id in ("chdman", "dolphin", "z3ds"):
+        monkeypatch.setattr(
+            registry.get(tool_id)._service, "verify", _record(tool_id)
+        )
+
+    result = asyncio.run(registry.for_mode(mode).verify("/data/out"))
+
+    assert result == {"valid": True, "message": "ok"}
+    assert called["id"] == _legacy_dispatch_id(mode)
+
+
+@pytest.mark.parametrize("mode", CONVERSION_MODES)
+def test_convert_dispatch_matches_legacy_ladder(mode, monkeypatch):
+    called: dict[str, str] = {}
+
+    def _record(tool_id):
+        def _convert(input_path, output_path, mode_, *, compression=None,
+                     cancel_event=None):
+            called["id"] = tool_id
+
+            async def _gen():
+                yield {"progress": 100, "message": "done"}
+
+            return _gen()
+
+        return _convert
+
+    for tool_id in ("chdman", "dolphin", "z3ds"):
+        monkeypatch.setattr(
+            registry.get(tool_id)._service, "convert", _record(tool_id)
+        )
+
+    async def _drain():
+        return [
+            u
+            async for u in registry.for_mode(mode).convert(
+                "/data/in", "/data/out", mode, compression=None, cancel_event=None
+            )
+        ]
+
+    updates = asyncio.run(_drain())
+
+    assert updates == [{"progress": 100, "message": "done"}]
+    assert called["id"] == _legacy_dispatch_id(mode)
+
+
+def test_external_modes_never_resolve():
+    for mode in EXTERNAL_MODES:
+        with pytest.raises(KeyError):
+            registry.for_mode(mode.value)

--- a/tests/test_mode_parity_fixes.py
+++ b/tests/test_mode_parity_fixes.py
@@ -513,8 +513,9 @@ async def test_z3ds_delete_on_verify_marks_output_verified(tmp_path: Path, monke
     clear_verified = AsyncMock()
     clear_metadata = AsyncMock()
 
-    monkeypatch.setattr(job_manager_module.z3ds_compress_service, "convert", fake_convert)
-    monkeypatch.setattr(job_manager_module.z3ds_compress_service, "verify", fake_verify)
+    _z3ds_service = job_manager_module.registry.for_mode("z3ds_compress")._service
+    monkeypatch.setattr(_z3ds_service, "convert", fake_convert)
+    monkeypatch.setattr(_z3ds_service, "verify", fake_verify)
     monkeypatch.setattr(job_manager_module.verification_store, "mark_verified", mark_verified)
     monkeypatch.setattr(job_manager_module.verification_store, "clear", clear_verified)
     monkeypatch.setattr(job_manager_module.chd_metadata_store, "clear", clear_metadata)
@@ -585,8 +586,9 @@ async def test_delete_on_verify_rejects_inode_device_fingerprint_mismatch(
     async def fake_verify(path: str):
         return {"valid": True, "message": "File verified successfully"}
 
-    monkeypatch.setattr(job_manager_module.z3ds_compress_service, "convert", fake_convert)
-    monkeypatch.setattr(job_manager_module.z3ds_compress_service, "verify", fake_verify)
+    _z3ds_service = job_manager_module.registry.for_mode("z3ds_compress")._service
+    monkeypatch.setattr(_z3ds_service, "convert", fake_convert)
+    monkeypatch.setattr(_z3ds_service, "verify", fake_verify)
     monkeypatch.setattr(job_manager_module.verification_store, "mark_verified", AsyncMock())
     monkeypatch.setattr(job_manager_module.verification_store, "clear", AsyncMock())
     monkeypatch.setattr(job_manager_module.chd_metadata_store, "clear", AsyncMock())


### PR DESCRIPTION
## Summary

Phase 3 of the tool plugin architecture refactor (`DESIGN_tool_plugin_architecture.md`). This is a behavior-preserving substitution that routes the two dispatch sites in `JobManager._process_job` through the in-process tool registry instead of hardcoded per-tool `if/elif` ladders.

### Re-routed sites
- **Convert dispatch** (`job_manager.py` ~`:1464`): the `dolphin_ / z3ds_compress / else chdman` service-selection ladder collapses to a single `registry.for_mode(job.mode.value)` lookup. The `convert(...)` call and the `async for` loop body are unchanged.
- **Verify dispatch** (`job_manager.py`, delete-on-verify block): the two verify branches (z3ds vs dolphin/chdman) are consolidated into one. The progress message is selected per mode and emitted, then verification routes through `registry.for_mode(job.mode.value).verify(...)`, followed by the shared `valid` check and `mark_verified(...)`.

### Parity guarantees
- **External modes never reach `_process_job`.** `create_external_job` registers jobs in `PROCESSING` state and never calls `self._queue.put_nowait(...)` (the only enqueue site is the conversion path in `_queue_job_locked`). The dispatcher (`_dispatcher_loop` → `_run_job` → `_process_job`) only ever sees queued conversion jobs, so `registry.for_mode(...)` here can never `KeyError` on `METADATA_SCAN`/`DAT_MATCH`.
- **Progress-message / SSE parity preserved exactly:** `"Verifying output (zstd -t)..."` for `z3ds_compress`, `"Verifying output..."` otherwise. SSE event shapes, the `RuntimeError("Verification failed: ...")` text, and `mark_verified(..., source_path=job.file_path)` are unchanged.
- `convert()` remains the un-awaited async generator iterated by `async for`; `verify()` remains an awaited coroutine. `compression=job.compression` / `cancel_event=cancel_event` plumbing is untouched.
- No changes to archive extraction, `allow_overwrite` pre-delete, output-size computation, disc-ID embedding, the delete-on-verify snapshot/fingerprint block, cancel/except/finally handling, or the `_debug_loop` `chdman_service.active_pids()` instrumentation.

### Imports removed
- `from services.dolphin_tool import dolphin_tool_service` — no longer referenced.
- `z3ds_compress_service` dropped from the `services.z3ds_compress` import (kept `Z3DS_OUTPUT_FORMATS`, still used by the Phase 2 fallback guard).
- Kept `chdman_service` (used by `_debug_loop` `active_pids()` + `/proc` heartbeat), `ConversionMode`, `Z3DS_OUTPUT_FORMATS`, and `registry`.

### Tests
- New `tests/test_dispatch_routing.py`: a convert/verify delegation-parity test across the 16-mode conversion matrix, asserting `registry.for_mode(mode).convert` / `.verify` reach the same underlying service the legacy ladders would have chosen (monkeypatching each tool's delegated `_service` and recording which one fires), plus an assertion that external modes never resolve.
- `tests/test_mode_parity_fixes.py`: the two z3ds delete-on-verify tests previously monkeypatched `job_manager_module.z3ds_compress_service` (now removed from that module's namespace). They are re-pointed at the same singleton via `registry.for_mode("z3ds_compress")._service` — the exact object the registry-routed dispatch delegates to — so they continue to exercise `_process_job` unchanged in behavior.

## Test plan
- [x] `PYTHONPATH=app python -m pytest tests -q` — 523 passed
- [x] `ruff check app tests` — clean
- [x] `PYTHONPATH=app pylint app/services/job_manager.py tests/test_dispatch_routing.py tests/test_mode_parity_fixes.py` — 10.00/10
- [x] Byte-fidelity of pushed files verified (`git diff` against local commit empty)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk6m89f2CXbCBWiFNKoTPS)_