### PR TITLE
feat: unify single/batch job planning in convert.py (Phase 4)

### DIFF
--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -707,6 +707,7 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
         except DeleteSnapshotError as exc:
             raise HTTPException(
                 status_code=400,
+                # nosemgrep: python.django.security.injection.tainted-sql-string.tainted-sql-string
                 detail=f"Delete-on-verify blocked for {file_path}: {exc.message}",
             ) from None
         candidates.append(plan)

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -2,6 +2,8 @@ import asyncio
 import logging
 import os
 import re
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 
 from config import settings
@@ -164,6 +166,251 @@ def get_unique_output_path_for_extractcd(base_path: str) -> str:
         counter += 1
 
 
+def _input_extension(path: str) -> str:
+    if "::" in path:
+        _, internal = path.split("::", 1)
+        return Path(internal).suffix.lower()
+    return Path(path).suffix.lower()
+
+
+def _priority(ext: str) -> int:
+    if ext in {".cue", ".gdi"}:
+        return 4
+    if ext == ".iso":
+        return 3
+    if ext == ".bin":
+        return 1
+    return 0
+
+
+@dataclass
+class JobPlan:
+    """Resolved per-file plan shared by single and batch job creation."""
+
+    file_path: str
+    output_path: str
+    base_output_path: str
+    allow_overwrite: bool
+    display_filename: str | None
+    delete_snapshot: dict | None
+    priority: int
+
+
+class SkipReason(Enum):
+    """Why ``plan_job`` could not turn a file into a job.
+
+    Single-job callers translate each reason into the matching
+    ``HTTPException``; batch callers append the file to ``skipped`` and
+    continue. The two behaviours are deliberately different (see
+    ``_SKIP_HTTP``).
+    """
+
+    ARCHIVE_INPUT_NOT_ALLOWED = "archive_input_not_allowed"
+    ARCHIVE_NOT_FOUND = "archive_not_found"
+    OUTPUT_EXISTS = "output_exists"
+    OUTPUT_LOCKED = "output_locked"
+    FILE_NOT_FOUND = "file_not_found"
+    EXTRACT_COPY_REQUIRES_CHD = "extract_copy_requires_chd"
+    CREATE_REQUIRES_NON_CHD = "create_requires_non_chd"
+    DOLPHIN_BAD_EXTENSION = "dolphin_bad_extension"
+    Z3DS_BAD_EXTENSION = "z3ds_bad_extension"
+    DOLPHIN_SAME_PATH = "dolphin_same_path"
+
+
+class SkipFile(Exception):  # noqa: N818 - control-flow signal, not an error
+    """Raised by ``plan_job`` when a file cannot be planned into a job."""
+
+    def __init__(self, reason: SkipReason):
+        self.reason = reason
+        super().__init__(reason.value)
+
+
+class DeleteSnapshotError(Exception):
+    """Raised when building the delete-on-verify snapshot fails.
+
+    Unlike ``SkipFile`` this aborts both single and batch creation; each
+    caller formats its own (differing) ``detail`` string.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+
+# Single-job status/detail for each skip reason. Must match the exact strings
+# and codes the pre-Phase-4 ``create_job`` raised. Batch callers ignore this
+# table and simply skip.
+_SKIP_HTTP: dict[SkipReason, tuple[int, str]] = {
+    SkipReason.ARCHIVE_INPUT_NOT_ALLOWED: (
+        400,
+        "Archive inputs are not supported for"
+        " extract/copy/dolphin/z3ds_compress modes",
+    ),
+    SkipReason.ARCHIVE_NOT_FOUND: (404, "Archive not found"),
+    SkipReason.OUTPUT_EXISTS: (409, "Output file already exists"),
+    SkipReason.OUTPUT_LOCKED: (409, "Output file is currently being converted"),
+    SkipReason.FILE_NOT_FOUND: (404, "File not found"),
+    SkipReason.EXTRACT_COPY_REQUIRES_CHD: (
+        400,
+        "Extract/copy modes require .chd input files",
+    ),
+    SkipReason.CREATE_REQUIRES_NON_CHD: (
+        400,
+        "Create modes require non-CHD input files",
+    ),
+    SkipReason.DOLPHIN_BAD_EXTENSION: (
+        400,
+        "Dolphin modes require GameCube/Wii disc images "
+        "(.iso, .gcz, .wia, .rvz, .wbfs)",
+    ),
+    SkipReason.Z3DS_BAD_EXTENSION: (
+        400,
+        "z3ds_compress mode requires Nintendo 3DS ROM files (.cci, .cia, .3ds)",
+    ),
+    SkipReason.DOLPHIN_SAME_PATH: (
+        400,
+        "Output path matches input; overwriting would delete the source file",
+    ),
+}
+
+
+async def plan_job(
+    file_path: str,
+    *,
+    spec,
+    mode: str,
+    output_dir: str | None,
+    duplicate_action: DuplicateAction,
+    delete_on_verify: bool,
+) -> JobPlan:
+    """Resolve one input file into a concrete ``JobPlan``.
+
+    Holds the per-file validation / output-path / duplicate-handling pipeline
+    shared by ``create_job`` and ``create_batch_jobs``. Validation failures are
+    signalled via ``SkipFile`` (the caller decides raise-vs-skip);
+    delete-snapshot failures raise ``DeleteSnapshotError``.
+
+    Request-level concerns (compression validation, volume containment, queue
+    backpressure, the cross-file archive multi-select guard, the batch dedup
+    pass) stay in the endpoints, not here.
+    """
+    is_dolphin = spec.tool_id == "dolphin"
+    is_z3ds = spec.tool_id == "z3ds"
+
+    archive_source_dir = None  # Directory where the archive is located (for output)
+    output_path = None
+    base_output_path = None
+    output_exists = False
+
+    display_filename = None
+
+    # Handle archive files
+    if "::" in file_path:
+        if not spec.allows_archive_input:
+            raise SkipFile(SkipReason.ARCHIVE_INPUT_NOT_ALLOWED)
+        archive_path, internal_path = file_path.split("::", 1)
+        archive_source_dir = os.path.dirname(archive_path)  # Save CHD next to archive
+        display_filename = os.path.basename(internal_path)
+
+        if not os.path.isfile(archive_path):
+            raise SkipFile(SkipReason.ARCHIVE_NOT_FOUND)
+
+        # Calculate output path before extraction to avoid unnecessary work
+        effective_output_dir = output_dir or archive_source_dir
+        output_stem = archive_service._output_stem_for_member(internal_path)
+        output_path = _get_output_path(
+            mode, output_stem, effective_output_dir, treat_as_stem=True,
+        )
+        base_output_path = output_path
+
+        output_exists, is_locked = check_output_conflicts(mode, output_path)
+        if output_exists or is_locked:
+            if duplicate_action == DuplicateAction.SKIP:
+                raise SkipFile(SkipReason.OUTPUT_EXISTS)
+            if duplicate_action == DuplicateAction.OVERWRITE:
+                if is_locked:
+                    raise SkipFile(SkipReason.OUTPUT_LOCKED)
+            elif duplicate_action == DuplicateAction.RENAME:
+                if mode == "extractcd":
+                    output_path = get_unique_output_path_for_extractcd(output_path)
+                else:
+                    output_path = get_unique_output_path(output_path)
+
+    if "::" not in file_path and not os.path.isfile(file_path):
+        raise SkipFile(SkipReason.FILE_NOT_FOUND)
+
+    if (
+        spec.tool_id == "chdman" and spec.kind in (ModeKind.EXTRACT, ModeKind.COPY)
+    ) and not file_path.lower().endswith(".chd"):
+        raise SkipFile(SkipReason.EXTRACT_COPY_REQUIRES_CHD)
+
+    if spec.kind == ModeKind.CREATE and file_path.lower().endswith(".chd"):
+        raise SkipFile(SkipReason.CREATE_REQUIRES_NON_CHD)
+
+    if is_dolphin:
+        ext = Path(file_path).suffix.lower()
+        if ext not in spec.input_extensions:
+            raise SkipFile(SkipReason.DOLPHIN_BAD_EXTENSION)
+
+    if is_z3ds:
+        ext = Path(file_path).suffix.lower()
+        if ext not in spec.input_extensions:
+            raise SkipFile(SkipReason.Z3DS_BAD_EXTENSION)
+
+    # Calculate output path and handle duplicates
+    # For archive files: use output_dir if specified, otherwise save next to archive
+    if output_path is None:
+        effective_output_dir = output_dir or archive_source_dir
+        output_path = _get_output_path(
+            mode, file_path, effective_output_dir,
+        )
+        base_output_path = output_path
+
+        output_exists, is_locked = check_output_conflicts(mode, output_path)
+        if output_exists or is_locked:
+            if duplicate_action == DuplicateAction.SKIP:
+                raise SkipFile(SkipReason.OUTPUT_EXISTS)
+            if duplicate_action == DuplicateAction.OVERWRITE:
+                if is_locked:
+                    raise SkipFile(SkipReason.OUTPUT_LOCKED)
+            elif duplicate_action == DuplicateAction.RENAME:
+                if mode == "extractcd":
+                    output_path = get_unique_output_path_for_extractcd(output_path)
+                else:
+                    output_path = get_unique_output_path(output_path)
+
+    if (
+        is_dolphin
+        and duplicate_action == DuplicateAction.OVERWRITE
+        and output_path
+        and _is_same_path(output_path, file_path)
+    ):
+        raise SkipFile(SkipReason.DOLPHIN_SAME_PATH)
+
+    allow_overwrite = (
+        duplicate_action == DuplicateAction.OVERWRITE and output_exists
+    )
+
+    delete_snapshot = None
+    if delete_on_verify:
+        try:
+            delete_snapshot = await run_in_threadpool(
+                build_delete_snapshot, file_path,
+            )
+        except ValueError as exc:
+            raise DeleteSnapshotError(str(exc)) from None
+
+    return JobPlan(
+        file_path=file_path,
+        output_path=output_path,
+        base_output_path=base_output_path or output_path,
+        allow_overwrite=allow_overwrite,
+        display_filename=display_filename,
+        delete_snapshot=delete_snapshot,
+        priority=_priority(_input_extension(file_path)),
+    )
+
+
 @router.post("/jobs/check-duplicates", response_model=list[DuplicateInfo])
 async def check_duplicates(request: CheckDuplicatesRequest):
     """Check which output files already exist for the given input files."""
@@ -283,7 +530,6 @@ async def create_job(request: JobCreateRequest):
     output_dir = normalize_output_dir(request.output_dir)
     spec = registry.spec(mode)
     is_dolphin = spec.tool_id == "dolphin"
-    is_z3ds = spec.tool_id == "z3ds"
     if compression and spec.tool_id == "chdman" and spec.kind == ModeKind.EXTRACT:
         raise HTTPException(
             status_code=400,
@@ -328,139 +574,23 @@ async def create_job(request: JobCreateRequest):
             detail="Access denied: output directory outside configured volumes",
         )
 
-    # Handle archive files
-    file_path = request.file_path
-    archive_source_dir = None  # Directory where the archive is located (for output)
-    output_path = None
-    output_exists = False
-    display_filename = None
-
-    if "::" in request.file_path:
-        if not spec.allows_archive_input:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "Archive inputs are not supported for"
-                    " extract/copy/dolphin/z3ds_compress modes"
-                ),
-            )
-        archive_path, internal_path = request.file_path.split("::", 1)
-        archive_source_dir = os.path.dirname(archive_path)  # Save CHD next to archive
-        display_filename = os.path.basename(internal_path)
-
-        if not os.path.isfile(archive_path):
-            raise HTTPException(status_code=404, detail="Archive not found")
-
-        # Calculate output path before extraction to avoid unnecessary work
-        effective_output_dir = output_dir or archive_source_dir
-        output_stem = archive_service._output_stem_for_member(internal_path)
-        output_path = _get_output_path(
-            mode, output_stem, effective_output_dir, treat_as_stem=True,
+    try:
+        plan = await plan_job(
+            request.file_path,
+            spec=spec,
+            mode=mode,
+            output_dir=output_dir,
+            duplicate_action=request.duplicate_action,
+            delete_on_verify=request.delete_on_verify,
         )
-
-        output_exists, is_locked = check_output_conflicts(mode, output_path)
-        if output_exists or is_locked:
-            if request.duplicate_action == DuplicateAction.SKIP:
-                raise HTTPException(
-                    status_code=409, detail="Output file already exists",
-                )
-            if request.duplicate_action == DuplicateAction.OVERWRITE:
-                if is_locked:
-                    raise HTTPException(
-                        status_code=409,
-                        detail="Output file is currently being converted",
-                    )
-            elif request.duplicate_action == DuplicateAction.RENAME:
-                if mode == "extractcd":
-                    output_path = get_unique_output_path_for_extractcd(output_path)
-                else:
-                    output_path = get_unique_output_path(output_path)
-
-    if "::" not in request.file_path and not os.path.isfile(file_path):
-        raise HTTPException(status_code=404, detail="File not found")
-
-    if (
-        spec.tool_id == "chdman" and spec.kind in (ModeKind.EXTRACT, ModeKind.COPY)
-    ) and not file_path.lower().endswith(".chd"):
-        raise HTTPException(
-            status_code=400, detail="Extract/copy modes require .chd input files",
-        )
-
-    if spec.kind == ModeKind.CREATE and file_path.lower().endswith(".chd"):
-        raise HTTPException(
-            status_code=400, detail="Create modes require non-CHD input files",
-        )
-
-    if is_dolphin:
-        ext = Path(file_path).suffix.lower()
-        if ext not in spec.input_extensions:
-            raise HTTPException(
-                status_code=400,
-                detail="Dolphin modes require GameCube/Wii disc images "
-                       "(.iso, .gcz, .wia, .rvz, .wbfs)",
-            )
-
-    if is_z3ds:
-        ext = Path(file_path).suffix.lower()
-        if ext not in spec.input_extensions:
-            raise HTTPException(
-                status_code=400,
-                detail="z3ds_compress mode requires Nintendo 3DS ROM files (.cci, .cia, .3ds)",
-            )
-
-    # Calculate output path and handle duplicates
-    # For archive files: use output_dir if specified, otherwise save next to archive
-    if output_path is None:
-        effective_output_dir = output_dir or archive_source_dir
-        output_path = _get_output_path(
-            mode, file_path, effective_output_dir,
-        )
-
-        output_exists, is_locked = check_output_conflicts(mode, output_path)
-        if output_exists or is_locked:
-            if request.duplicate_action == DuplicateAction.SKIP:
-                raise HTTPException(
-                    status_code=409, detail="Output file already exists",
-                )
-            if request.duplicate_action == DuplicateAction.OVERWRITE:
-                if is_locked:
-                    raise HTTPException(
-                        status_code=409,
-                        detail="Output file is currently being converted",
-                    )
-            elif request.duplicate_action == DuplicateAction.RENAME:
-                if mode == "extractcd":
-                    output_path = get_unique_output_path_for_extractcd(output_path)
-                else:
-                    output_path = get_unique_output_path(output_path)
-
-    if (
-        is_dolphin
-        and request.duplicate_action == DuplicateAction.OVERWRITE
-        and output_path
-        and _is_same_path(output_path, file_path)
-    ):
+    except SkipFile as skip:
+        status_code, detail = _SKIP_HTTP[skip.reason]
+        raise HTTPException(status_code=status_code, detail=detail) from None
+    except DeleteSnapshotError as exc:
         raise HTTPException(
             status_code=400,
-            detail=(
-                "Output path matches input; overwriting would delete the source file"
-            ),
-        )
-
-    allow_overwrite = (
-        request.duplicate_action == DuplicateAction.OVERWRITE and output_exists
-    )
-    delete_snapshot = None
-    if request.delete_on_verify:
-        try:
-            delete_snapshot = await run_in_threadpool(
-                build_delete_snapshot, file_path,
-            )
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Delete-on-verify blocked: {exc}",
-            ) from None
+            detail=f"Delete-on-verify blocked: {exc.message}",
+        ) from None
 
     # Proactive queue-depth check: reject with 429 before spending work
     # on job construction if the queue is already at capacity.  Parity
@@ -475,14 +605,14 @@ async def create_job(request: JobCreateRequest):
 
     try:
         job = await job_manager.create_job(
-            file_path,
+            plan.file_path,
             request.mode,
-            output_path=output_path,
-            allow_overwrite=allow_overwrite,
-            filename_override=display_filename,
+            output_path=plan.output_path,
+            allow_overwrite=plan.allow_overwrite,
+            filename_override=plan.display_filename,
             compression=compression,
             delete_on_verify=request.delete_on_verify,
-            delete_snapshot=delete_snapshot,
+            delete_snapshot=plan.delete_snapshot,
         )
     except QueueBackpressureError as exc:
         raise HTTPException(status_code=429, detail=exc.detail) from exc
@@ -502,7 +632,6 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
     mode = request.mode.value
     spec = registry.spec(mode)
     is_dolphin = spec.tool_id == "dolphin"
-    is_z3ds = spec.tool_id == "z3ds"
     output_dir = normalize_output_dir(request.output_dir)
     if compression and spec.tool_id == "chdman" and spec.kind == ModeKind.EXTRACT:
         raise HTTPException(
@@ -559,182 +688,53 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
             detail="Access denied: output directory outside configured volumes",
         )
 
-    def _input_extension(path: str) -> str:
-        if "::" in path:
-            _, internal = path.split("::", 1)
-            return Path(internal).suffix.lower()
-        return Path(path).suffix.lower()
-
-    def _priority(ext: str) -> int:
-        if ext in {".cue", ".gdi"}:
-            return 4
-        if ext == ".iso":
-            return 3
-        if ext == ".bin":
-            return 1
-        return 0
-
     skipped = []
-    candidates = []
+    candidates: list[JobPlan] = []
 
     for file_path in request.file_paths:
-        archive_source_dir = None  # Directory where the archive is located (for output)
-        output_path = None
-        base_output_path = None
-        output_exists = False
-        display_filename = None
-
-        # Handle archive files
-        if "::" in file_path:
-            if not spec.allows_archive_input:
-                skipped.append(file_path)
-                continue
-            archive_path, internal_path = file_path.split("::", 1)
-            archive_source_dir = os.path.dirname(
-                archive_path,
-            )  # Save CHD next to archive
-            display_filename = os.path.basename(internal_path)
-
-            if not os.path.isfile(archive_path):
-                skipped.append(file_path)
-                continue
-
-            # Calculate output path before extraction to avoid unnecessary work
-            effective_output_dir = output_dir or archive_source_dir
-            output_stem = archive_service._output_stem_for_member(internal_path)
-            output_path = _get_output_path(
-                mode, output_stem, effective_output_dir, treat_as_stem=True,
+        try:
+            plan = await plan_job(
+                file_path,
+                spec=spec,
+                mode=mode,
+                output_dir=output_dir,
+                duplicate_action=request.duplicate_action,
+                delete_on_verify=request.delete_on_verify,
             )
-            base_output_path = output_path
-            output_exists, is_locked = check_output_conflicts(mode, output_path)
-
-            if output_exists or is_locked:
-                if request.duplicate_action == DuplicateAction.SKIP:
-                    skipped.append(file_path)
-                    continue
-                if request.duplicate_action == DuplicateAction.OVERWRITE:
-                    if is_locked:
-                        skipped.append(file_path)
-                        continue
-                elif request.duplicate_action == DuplicateAction.RENAME:
-                    if mode == "extractcd":
-                        output_path = get_unique_output_path_for_extractcd(output_path)
-                    else:
-                        output_path = get_unique_output_path(output_path)
-
-        if "::" not in file_path and not os.path.isfile(file_path):
+        except SkipFile:
             skipped.append(file_path)
             continue
+        except DeleteSnapshotError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Delete-on-verify blocked for {file_path}: {exc.message}",
+            ) from None
+        candidates.append(plan)
 
-        if (
-            spec.tool_id == "chdman" and spec.kind in (ModeKind.EXTRACT, ModeKind.COPY)
-        ) and not file_path.lower().endswith(".chd"):
-            skipped.append(file_path)
-            continue
-
-        if spec.kind == ModeKind.CREATE and file_path.lower().endswith(".chd"):
-            skipped.append(file_path)
-            continue
-
-        if is_dolphin:
-            ext = Path(file_path).suffix.lower()
-            if ext not in spec.input_extensions:
-                skipped.append(file_path)
-                continue
-
-        if is_z3ds:
-            ext = Path(file_path).suffix.lower()
-            if ext not in spec.input_extensions:
-                skipped.append(file_path)
-                continue
-
-        # Calculate output path and handle duplicates
-        # For archive files: use output_dir if specified, otherwise save next to archive
-        if output_path is None:
-            effective_output_dir = output_dir or archive_source_dir
-            output_path = _get_output_path(
-                mode, file_path, effective_output_dir,
-            )
-            base_output_path = output_path
-            output_exists, is_locked = check_output_conflicts(mode, output_path)
-
-            if output_exists or is_locked:
-                if request.duplicate_action == DuplicateAction.SKIP:
-                    skipped.append(file_path)
-                    continue
-                if request.duplicate_action == DuplicateAction.OVERWRITE:
-                    if is_locked:
-                        skipped.append(file_path)
-                        continue
-                elif request.duplicate_action == DuplicateAction.RENAME:
-                    if mode == "extractcd":
-                        output_path = get_unique_output_path_for_extractcd(output_path)
-                    else:
-                        output_path = get_unique_output_path(output_path)
-
-        if (
-            is_dolphin
-            and request.duplicate_action == DuplicateAction.OVERWRITE
-            and output_path
-            and _is_same_path(output_path, file_path)
-        ):
-            skipped.append(file_path)
-            continue
-
-        allow_overwrite = (
-            request.duplicate_action == DuplicateAction.OVERWRITE and output_exists
-        )
-        delete_snapshot = None
-        if request.delete_on_verify:
-            try:
-                delete_snapshot = await run_in_threadpool(
-                    build_delete_snapshot, file_path,
-                )
-            except ValueError as exc:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Delete-on-verify blocked for {file_path}: {exc}",
-                ) from None
-
-        candidates.append(
-            {
-                "file_path": file_path,
-                "output_path": output_path,
-                "base_output_path": base_output_path or output_path,
-                "allow_overwrite": allow_overwrite,
-                "display_filename": display_filename,
-                "priority": _priority(_input_extension(file_path)),
-                "delete_snapshot": delete_snapshot,
-            },
-        )
-
-    selected = {}
+    # Collapse multiple inputs that resolve to the same output (e.g. a .cue and
+    # its .bin) down to the highest-priority one. No single-job analog.
+    selected: dict[str, JobPlan] = {}
     order = []
-    for candidate in candidates:
-        key = candidate["base_output_path"]
+    for plan in candidates:
+        key = plan.base_output_path
         existing = selected.get(key)
         if not existing:
-            selected[key] = candidate
+            selected[key] = plan
             order.append(key)
             continue
-        if candidate["priority"] > existing["priority"]:
-            selected[key] = candidate
-
-    if order:
-        # Job creation will enforce backpressure atomically under lock.
-        # No need for a pre-check here as it would race with the locked check.
-        pass
+        if plan.priority > existing.priority:
+            selected[key] = plan
 
     job_specs = []
     for key in order:
-        candidate = selected[key]
+        plan = selected[key]
         job_specs.append(
             {
-                "file_path": candidate["file_path"],
-                "output_path": candidate["output_path"],
-                "allow_overwrite": candidate["allow_overwrite"],
-                "filename_override": candidate["display_filename"],
-                "delete_snapshot": candidate.get("delete_snapshot"),
+                "file_path": plan.file_path,
+                "output_path": plan.output_path,
+                "allow_overwrite": plan.allow_overwrite,
+                "filename_override": plan.display_filename,
+                "delete_snapshot": plan.delete_snapshot,
             },
         )
 

--- a/tests/test_single_batch_plan_parity.py
+++ b/tests/test_single_batch_plan_parity.py
@@ -1,0 +1,397 @@
+"""Single-vs-batch planning parity tests for Phase 4.
+
+Phase 4 collapses the per-file validation / output-path / duplicate-handling
+pipeline that ``create_job`` and ``create_batch_jobs`` used to re-implement
+independently into one shared ``plan_job``. The two endpoints intentionally
+react differently to the *same* per-file failure: ``create_job`` raises an
+``HTTPException`` while ``create_batch_jobs`` drops the file from the batch
+("skip"). These tests lock that divergence in place: for a representative
+matrix of modes x archive/non-archive x ``DuplicateAction``, a file that
+``create_job`` rejects with a 4xx is exactly the file ``create_batch_jobs``
+skips, and an accepted file resolves to an identical ``output_path`` /
+``allow_overwrite`` on both paths.
+"""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.models import (
+    BatchJobCreateRequest,
+    ConversionMode,
+    DuplicateAction,
+    JobCreateRequest,
+)
+from app.routes import convert as convert_routes
+
+
+@pytest.fixture(name="parity_env")
+def _parity_env(tmp_path: Path, monkeypatch):
+    """Confine routes to ``tmp_path``, disable backpressure, capture sinks."""
+    monkeypatch.setattr(convert_routes.settings, "chd_volumes", str(tmp_path))
+    monkeypatch.setattr(convert_routes.settings, "data_mount_root", str(tmp_path))
+    monkeypatch.setattr(convert_routes.settings, "max_queue_depth", 0)
+    monkeypatch.setattr(convert_routes.job_manager, "get_queue_depth", lambda: 0)
+
+    single_mock = AsyncMock(return_value="job")
+    monkeypatch.setattr(convert_routes.job_manager, "create_job", single_mock)
+
+    captured: dict = {}
+
+    async def fake_atomic(job_specs, _mode, **_kwargs):
+        captured["job_specs"] = job_specs
+        return []
+
+    monkeypatch.setattr(convert_routes.job_manager, "create_jobs_atomic", fake_atomic)
+
+    return {
+        "tmp_path": tmp_path,
+        "single_mock": single_mock,
+        "captured": captured,
+    }
+
+
+async def _run_single(env, *, file_path, mode, duplicate_action, delete_on_verify):
+    env["single_mock"].reset_mock()
+    request = JobCreateRequest(
+        file_path=file_path,
+        mode=mode,
+        duplicate_action=duplicate_action,
+        delete_on_verify=delete_on_verify,
+    )
+    try:
+        await convert_routes.create_job(request)
+    except HTTPException as exc:
+        return {"status": exc.status_code, "detail": exc.detail}
+    call = env["single_mock"].call_args
+    return {
+        "output_path": call.kwargs["output_path"],
+        "allow_overwrite": call.kwargs["allow_overwrite"],
+    }
+
+
+async def _run_batch(env, *, file_path, mode, duplicate_action, delete_on_verify):
+    env["captured"].clear()
+    request = BatchJobCreateRequest(
+        file_paths=[file_path],
+        mode=mode,
+        duplicate_action=duplicate_action,
+        delete_on_verify=delete_on_verify,
+    )
+    try:
+        await convert_routes.create_batch_jobs(request)
+    except HTTPException as exc:
+        return {"status": exc.status_code, "detail": exc.detail}
+    specs = env["captured"]["job_specs"]
+    if not specs:
+        return {"skipped": True}
+    spec = specs[0]
+    return {
+        "output_path": spec["output_path"],
+        "allow_overwrite": spec["allow_overwrite"],
+    }
+
+
+def _make_zip(tmp_path: Path, name: str) -> str:
+    archive = tmp_path / name
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("placeholder.txt", "x")
+    return str(archive)
+
+
+# Each case: (id, builder(tmp_path)->file_path, mode, duplicate_action, expect).
+# ``expect`` is "reject" (single 4xx / batch skip) or "accept" (job on both).
+def _cases():
+    def write(tmp_path: Path, name: str) -> str:
+        path = tmp_path / name
+        path.write_bytes(b"data")
+        return str(path)
+
+    return [
+        # --- acceptances (single creates a job; batch enqueues a spec) ---
+        (
+            "createcd_iso_accept",
+            lambda t: write(t, "game.iso"),
+            ConversionMode.CREATECD,
+            DuplicateAction.SKIP,
+            "accept",
+        ),
+        (
+            "extractcd_chd_accept",
+            lambda t: write(t, "game.chd"),
+            ConversionMode.EXTRACTCD,
+            DuplicateAction.SKIP,
+            "accept",
+        ),
+        (
+            "copy_chd_accept",
+            lambda t: write(t, "game.chd"),
+            ConversionMode.COPY,
+            DuplicateAction.SKIP,
+            "accept",
+        ),
+        (
+            "dolphin_rvz_iso_accept",
+            lambda t: write(t, "game.iso"),
+            ConversionMode.DOLPHIN_RVZ,
+            DuplicateAction.SKIP,
+            "accept",
+        ),
+        (
+            "dolphin_iso_rvz_accept",
+            lambda t: write(t, "game.rvz"),
+            ConversionMode.DOLPHIN_ISO,
+            DuplicateAction.SKIP,
+            "accept",
+        ),
+        (
+            "z3ds_3ds_accept",
+            lambda t: write(t, "game.3ds"),
+            ConversionMode.Z3DS_COMPRESS,
+            DuplicateAction.SKIP,
+            "accept",
+        ),
+        # --- rejections / skips ---
+        (
+            "createcd_chd_reject",  # CREATE_REQUIRES_NON_CHD
+            lambda t: write(t, "game.chd"),
+            ConversionMode.CREATECD,
+            DuplicateAction.SKIP,
+            "reject",
+        ),
+        (
+            "extractcd_iso_reject",  # EXTRACT_COPY_REQUIRES_CHD
+            lambda t: write(t, "game.iso"),
+            ConversionMode.EXTRACTCD,
+            DuplicateAction.SKIP,
+            "reject",
+        ),
+        (
+            "copy_iso_reject",  # EXTRACT_COPY_REQUIRES_CHD
+            lambda t: write(t, "game.iso"),
+            ConversionMode.COPY,
+            DuplicateAction.SKIP,
+            "reject",
+        ),
+        (
+            "dolphin_rvz_bad_ext_reject",  # DOLPHIN_BAD_EXTENSION
+            lambda t: write(t, "game.txt"),
+            ConversionMode.DOLPHIN_RVZ,
+            DuplicateAction.SKIP,
+            "reject",
+        ),
+        (
+            "z3ds_bad_ext_reject",  # Z3DS_BAD_EXTENSION
+            lambda t: write(t, "game.txt"),
+            ConversionMode.Z3DS_COMPRESS,
+            DuplicateAction.SKIP,
+            "reject",
+        ),
+        (
+            "createcd_missing_reject",  # FILE_NOT_FOUND
+            lambda t: str(t / "absent.iso"),
+            ConversionMode.CREATECD,
+            DuplicateAction.SKIP,
+            "reject",
+        ),
+        (
+            "dolphin_iso_same_path_reject",  # DOLPHIN_SAME_PATH (overwrite)
+            lambda t: write(t, "game.iso"),
+            ConversionMode.DOLPHIN_ISO,
+            DuplicateAction.OVERWRITE,
+            "reject",
+        ),
+        # --- archive inputs ---
+        (
+            "archive_createcd_accept",  # archive allowed for create
+            lambda t: f"{_make_zip(t, 'arch.zip')}::game.iso",
+            ConversionMode.CREATECD,
+            DuplicateAction.SKIP,
+            "accept",
+        ),
+        (
+            "archive_extractcd_reject",  # ARCHIVE_INPUT_NOT_ALLOWED
+            lambda t: f"{_make_zip(t, 'arch.zip')}::game.iso",
+            ConversionMode.EXTRACTCD,
+            DuplicateAction.SKIP,
+            "reject",
+        ),
+        (
+            "archive_dolphin_reject",  # ARCHIVE_INPUT_NOT_ALLOWED
+            lambda t: f"{_make_zip(t, 'arch.zip')}::game.iso",
+            ConversionMode.DOLPHIN_RVZ,
+            DuplicateAction.SKIP,
+            "reject",
+        ),
+        (
+            "archive_missing_reject",  # ARCHIVE_NOT_FOUND
+            lambda t: f"{t / 'absent.zip'}::game.iso",
+            ConversionMode.CREATECD,
+            DuplicateAction.SKIP,
+            "reject",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case_id", "builder", "mode", "duplicate_action", "expect"),
+    _cases(),
+    ids=[c[0] for c in _cases()],
+)
+async def test_single_and_batch_agree(
+    parity_env, case_id, builder, mode, duplicate_action, expect,
+):
+    file_path = builder(parity_env["tmp_path"])
+    kwargs = {
+        "file_path": file_path,
+        "mode": mode,
+        "duplicate_action": duplicate_action,
+        "delete_on_verify": False,
+    }
+    single = await _run_single(parity_env, **kwargs)
+    batch = await _run_batch(parity_env, **kwargs)
+
+    if expect == "reject":
+        assert single.get("status") is not None, (case_id, single)
+        assert 400 <= single["status"] < 500, (case_id, single)
+        # The file create_job rejects is exactly the file the batch skips.
+        assert batch == {"skipped": True}, (case_id, batch)
+    else:
+        assert "status" not in single, (case_id, single)
+        assert "skipped" not in batch, (case_id, batch)
+        assert single["output_path"] == batch["output_path"], case_id
+        assert single["allow_overwrite"] == batch["allow_overwrite"], case_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("action", "expect"),
+    [
+        (DuplicateAction.SKIP, "reject"),
+        (DuplicateAction.OVERWRITE, "accept"),
+        (DuplicateAction.RENAME, "accept"),
+    ],
+)
+async def test_existing_output_duplicate_actions_agree(parity_env, action, expect):
+    """Existing-output handling must agree across single and batch per action."""
+    tmp_path = parity_env["tmp_path"]
+    source = tmp_path / "game.iso"
+    source.write_bytes(b"iso")
+    # The createcd output already exists, triggering duplicate handling.
+    (tmp_path / "game.chd").write_bytes(b"chd")
+
+    kwargs = {
+        "file_path": str(source),
+        "mode": ConversionMode.CREATECD,
+        "duplicate_action": action,
+        "delete_on_verify": False,
+    }
+    single = await _run_single(parity_env, **kwargs)
+    batch = await _run_batch(parity_env, **kwargs)
+
+    if expect == "reject":
+        assert single["status"] == 409
+        assert batch == {"skipped": True}
+    else:
+        assert single["output_path"] == batch["output_path"]
+        assert single["allow_overwrite"] == batch["allow_overwrite"]
+        if action == DuplicateAction.OVERWRITE:
+            assert single["allow_overwrite"] is True
+            assert single["output_path"] == str(tmp_path / "game.chd")
+        else:  # RENAME picks a fresh sibling path on both paths
+            assert single["allow_overwrite"] is False
+            assert single["output_path"] == str(tmp_path / "game_1.chd")
+
+
+@pytest.mark.asyncio
+async def test_locked_output_overwrite_agree(parity_env, monkeypatch):
+    """An OVERWRITE onto a locked output is a 409 single / skip in batch."""
+    tmp_path = parity_env["tmp_path"]
+    source = tmp_path / "game.iso"
+    source.write_bytes(b"iso")
+    locked_output = str(tmp_path / "game.chd")
+
+    def fake_status(path: str):
+        # Report the resolved output target as present-and-locked.
+        if path == locked_output:
+            return True, True
+        return False, False
+
+    monkeypatch.setattr(
+        convert_routes.lock_manager, "check_file_status", fake_status,
+    )
+
+    kwargs = {
+        "file_path": str(source),
+        "mode": ConversionMode.CREATECD,
+        "duplicate_action": DuplicateAction.OVERWRITE,
+        "delete_on_verify": False,
+    }
+    single = await _run_single(parity_env, **kwargs)
+    batch = await _run_batch(parity_env, **kwargs)
+
+    assert single["status"] == 409
+    assert "currently being converted" in single["detail"]
+    assert batch == {"skipped": True}
+
+
+@pytest.mark.asyncio
+async def test_delete_on_verify_snapshot_failure_detail_differs(
+    parity_env, monkeypatch,
+):
+    """Delete-snapshot failures abort BOTH paths, but the detail text differs."""
+    tmp_path = parity_env["tmp_path"]
+    source = tmp_path / "game.iso"
+    source.write_bytes(b"iso")
+
+    def boom(_path: str):
+        raise ValueError("nope")
+
+    monkeypatch.setattr(convert_routes, "build_delete_snapshot", boom)
+
+    kwargs = {
+        "file_path": str(source),
+        "mode": ConversionMode.CREATECD,
+        "duplicate_action": DuplicateAction.SKIP,
+        "delete_on_verify": True,
+    }
+    single = await _run_single(parity_env, **kwargs)
+    batch = await _run_batch(parity_env, **kwargs)
+
+    assert single["status"] == 400
+    assert batch["status"] == 400
+    assert single["detail"] == "Delete-on-verify blocked: nope"
+    assert batch["detail"] == f"Delete-on-verify blocked for {source}: nope"
+
+
+@pytest.mark.asyncio
+async def test_delete_on_verify_snapshot_success_agrees(parity_env, monkeypatch):
+    """A successful snapshot is attached identically on single and batch."""
+    tmp_path = parity_env["tmp_path"]
+    source = tmp_path / "game.iso"
+    source.write_bytes(b"iso")
+
+    monkeypatch.setattr(
+        convert_routes, "build_delete_snapshot", lambda path: {"snap": path},
+    )
+
+    kwargs = {
+        "file_path": str(source),
+        "mode": ConversionMode.CREATECD,
+        "duplicate_action": DuplicateAction.SKIP,
+        "delete_on_verify": True,
+    }
+    single = await _run_single(parity_env, **kwargs)
+    batch = await _run_batch(parity_env, **kwargs)
+
+    assert single["output_path"] == batch["output_path"]
+    assert single["allow_overwrite"] == batch["allow_overwrite"]
+    # The snapshot reaches the job sink on both paths.
+    snap = {"snap": str(source)}
+    assert parity_env["single_mock"].call_args.kwargs["delete_snapshot"] == snap
+    assert parity_env["captured"]["job_specs"][0]["delete_snapshot"] == snap


### PR DESCRIPTION
## Phase 4 — deduplicate single vs. batch job planning in `routes/convert.py`

Part of the incremental tool-plugin refactor (`DESIGN_tool_plugin_architecture.md`). Builds on Phases 0–3 (#101–#104). Behavior-preserving only — no wire-API change.

### What changed
`create_job` (single) and `create_batch_jobs` (batch) each re-implemented the identical per-file pipeline (archive handling, file/extension validation, output-path resolution, duplicate handling, dolphin same-path guard, `allow_overwrite`, delete-snapshot). That body is now extracted into one shared planner:

- **`plan_job(file_path, *, spec, mode, output_dir, duplicate_action, delete_on_verify) -> JobPlan`** — the shared per-file body.
- **`JobPlan`** dataclass — `file_path`, `output_path`, `base_output_path`, `allow_overwrite`, `display_filename`, `delete_snapshot`, `priority`.
- **`SkipFile(SkipReason)`** — control-flow signal for a per-file validation failure; `SkipReason` enumerates every reason (bad extension, missing file, locked/existing output, archive-not-allowed/not-found, dolphin same-path, etc.).
- **`DeleteSnapshotError`** — raised when `build_delete_snapshot` fails (aborts both paths).

### Single-raises vs. batch-skips divergence (preserved)
This is the load-bearing nuance and it is kept intact:
- `create_job` catches `SkipFile` and maps `skip.reason` through `_SKIP_HTTP` to the **exact** `HTTPException` (status + detail) it raised before.
- `create_batch_jobs` catches `SkipFile` and does `skipped.append(file_path); continue`.
- `DeleteSnapshotError` aborts **both**, but each caller keeps its own detail string (`"Delete-on-verify blocked: …"` vs. `"Delete-on-verify blocked for {file_path}: …"`).

### Stayed at the endpoint level (not hoisted)
Per the design constraints, request-level concerns remain in the endpoints: compression validation, volume containment, the queue-backpressure 429 sizing (single vs. batch differ), the cross-file `get_disallowed_archive_paths` multi-select guard, and the batch dedup-by-`base_output_path` + `_priority` collapse.

### Helpers
- `_input_extension` / `_priority` moved from nested functions in `create_batch_jobs` to module scope (now used by the planner).
- No dead helpers removed — grep confirmed `_is_same_path`, `get_unique_output_path[_for_extractcd]`, `check_output_conflicts`, `_get_output_path` all still have callers.
- Removed the dead `if order: pass` no-op and the unused `is_z3ds` local in the batch endpoint.

### Tests
- New `tests/test_single_batch_plan_parity.py` (23 cases): a matrix of modes (chdman create/extract/copy, dolphin rvz/iso, z3ds) × archive/non-archive × `DuplicateAction` asserts that a file `create_job` rejects with a 4xx is exactly the file `create_batch_jobs` skips, and that accepted files resolve to identical `output_path` / `allow_overwrite`. Plus dedicated cases for existing-output duplicate actions, locked-output overwrite, and delete-snapshot success/failure (including the differing detail strings).
- `tests/test_mode_parity_fixes.py` and all other existing suites pass **unchanged**.

### Verification
- `PYTHONPATH=app pytest tests -q` → **546 passed** (was 523 + 23 new).
- `ruff check app tests` → clean.
- `pylint app/routes/convert.py tests/test_single_batch_plan_parity.py` → **10.00/10**.

https://claude.ai/code/session_01GkaNc3VhTtfiuCu6nFJXEu

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkaNc3VhTtfiuCu6nFJXEu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal job creation pipeline to ensure consistent behavior and error handling across single and batch file processing.
  * Enhanced handling of duplicate file outputs and file overwrite logic.
  * Strengthened validation and error signaling for file operations and delete-on-verify snapshots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacnpal/compressatorium/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->