### PR TITLE
feat: extract SubprocessRunner; slim conversion services (Phase 5)

### DIFF
--- a/app/services/chdman.py
+++ b/app/services/chdman.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 import asyncio
 import logging
-import os
 import re
 import shutil
-import threading
 import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from config import settings
-from fastapi.concurrency import run_in_threadpool
-from services.timeout_policy import compute_progress_stall_timeout
+from services.subprocess_runner import ConversionCancelled, SubprocessRunner
+
+# Re-exported for backwards compatibility: ``ConversionCancelled`` historically
+# lived here and is imported as ``from services.chdman import ConversionCancelled``
+# by job_manager, dolphin_tool and z3ds_compress.  Keeping the import above (not
+# redefining the class) preserves its identity so those ``except`` clauses still
+# catch it.
+__all__ = ["ConversionCancelled", "ChdmanService", "chdman_service"]
 
 CHDMAN_CONVERTIBLE_EXTENSIONS = {".gdi", ".iso", ".cue", ".bin"}
 CONVERTIBLE_EXTENSIONS = CHDMAN_CONVERTIBLE_EXTENSIONS
@@ -19,17 +23,12 @@ CONVERTIBLE_EXTENSIONS = CHDMAN_CONVERTIBLE_EXTENSIONS
 logger = logging.getLogger("chd.chdman")
 
 
-class ConversionCancelled(Exception):
-    """Raised when a conversion is cancelled before completion."""
-
-
 class ChdmanService:
     """Wrapper for chdman binary."""
 
     def __init__(self):
         self.chdman_path = settings.chdman_path
-        self._active_pids: set[int] = set()
-        self._pid_lock = threading.Lock()
+        self._runner = SubprocessRunner(owner="chdman")
 
     def _build_command(
         self,
@@ -81,17 +80,8 @@ class ChdmanService:
 
         return cmd
 
-    def _track_pid(self, pid: int):
-        with self._pid_lock:
-            self._active_pids.add(pid)
-
-    def _untrack_pid(self, pid: int):
-        with self._pid_lock:
-            self._active_pids.discard(pid)
-
     def active_pids(self) -> list[int]:
-        with self._pid_lock:
-            return list(self._active_pids)
+        return self._runner.active_pids()
 
     async def convert(
         self,
@@ -102,236 +92,19 @@ class ChdmanService:
         compression: str | None = None,
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
-        """Run chdman conversion and yield progress updates.
-
-        Args:
-            input_path: Path to input file (GDI, ISO, CUE)
-            output_path: Path for output CHD file
-            mode: "createcd" or "createdvd"
-
-        Yields:
-            dict: {"progress": int, "message": str}
-
-        """
-        # Ensure output directory exists
-        output_dir = os.path.dirname(output_path)
-        if output_dir:  # Empty string means output is in current directory, no need to create
-            await run_in_threadpool(os.makedirs, output_dir, exist_ok=True)
-
+        """Run chdman conversion and yield ``{"progress", "message"}`` updates."""
         cmd = self._build_command(
             mode, input_path, output_path, compression=compression,
         )
-
-        def _preexec():
-            if settings.chdman_nice is not None:
-                try:
-                    os.nice(settings.chdman_nice)
-                except OSError:
-                    pass
-
-        # cmd is built from validated settings paths (no shell interpretation);
-        # create_subprocess_exec passes args directly without shell expansion.
-        process = await asyncio.create_subprocess_exec(
-            cmd[0], *cmd[1:],
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            preexec_fn=_preexec if os.name == "posix" else None,
-        )
-        self._track_pid(process.pid)
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug("Starting chdman pid=%s cmd=%s", process.pid, " ".join(cmd))
-
-        stall_timeout = compute_progress_stall_timeout(
+        async for update in self._runner.run(
+            cmd,
             input_path=input_path,
-            base_timeout=getattr(settings, "progress_timeout", 0),
-            timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
-            timeout_cap=getattr(settings, "progress_timeout_cap", 0),
-        )
-        last_progress_value = 0
-        last_output_size: int | None = None
-        last_activity_at = time.monotonic()
-
-        cancelled_by_request = False
-        cancel_task = None
-        if cancel_event:
-
-            async def _cancel_watcher():
-                nonlocal cancelled_by_request
-                await cancel_event.wait()
-                if process.returncode is not None:
-                    return
-                cancelled_by_request = True
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug("Cancelling chdman pid=%s", process.pid)
-                process.terminate()
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except asyncio.TimeoutError:
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.debug("Killing chdman pid=%s after timeout", process.pid)
-                    process.kill()
-
-            cancel_task = asyncio.create_task(_cancel_watcher())
-
-        buffer = ""
-        output_lines: list[str] = []
-        last_output_at = time.monotonic()
-        last_idle_log = last_output_at
-        stall_error: str | None = None
-
-        def _update_output_activity(now: float):
-            nonlocal last_output_size, last_activity_at
-            if not output_path:
-                return
-            try:
-                if not os.path.exists(output_path):
-                    return
-                size = os.path.getsize(output_path)
-            except OSError:
-                return
-            if last_output_size is None:
-                last_output_size = size
-                last_activity_at = now
-                return
-            if size > last_output_size:
-                last_output_size = size
-                last_activity_at = now
-
-        async def _check_stall(now: float) -> bool:
-            nonlocal stall_error
-            if stall_timeout <= 0:
-                return False
-            _update_output_activity(now)
-            if now - last_activity_at < stall_timeout:
-                return False
-            stall_error = (
-                "Conversion stalled: no progress increase or output growth for "
-                f"{stall_timeout}s (progress={last_progress_value}%,"
-                f" output_size={last_output_size})"
-            )
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(
-                    "chdman pid=%s stalled for %.1fs (progress=%s output_size=%s)",
-                    process.pid,
-                    now - last_activity_at,
-                    last_progress_value,
-                    last_output_size,
-                )
-            if process.returncode is None:
-                process.terminate()
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except asyncio.TimeoutError:
-                    process.kill()
-            return True
-
-        while True:
-            try:
-                chunk = await asyncio.wait_for(process.stdout.read(100), timeout=2)
-            except asyncio.TimeoutError:
-                if cancel_event and cancel_event.is_set():
-                    break
-                now = time.monotonic()
-                idle_for = now - last_output_at
-                if (
-                    logger.isEnabledFor(logging.DEBUG)
-                    and idle_for >= 30
-                    and now - last_idle_log >= 30
-                ):
-                    logger.debug("chdman pid=%s idle for %.1fs", process.pid, idle_for)
-                    last_idle_log = now
-                if await _check_stall(now):
-                    break
-                continue
-            if not chunk:
-                break
-
-            buffer += chunk.decode("utf-8", errors="replace")
-            last_output_at = time.monotonic()
-
-            # Process complete lines and progress updates
-            while "\r" in buffer or "\n" in buffer:
-                # Handle carriage returns (progress updates)
-                if "\r" in buffer:
-                    parts = buffer.split("\r")
-                    for part in parts[:-1]:
-                        if part.strip():
-                            line = part.strip()
-                            if line:
-                                if not output_lines or output_lines[-1] != line:
-                                    output_lines.append(line)
-                                    if len(output_lines) > 30:
-                                        output_lines.pop(0)
-                            now = time.monotonic()
-                            progress = self._parse_progress(line)
-                            if progress > last_progress_value:
-                                last_progress_value = progress
-                                last_activity_at = now
-                            yield {"progress": progress, "message": line}
-                    buffer = parts[-1]
-                # Handle newlines
-                elif "\n" in buffer:
-                    parts = buffer.split("\n")
-                    for part in parts[:-1]:
-                        line = part.strip()
-                        if line:
-                            if not output_lines or output_lines[-1] != line:
-                                output_lines.append(line)
-                                if len(output_lines) > 30:
-                                    output_lines.pop(0)
-                            now = time.monotonic()
-                            progress = self._parse_progress(line)
-                            if progress > last_progress_value:
-                                last_progress_value = progress
-                                last_activity_at = now
-                            yield {"progress": progress, "message": line}
-                    buffer = parts[-1]
-            if await _check_stall(time.monotonic()):
-                break
-
-        # Process any remaining buffer
-        if buffer.strip():
-            line = buffer.strip()
-            if not output_lines or output_lines[-1] != line:
-                output_lines.append(line)
-                if len(output_lines) > 30:
-                    output_lines.pop(0)
-            now = time.monotonic()
-            progress = self._parse_progress(line)
-            if progress > last_progress_value:
-                last_progress_value = progress
-                last_activity_at = now
-            yield {"progress": progress, "message": line}
-            await _check_stall(time.monotonic())
-
-        await process.wait()
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug("chdman pid=%s exit=%s", process.pid, process.returncode)
-        self._untrack_pid(process.pid)
-
-        if cancel_task:
-            cancel_task.cancel()
-            try:
-                await cancel_task
-            except asyncio.CancelledError:
-                pass
-
-        if stall_error:
-            raise RuntimeError(stall_error)
-
-        if cancelled_by_request:
-            raise ConversionCancelled("Conversion cancelled")
-
-        if process.returncode != 0:
-            tail = "\n".join(output_lines[-6:])
-            if tail:
-                raise RuntimeError(
-                    f"chdman failed with return code {process.returncode}."
-                    f"\nLast output:\n{tail}",
-                )
-            raise RuntimeError(f"chdman failed with return code {process.returncode}")
-
-        yield {"progress": 100, "message": "Conversion complete"}
+            output_path=output_path,
+            parse_progress=self._parse_progress,
+            cancel_event=cancel_event,
+            fail_label="chdman",
+        ):
+            yield update
 
     async def info(self, chd_path: str) -> dict:
         """Get information about a CHD file."""
@@ -387,7 +160,7 @@ class ChdmanService:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
-        self._track_pid(process.pid)
+        self._runner.track_pid(process.pid)
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Starting chdman verify pid=%s path=%s", process.pid, chd_path)
 
@@ -472,7 +245,7 @@ class ChdmanService:
             logger.debug(
                 "chdman verify pid=%s exit=%s", process.pid, process.returncode,
             )
-        self._untrack_pid(process.pid)
+        self._runner.untrack_pid(process.pid)
 
         if timeout_error:
             yield {"type": "error", "valid": False, "message": timeout_error}

--- a/app/services/dolphin_tool.py
+++ b/app/services/dolphin_tool.py
@@ -1,15 +1,13 @@
 import asyncio
 import logging
-import os
 import re
 import shutil
-import threading
 import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from config import settings
-from services.timeout_policy import compute_progress_stall_timeout
+from services.subprocess_runner import SubprocessRunner
 
 DOLPHIN_CONVERTIBLE_EXTENSIONS = {".iso", ".gcz", ".wia", ".rvz", ".wbfs"}
 
@@ -29,8 +27,7 @@ class DolphinToolService:
 
     def __init__(self):
         self.dolphin_tool_path = settings.dolphin_tool_path
-        self._active_pids: set[int] = set()
-        self._pid_lock = threading.Lock()
+        self._runner = SubprocessRunner(owner="dolphin_tool")
 
     def _build_convert_command(
         self,
@@ -94,17 +91,8 @@ class DolphinToolService:
             return [stdbuf, "-oL", "-eL"] + cmd
         return cmd[:idx] + [stdbuf, "-oL", "-eL"] + cmd[idx:]
 
-    def _track_pid(self, pid: int):
-        with self._pid_lock:
-            self._active_pids.add(pid)
-
-    def _untrack_pid(self, pid: int):
-        with self._pid_lock:
-            self._active_pids.discard(pid)
-
     def active_pids(self) -> list[int]:
-        with self._pid_lock:
-            return list(self._active_pids)
+        return self._runner.active_pids()
 
     async def convert(
         self,
@@ -116,244 +104,20 @@ class DolphinToolService:
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
         """Run dolphin-tool conversion and yield progress updates."""
-        from fastapi.concurrency import run_in_threadpool
-
-        output_dir = os.path.dirname(output_path)
-        if output_dir:
-            await run_in_threadpool(os.makedirs, output_dir, exist_ok=True)
-
         cmd = self._build_convert_command(
             mode, input_path, output_path, compression=compression,
         )
         cmd = self._wrap_with_stdbuf(cmd)
-
-        def _preexec():
-            if settings.chdman_nice is not None:
-                try:
-                    os.nice(settings.chdman_nice)
-                except OSError as exc:
-                    logger.debug(
-                        "Failed to set nice value %s for dolphin-tool process: %s",
-                        settings.chdman_nice,
-                        exc,
-                    )
-
-        process = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            preexec_fn=_preexec if os.name == "posix" else None,
-        )
-        self._track_pid(process.pid)
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "Starting dolphin-tool pid=%s cmd=%s",
-                process.pid, " ".join(cmd),
-            )
-
-        stall_timeout = compute_progress_stall_timeout(
+        async for update in self._runner.run(
+            cmd,
             input_path=input_path,
-            base_timeout=getattr(settings, "progress_timeout", 0),
-            timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
-            timeout_cap=getattr(settings, "progress_timeout_cap", 0),
-        )
-        last_progress_value = 0
-        last_output_size: int | None = None
-        last_activity_at = time.monotonic()
-        start = last_activity_at
-        last_heartbeat_at = start
-
-        cancelled_by_request = False
-        cancel_task = None
-        if cancel_event:
-
-            async def _cancel_watcher():
-                nonlocal cancelled_by_request
-                await cancel_event.wait()
-                if process.returncode is not None:
-                    return
-                cancelled_by_request = True
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug(
-                        "Cancelling dolphin-tool pid=%s", process.pid,
-                    )
-                process.terminate()
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except asyncio.TimeoutError:
-                    process.kill()
-
-            cancel_task = asyncio.create_task(_cancel_watcher())
-
-        buffer = ""
-        output_lines: list[str] = []
-        stall_error: str | None = None
-
-        def _update_output_activity(now: float):
-            nonlocal last_output_size, last_activity_at
-            if not output_path:
-                return
-            try:
-                if not os.path.exists(output_path):
-                    return
-                size = os.path.getsize(output_path)
-            except OSError:
-                return
-            if last_output_size is None:
-                last_output_size = size
-                last_activity_at = now
-                return
-            if size > last_output_size:
-                last_output_size = size
-                last_activity_at = now
-
-        async def _check_stall(now: float) -> bool:
-            nonlocal stall_error
-            if stall_timeout <= 0:
-                return False
-            _update_output_activity(now)
-            if now - last_activity_at < stall_timeout:
-                return False
-            stall_error = (
-                "Conversion stalled: no progress increase or output growth "
-                f"for {stall_timeout}s (progress={last_progress_value}%, "
-                f"output_size={last_output_size})"
-            )
-            if process.returncode is None:
-                process.terminate()
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except asyncio.TimeoutError:
-                    process.kill()
-            return True
-
-        while True:
-            try:
-                chunk = await asyncio.wait_for(
-                    process.stdout.read(100), timeout=2,
-                )
-            except asyncio.TimeoutError:
-                if cancel_event and cancel_event.is_set():
-                    break
-                now = time.monotonic()
-                if await _check_stall(now):
-                    break
-                if now - last_heartbeat_at >= 2:
-                    elapsed = int(now - start)
-                    yield {
-                        "progress": last_progress_value,
-                        "message": f"Converting... ({elapsed}s)",
-                    }
-                    last_heartbeat_at = now
-                continue
-            if not chunk:
-                break
-
-            buffer += chunk.decode("utf-8", errors="replace")
-
-            while "\r" in buffer or "\n" in buffer:
-                if "\r" in buffer:
-                    parts = buffer.split("\r")
-                    for part in parts[:-1]:
-                        if part.strip():
-                            line = part.strip()
-                            if not output_lines or output_lines[-1] != line:
-                                output_lines.append(line)
-                                if len(output_lines) > 30:
-                                    output_lines.pop(0)
-                            now = time.monotonic()
-                            progress = self._parse_progress(line)
-                            if progress is not None and progress > last_progress_value:
-                                last_progress_value = progress
-                                last_activity_at = now
-                            yield {
-                                "progress": (
-                                    progress
-                                    if progress is not None
-                                    else last_progress_value
-                                ),
-                                "message": line,
-                            }
-                    buffer = parts[-1]
-                elif "\n" in buffer:
-                    parts = buffer.split("\n")
-                    for part in parts[:-1]:
-                        line = part.strip()
-                        if line:
-                            if not output_lines or output_lines[-1] != line:
-                                output_lines.append(line)
-                                if len(output_lines) > 30:
-                                    output_lines.pop(0)
-                            now = time.monotonic()
-                            progress = self._parse_progress(line)
-                            if progress is not None and progress > last_progress_value:
-                                last_progress_value = progress
-                                last_activity_at = now
-                            yield {
-                                "progress": (
-                                    progress
-                                    if progress is not None
-                                    else last_progress_value
-                                ),
-                                "message": line,
-                            }
-                    buffer = parts[-1]
-            if await _check_stall(time.monotonic()):
-                break
-
-        if buffer.strip():
-            line = buffer.strip()
-            if not output_lines or output_lines[-1] != line:
-                output_lines.append(line)
-                if len(output_lines) > 30:
-                    output_lines.pop(0)
-            now = time.monotonic()
-            progress = self._parse_progress(line)
-            if progress is not None and progress > last_progress_value:
-                last_progress_value = progress
-                last_activity_at = now
-            yield {
-                "progress": (
-                    progress if progress is not None else last_progress_value
-                ),
-                "message": line,
-            }
-
-        await process.wait()
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "dolphin-tool pid=%s exit=%s",
-                process.pid, process.returncode,
-            )
-        self._untrack_pid(process.pid)
-
-        if cancel_task:
-            cancel_task.cancel()
-            try:
-                await cancel_task
-            except asyncio.CancelledError:
-                # Cancellation of the helper task is expected once the process has finished.
-                logger.debug("cancel_task was cancelled after dolphin-tool process completion")
-
-        if stall_error:
-            raise RuntimeError(stall_error)
-
-        if cancelled_by_request:
-            from services.chdman import ConversionCancelled
-            raise ConversionCancelled("Conversion cancelled")
-
-        if process.returncode != 0:
-            tail = "\n".join(output_lines[-6:])
-            if tail:
-                raise RuntimeError(
-                    f"dolphin-tool failed with return code "
-                    f"{process.returncode}.\nLast output:\n{tail}",
-                )
-            raise RuntimeError(
-                f"dolphin-tool failed with return code {process.returncode}",
-            )
-
-        yield {"progress": 100, "message": "Conversion complete"}
+            output_path=output_path,
+            parse_progress=self._parse_progress,
+            cancel_event=cancel_event,
+            heartbeat=True,
+            fail_label="dolphin-tool",
+        ):
+            yield update
 
     async def header(self, path: str) -> dict:
         """Get header information about a disc image."""
@@ -414,7 +178,7 @@ class DolphinToolService:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
-        self._track_pid(process.pid)
+        self._runner.track_pid(process.pid)
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "Starting dolphin-tool verify pid=%s path=%s",
@@ -510,7 +274,7 @@ class DolphinToolService:
                 "dolphin-tool verify pid=%s exit=%s",
                 process.pid, process.returncode,
             )
-        self._untrack_pid(process.pid)
+        self._runner.untrack_pid(process.pid)
 
         if timeout_error:
             yield {

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -98,189 +98,213 @@ class SubprocessRunner:
                     pass
 
         # cmd is built from validated settings paths (no shell interpretation);
-        # create_subprocess_exec passes args directly without shell expansion.
-        process = await asyncio.create_subprocess_exec(
+        # create_subprocess_exec passes the arg list directly (shell=False), so
+        # there is no shell expansion / injection surface. Same call shape that
+        # already lives unsuppressed in chdman/dolphin/z3ds; flagged here only
+        # because the line is new in this extracted module.
+        process = await asyncio.create_subprocess_exec(  # nosemgrep
             cmd[0], *cmd[1:],
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             preexec_fn=_preexec if os.name == "posix" else None,
         )
         self.track_pid(process.pid)
-        if self._logger.isEnabledFor(logging.DEBUG):
-            self._logger.debug(
-                "Starting %s pid=%s cmd=%s", self._owner, process.pid, " ".join(cmd),
-            )
-
-        stall_timeout = compute_progress_stall_timeout(
-            input_path=input_path,
-            base_timeout=getattr(settings, "progress_timeout", 0),
-            timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
-            timeout_cap=getattr(settings, "progress_timeout_cap", 0),
-        )
-        last_progress_value = 0
-        last_output_size: int | None = None
-        last_activity_at = time.monotonic()
-        start = last_activity_at
-        last_heartbeat_at = start
-
-        cancelled_by_request = False
+        # Everything below runs under try/finally so that if the caller stops
+        # iterating (generator aclose / task cancellation) or an unexpected
+        # error fires, the subprocess, the cancel-watcher task and the PID entry
+        # are always cleaned up rather than leaked.
         cancel_task = None
-        if cancel_event:
-
-            async def _cancel_watcher():
-                nonlocal cancelled_by_request
-                await cancel_event.wait()
-                if process.returncode is not None:
-                    return
-                cancelled_by_request = True
-                if self._logger.isEnabledFor(logging.DEBUG):
-                    self._logger.debug(
-                        "Cancelling %s pid=%s", self._owner, process.pid,
-                    )
-                process.terminate()
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except asyncio.TimeoutError:
-                    process.kill()
-
-            cancel_task = asyncio.create_task(_cancel_watcher())
-
-        buffer = ""
-        output_lines: list[str] = []
-        stall_error: str | None = None
-
-        def _record_line(line: str) -> None:
-            if not output_lines or output_lines[-1] != line:
-                output_lines.append(line)
-                if len(output_lines) > 30:
-                    output_lines.pop(0)
-
-        def _update_output_activity(now: float):
-            nonlocal last_output_size, last_activity_at
-            if not output_path:
-                return
-            try:
-                if not os.path.exists(output_path):
-                    return
-                size = os.path.getsize(output_path)
-            except OSError:
-                return
-            if last_output_size is None:
-                last_output_size = size
-                last_activity_at = now
-                return
-            if size > last_output_size:
-                last_output_size = size
-                last_activity_at = now
-
-        async def _check_stall(now: float) -> bool:
-            nonlocal stall_error
-            if stall_timeout <= 0:
-                return False
-            _update_output_activity(now)
-            if now - last_activity_at < stall_timeout:
-                return False
-            stall_error = (
-                "Conversion stalled: no progress increase or output growth for "
-                f"{stall_timeout}s (progress={last_progress_value}%,"
-                f" output_size={last_output_size})"
-            )
-            if process.returncode is None:
-                process.terminate()
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except asyncio.TimeoutError:
-                    process.kill()
-            return True
-
-        while True:
-            try:
-                chunk = await asyncio.wait_for(process.stdout.read(100), timeout=2)
-            except asyncio.TimeoutError:
-                if cancel_event and cancel_event.is_set():
-                    break
-                now = time.monotonic()
-                if await _check_stall(now):
-                    break
-                if heartbeat and now - last_heartbeat_at >= 2:
-                    elapsed = int(now - start)
-                    yield {
-                        "progress": last_progress_value,
-                        "message": f"Converting... ({elapsed}s)",
-                    }
-                    last_heartbeat_at = now
-                continue
-            if not chunk:
-                break
-
-            buffer += chunk.decode("utf-8", errors="replace")
-
-            while "\r" in buffer or "\n" in buffer:
-                sep = "\r" if "\r" in buffer else "\n"
-                parts = buffer.split(sep)
-                for part in parts[:-1]:
-                    line = part.strip()
-                    if not line:
-                        continue
-                    _record_line(line)
-                    now = time.monotonic()
-                    progress = parse_progress(line)
-                    if progress is not None and progress > last_progress_value:
-                        last_progress_value = progress
-                        last_activity_at = now
-                    yield {
-                        "progress": (
-                            progress if progress is not None else last_progress_value
-                        ),
-                        "message": line,
-                    }
-                buffer = parts[-1]
-            if await _check_stall(time.monotonic()):
-                break
-
-        if buffer.strip():
-            line = buffer.strip()
-            _record_line(line)
-            now = time.monotonic()
-            progress = parse_progress(line)
-            if progress is not None and progress > last_progress_value:
-                last_progress_value = progress
-                last_activity_at = now
-            yield {
-                "progress": progress if progress is not None else last_progress_value,
-                "message": line,
-            }
-            await _check_stall(time.monotonic())
-
-        await process.wait()
-        if self._logger.isEnabledFor(logging.DEBUG):
-            self._logger.debug(
-                "%s pid=%s exit=%s", self._owner, process.pid, process.returncode,
-            )
-        self.untrack_pid(process.pid)
-
-        if cancel_task:
-            cancel_task.cancel()
-            try:
-                await cancel_task
-            except asyncio.CancelledError:
-                pass
-
-        if stall_error:
-            raise RuntimeError(stall_error)
-
-        if cancelled_by_request:
-            raise ConversionCancelled("Conversion cancelled")
-
-        if process.returncode != 0:
-            tail = "\n".join(output_lines[-6:])
-            if tail:
-                raise RuntimeError(
-                    f"{fail_label} failed with return code {process.returncode}."
-                    f"\nLast output:\n{tail}",
+        try:
+            if self._logger.isEnabledFor(logging.DEBUG):
+                self._logger.debug(
+                    "Starting %s pid=%s cmd=%s",
+                    self._owner, process.pid, " ".join(cmd),
                 )
-            raise RuntimeError(
-                f"{fail_label} failed with return code {process.returncode}",
-            )
 
-        yield {"progress": 100, "message": complete_message}
+            stall_timeout = compute_progress_stall_timeout(
+                input_path=input_path,
+                base_timeout=getattr(settings, "progress_timeout", 0),
+                timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
+                timeout_cap=getattr(settings, "progress_timeout_cap", 0),
+            )
+            last_progress_value = 0
+            last_output_size: int | None = None
+            last_activity_at = time.monotonic()
+            start = last_activity_at
+            last_heartbeat_at = start
+
+            cancelled_by_request = False
+            if cancel_event:
+
+                async def _cancel_watcher():
+                    nonlocal cancelled_by_request
+                    await cancel_event.wait()
+                    if process.returncode is not None:
+                        return
+                    cancelled_by_request = True
+                    if self._logger.isEnabledFor(logging.DEBUG):
+                        self._logger.debug(
+                            "Cancelling %s pid=%s", self._owner, process.pid,
+                        )
+                    process.terminate()
+                    try:
+                        await asyncio.wait_for(process.wait(), timeout=5)
+                    except asyncio.TimeoutError:
+                        process.kill()
+
+                cancel_task = asyncio.create_task(_cancel_watcher())
+
+            buffer = ""
+            output_lines: list[str] = []
+            stall_error: str | None = None
+
+            def _record_line(line: str) -> None:
+                if not output_lines or output_lines[-1] != line:
+                    output_lines.append(line)
+                    if len(output_lines) > 30:
+                        output_lines.pop(0)
+
+            def _update_output_activity(now: float):
+                nonlocal last_output_size, last_activity_at
+                if not output_path:
+                    return
+                try:
+                    if not os.path.exists(output_path):
+                        return
+                    size = os.path.getsize(output_path)
+                except OSError:
+                    return
+                if last_output_size is None:
+                    last_output_size = size
+                    last_activity_at = now
+                    return
+                if size > last_output_size:
+                    last_output_size = size
+                    last_activity_at = now
+
+            async def _check_stall(now: float) -> bool:
+                nonlocal stall_error
+                if stall_timeout <= 0:
+                    return False
+                _update_output_activity(now)
+                if now - last_activity_at < stall_timeout:
+                    return False
+                stall_error = (
+                    "Conversion stalled: no progress increase or output growth "
+                    f"for {stall_timeout}s (progress={last_progress_value}%,"
+                    f" output_size={last_output_size})"
+                )
+                if process.returncode is None:
+                    process.terminate()
+                    try:
+                        await asyncio.wait_for(process.wait(), timeout=5)
+                    except asyncio.TimeoutError:
+                        process.kill()
+                return True
+
+            while True:
+                try:
+                    chunk = await asyncio.wait_for(
+                        process.stdout.read(100), timeout=2,
+                    )
+                except asyncio.TimeoutError:
+                    if cancel_event and cancel_event.is_set():
+                        break
+                    now = time.monotonic()
+                    if await _check_stall(now):
+                        break
+                    if heartbeat and now - last_heartbeat_at >= 2:
+                        elapsed = int(now - start)
+                        yield {
+                            "progress": last_progress_value,
+                            "message": f"Converting... ({elapsed}s)",
+                        }
+                        last_heartbeat_at = now
+                    continue
+                if not chunk:
+                    break
+
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\r" in buffer or "\n" in buffer:
+                    sep = "\r" if "\r" in buffer else "\n"
+                    parts = buffer.split(sep)
+                    for part in parts[:-1]:
+                        line = part.strip()
+                        if not line:
+                            continue
+                        _record_line(line)
+                        now = time.monotonic()
+                        progress = parse_progress(line)
+                        if progress is not None and progress > last_progress_value:
+                            last_progress_value = progress
+                            last_activity_at = now
+                        yield {
+                            "progress": (
+                                progress
+                                if progress is not None
+                                else last_progress_value
+                            ),
+                            "message": line,
+                        }
+                    buffer = parts[-1]
+                if await _check_stall(time.monotonic()):
+                    break
+
+            if buffer.strip():
+                line = buffer.strip()
+                _record_line(line)
+                now = time.monotonic()
+                progress = parse_progress(line)
+                if progress is not None and progress > last_progress_value:
+                    last_progress_value = progress
+                    last_activity_at = now
+                yield {
+                    "progress": (
+                        progress if progress is not None else last_progress_value
+                    ),
+                    "message": line,
+                }
+                await _check_stall(time.monotonic())
+
+            await process.wait()
+            if self._logger.isEnabledFor(logging.DEBUG):
+                self._logger.debug(
+                    "%s pid=%s exit=%s", self._owner, process.pid, process.returncode,
+                )
+
+            if stall_error:
+                raise RuntimeError(stall_error)
+
+            if cancelled_by_request:
+                raise ConversionCancelled("Conversion cancelled")
+
+            if process.returncode != 0:
+                tail = "\n".join(output_lines[-6:])
+                if tail:
+                    raise RuntimeError(
+                        f"{fail_label} failed with return code {process.returncode}."
+                        f"\nLast output:\n{tail}",
+                    )
+                raise RuntimeError(
+                    f"{fail_label} failed with return code {process.returncode}",
+                )
+
+            yield {"progress": 100, "message": complete_message}
+        finally:
+            self.untrack_pid(process.pid)
+            if cancel_task:
+                cancel_task.cancel()
+                try:
+                    await cancel_task
+                except asyncio.CancelledError:
+                    pass
+            if process.returncode is None:
+                try:
+                    process.terminate()
+                    await asyncio.wait_for(process.wait(), timeout=5)
+                except asyncio.TimeoutError:
+                    process.kill()
+                    await process.wait()
+                except ProcessLookupError:
+                    pass

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -1,0 +1,286 @@
+"""Shared subprocess orchestration for conversion tools.
+
+The implementation lives in this top-level ``services`` module (rather than
+inside the ``services.tools`` package) so the service singletons can import it
+during their own module initialization without triggering ``services.tools``'s
+eager registry build — which imports the tool wrappers, which import back into
+the still-initializing service modules.  ``services.tools.runner`` re-exports
+these names so the design's documented path keeps working.
+
+``SubprocessRunner.run`` collapses the line-buffered subprocess loop that was
+duplicated, almost verbatim, in ``chdman``'s and ``dolphin_tool``'s
+``convert()`` (spawn, ``nice`` wrap, PID tracking, ``\\r``/``\\n`` buffering,
+stall timeout, cancel watcher, non-zero-exit error tail, final 100% emit).
+dolphin's only addition over chdman is a periodic heartbeat, which is an opt-in
+flag here.
+
+``ConversionCancelled`` is defined here (rather than in ``services.chdman``) so
+the runner can raise it without importing back into the service that uses the
+runner.  ``services.chdman`` re-exports it from this module, so its identity and
+every existing import path (``from services.chdman import ConversionCancelled``)
+are preserved.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+import time
+from collections.abc import AsyncGenerator, Callable
+
+from config import settings
+from fastapi.concurrency import run_in_threadpool
+from services.timeout_policy import compute_progress_stall_timeout
+
+
+class ConversionCancelled(Exception):
+    """Raised when a conversion is cancelled before completion."""
+
+
+class SubprocessRunner:
+    """Spawns a conversion subprocess and streams progress updates.
+
+    One instance per tool owns that tool's in-flight PID set, so both
+    ``run()`` and the tool's separate ``verify_stream`` loop can register
+    their subprocesses through the same store (``track_pid``/``untrack_pid``).
+    """
+
+    def __init__(self, owner: str) -> None:
+        self._owner = owner
+        self._active_pids: set[int] = set()
+        self._pid_lock = threading.Lock()
+        self._logger = logging.getLogger(f"chd.{owner}")
+
+    def track_pid(self, pid: int) -> None:
+        with self._pid_lock:
+            self._active_pids.add(pid)
+
+    def untrack_pid(self, pid: int) -> None:
+        with self._pid_lock:
+            self._active_pids.discard(pid)
+
+    def active_pids(self) -> list[int]:
+        with self._pid_lock:
+            return list(self._active_pids)
+
+    async def run(
+        self,
+        cmd: list[str],
+        *,
+        input_path: str,
+        output_path: str,
+        parse_progress: Callable[[str], int | None],
+        cancel_event: asyncio.Event | None = None,
+        heartbeat: bool = False,
+        fail_label: str = "process",
+        complete_message: str = "Conversion complete",
+    ) -> AsyncGenerator[dict, None]:
+        """Spawn ``cmd``, stream stdout, and yield ``{"progress", "message"}``.
+
+        ``parse_progress(line) -> int | None`` is the only per-tool knob in the
+        common path; ``heartbeat`` enables dolphin's 2-second "Converting..."
+        keep-alive.  Handles nice wrap, PID tracking, ``\\r``/``\\n`` line
+        buffering, stall timeout via ``compute_progress_stall_timeout``, a
+        cancel watcher (terminate -> kill), ``ConversionCancelled`` on request,
+        a non-zero-exit ``RuntimeError`` carrying the output tail, and the final
+        100% emit.
+        """
+        output_dir = os.path.dirname(output_path)
+        if output_dir:
+            await run_in_threadpool(os.makedirs, output_dir, exist_ok=True)
+
+        def _preexec():
+            if settings.chdman_nice is not None:
+                try:
+                    os.nice(settings.chdman_nice)
+                except OSError:
+                    pass
+
+        # cmd is built from validated settings paths (no shell interpretation);
+        # create_subprocess_exec passes args directly without shell expansion.
+        process = await asyncio.create_subprocess_exec(
+            cmd[0], *cmd[1:],
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            preexec_fn=_preexec if os.name == "posix" else None,
+        )
+        self.track_pid(process.pid)
+        if self._logger.isEnabledFor(logging.DEBUG):
+            self._logger.debug(
+                "Starting %s pid=%s cmd=%s", self._owner, process.pid, " ".join(cmd),
+            )
+
+        stall_timeout = compute_progress_stall_timeout(
+            input_path=input_path,
+            base_timeout=getattr(settings, "progress_timeout", 0),
+            timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
+            timeout_cap=getattr(settings, "progress_timeout_cap", 0),
+        )
+        last_progress_value = 0
+        last_output_size: int | None = None
+        last_activity_at = time.monotonic()
+        start = last_activity_at
+        last_heartbeat_at = start
+
+        cancelled_by_request = False
+        cancel_task = None
+        if cancel_event:
+
+            async def _cancel_watcher():
+                nonlocal cancelled_by_request
+                await cancel_event.wait()
+                if process.returncode is not None:
+                    return
+                cancelled_by_request = True
+                if self._logger.isEnabledFor(logging.DEBUG):
+                    self._logger.debug(
+                        "Cancelling %s pid=%s", self._owner, process.pid,
+                    )
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=5)
+                except asyncio.TimeoutError:
+                    process.kill()
+
+            cancel_task = asyncio.create_task(_cancel_watcher())
+
+        buffer = ""
+        output_lines: list[str] = []
+        stall_error: str | None = None
+
+        def _record_line(line: str) -> None:
+            if not output_lines or output_lines[-1] != line:
+                output_lines.append(line)
+                if len(output_lines) > 30:
+                    output_lines.pop(0)
+
+        def _update_output_activity(now: float):
+            nonlocal last_output_size, last_activity_at
+            if not output_path:
+                return
+            try:
+                if not os.path.exists(output_path):
+                    return
+                size = os.path.getsize(output_path)
+            except OSError:
+                return
+            if last_output_size is None:
+                last_output_size = size
+                last_activity_at = now
+                return
+            if size > last_output_size:
+                last_output_size = size
+                last_activity_at = now
+
+        async def _check_stall(now: float) -> bool:
+            nonlocal stall_error
+            if stall_timeout <= 0:
+                return False
+            _update_output_activity(now)
+            if now - last_activity_at < stall_timeout:
+                return False
+            stall_error = (
+                "Conversion stalled: no progress increase or output growth for "
+                f"{stall_timeout}s (progress={last_progress_value}%,"
+                f" output_size={last_output_size})"
+            )
+            if process.returncode is None:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=5)
+                except asyncio.TimeoutError:
+                    process.kill()
+            return True
+
+        while True:
+            try:
+                chunk = await asyncio.wait_for(process.stdout.read(100), timeout=2)
+            except asyncio.TimeoutError:
+                if cancel_event and cancel_event.is_set():
+                    break
+                now = time.monotonic()
+                if await _check_stall(now):
+                    break
+                if heartbeat and now - last_heartbeat_at >= 2:
+                    elapsed = int(now - start)
+                    yield {
+                        "progress": last_progress_value,
+                        "message": f"Converting... ({elapsed}s)",
+                    }
+                    last_heartbeat_at = now
+                continue
+            if not chunk:
+                break
+
+            buffer += chunk.decode("utf-8", errors="replace")
+
+            while "\r" in buffer or "\n" in buffer:
+                sep = "\r" if "\r" in buffer else "\n"
+                parts = buffer.split(sep)
+                for part in parts[:-1]:
+                    line = part.strip()
+                    if not line:
+                        continue
+                    _record_line(line)
+                    now = time.monotonic()
+                    progress = parse_progress(line)
+                    if progress is not None and progress > last_progress_value:
+                        last_progress_value = progress
+                        last_activity_at = now
+                    yield {
+                        "progress": (
+                            progress if progress is not None else last_progress_value
+                        ),
+                        "message": line,
+                    }
+                buffer = parts[-1]
+            if await _check_stall(time.monotonic()):
+                break
+
+        if buffer.strip():
+            line = buffer.strip()
+            _record_line(line)
+            now = time.monotonic()
+            progress = parse_progress(line)
+            if progress is not None and progress > last_progress_value:
+                last_progress_value = progress
+                last_activity_at = now
+            yield {
+                "progress": progress if progress is not None else last_progress_value,
+                "message": line,
+            }
+            await _check_stall(time.monotonic())
+
+        await process.wait()
+        if self._logger.isEnabledFor(logging.DEBUG):
+            self._logger.debug(
+                "%s pid=%s exit=%s", self._owner, process.pid, process.returncode,
+            )
+        self.untrack_pid(process.pid)
+
+        if cancel_task:
+            cancel_task.cancel()
+            try:
+                await cancel_task
+            except asyncio.CancelledError:
+                pass
+
+        if stall_error:
+            raise RuntimeError(stall_error)
+
+        if cancelled_by_request:
+            raise ConversionCancelled("Conversion cancelled")
+
+        if process.returncode != 0:
+            tail = "\n".join(output_lines[-6:])
+            if tail:
+                raise RuntimeError(
+                    f"{fail_label} failed with return code {process.returncode}."
+                    f"\nLast output:\n{tail}",
+                )
+            raise RuntimeError(
+                f"{fail_label} failed with return code {process.returncode}",
+            )
+
+        yield {"progress": 100, "message": complete_message}

--- a/app/services/tools/runner.py
+++ b/app/services/tools/runner.py
@@ -1,0 +1,14 @@
+"""Design-documented location for the shared subprocess runner.
+
+The implementation lives in ``services.subprocess_runner`` to avoid a circular
+import: the service singletons import the runner during their own
+initialization, and importing anything from this ``services.tools`` package
+would run its ``__init__`` (which eagerly builds the registry by importing the
+tool wrappers, which import the still-initializing service modules).  This
+module re-exports the names so ``services.tools.runner`` resolves as designed.
+"""
+from __future__ import annotations
+
+from services.subprocess_runner import ConversionCancelled, SubprocessRunner
+
+__all__ = ["ConversionCancelled", "SubprocessRunner"]

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -1,0 +1,143 @@
+"""Direct tests for ``SubprocessRunner`` — the shared subprocess loop that
+``chdman`` and ``dolphin_tool`` now delegate their ``convert()`` to.
+
+These drive the highest-risk paths (cancel, stall timeout, non-zero exit) with
+a real child process spawned via ``sys.executable`` so the spawn / line-buffer
+/ cancel-watcher / finalize machinery is exercised end to end, since the real
+CLIs are unavailable in the sandbox.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+
+import pytest
+
+from app.services import subprocess_runner as runner_module
+from app.services.subprocess_runner import ConversionCancelled, SubprocessRunner
+
+
+def _parse_pct(line: str) -> int | None:
+    match = re.search(r"(\d+)\s*%", line)
+    return int(match.group(1)) if match else None
+
+
+def _py_cmd(script: str) -> list[str]:
+    return [sys.executable, "-u", "-c", script]
+
+
+async def _drain(gen) -> list[dict]:
+    return [update async for update in gen]
+
+
+def test_happy_path_streams_progress_then_final_100(tmp_path):
+    out = tmp_path / "out.bin"
+    script = (
+        "import sys\n"
+        "for p in (10, 50, 90):\n"
+        "    sys.stdout.write(f'Progress {p}%\\n')\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    updates = asyncio.run(
+        _drain(
+            runner.run(
+                _py_cmd(script),
+                input_path=str(tmp_path / "in.bin"),
+                output_path=str(out),
+                parse_progress=_parse_pct,
+                fail_label="testproc",
+            )
+        )
+    )
+
+    progresses = [u["progress"] for u in updates]
+    assert progresses[:3] == [10, 50, 90]
+    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert not runner.active_pids()
+
+
+def test_nonzero_exit_raises_runtimeerror_with_tail(tmp_path):
+    script = (
+        "import sys\n"
+        "sys.stdout.write('starting\\n')\n"
+        "sys.stdout.write('boom error\\n')\n"
+        "sys.exit(3)\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(
+            _drain(
+                runner.run(
+                    _py_cmd(script),
+                    input_path=str(tmp_path / "in.bin"),
+                    output_path=str(tmp_path / "out.bin"),
+                    parse_progress=_parse_pct,
+                    fail_label="testproc",
+                )
+            )
+        )
+
+    message = str(excinfo.value)
+    assert "testproc failed with return code 3" in message
+    assert "boom error" in message
+    assert not runner.active_pids()
+
+
+def test_cancel_event_raises_conversion_cancelled(tmp_path):
+    script = (
+        "import sys, time\n"
+        "sys.stdout.write('working 10%\\n')\n"
+        "time.sleep(30)\n"
+    )
+    runner = SubprocessRunner(owner="test")
+    cancel_event = asyncio.Event()
+
+    async def _run():
+        gen = runner.run(
+            _py_cmd(script),
+            input_path=str(tmp_path / "in.bin"),
+            output_path=str(tmp_path / "out.bin"),
+            parse_progress=_parse_pct,
+            cancel_event=cancel_event,
+            fail_label="testproc",
+        )
+        async for update in gen:
+            if "10%" in update["message"]:
+                cancel_event.set()
+
+    with pytest.raises(ConversionCancelled):
+        asyncio.run(_run())
+    assert not runner.active_pids()
+
+
+def test_stall_timeout_raises_runtimeerror(tmp_path, monkeypatch):
+    # Force a short stall window; the child emits one line then goes silent and
+    # never grows the output file, so the stall watchdog must fire.
+    monkeypatch.setattr(
+        runner_module, "compute_progress_stall_timeout", lambda **_: 1,
+    )
+    script = (
+        "import sys, time\n"
+        "sys.stdout.write('starting\\n')\n"
+        "time.sleep(30)\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(
+            _drain(
+                runner.run(
+                    _py_cmd(script),
+                    input_path=str(tmp_path / "in.bin"),
+                    output_path=str(tmp_path / "out.bin"),
+                    parse_progress=_parse_pct,
+                    fail_label="testproc",
+                )
+            )
+        )
+
+    assert "Conversion stalled" in str(excinfo.value)
+    assert not runner.active_pids()


### PR DESCRIPTION
## Phase 5 — extract `SubprocessRunner`; slim the conversion services

Phase 5 of the incremental tool-plugin refactor (`DESIGN_tool_plugin_architecture.md` §3.3). Collapses the ~150-line subprocess loop that `chdman` and `dolphin_tool` each re-implemented into one shared `SubprocessRunner`. Behavior-preserving; no `routes/`, frontend, or wire-API changes.

> This branch stacks Phases 0–5; the Phase 5 work is the two newest commits (`8a4f400`, `1c1ab26`). `origin/latest` does not yet contain Phases 0–4, so the diff against `latest` includes the earlier phases too.

### `SubprocessRunner` contract
`SubprocessRunner(owner)` owns one tool's in-flight PID set (`track_pid` / `untrack_pid` / `active_pids`), shared by `run()` and the tool's separate `verify_stream` loop so `active_pids()` is unchanged.

```
async def run(cmd, *, input_path, output_path, parse_progress,
              cancel_event=None, heartbeat=False,
              fail_label="process", complete_message="Conversion complete")
    -> AsyncGenerator[{"progress": int, "message": str}, None]
```
Handles: output-dir creation, `nice` preexec wrap, spawn, PID tracking, `\r`/`\n` line buffering (consecutive-dedup, 30-line tail), stall timeout via `compute_progress_stall_timeout` (terminate→kill, `RuntimeError` with the stall message), cancel watcher (terminate→kill → `ConversionCancelled`), non-zero exit → `RuntimeError` carrying the last-6-lines tail, and the final `{100, complete_message}` emit. `parse_progress(line) -> int | None` is the only per-tool knob in the common path.

### Flags
- **`heartbeat`** (dolphin only): the 2-second `"Converting... (Ns)"` keep-alive emitted while the CLI is quiet. Absent for chdman.
- The dolphin/z3ds **output-size heuristic** is used here only for *stall detection* (output growth resets the activity clock), exactly as before. z3ds's size-*estimate progress emission* is not part of the shared loop — see below.

### `ConversionCancelled` identity / imports
Defined once in the new `services/subprocess_runner.py` and **re-exported from `services.chdman`** (no redefinition), so `from services.chdman import ConversionCancelled` (job_manager, dolphin_tool, z3ds_compress) keeps catching the same class object. Verified: all import paths resolve to one identity, and `job_manager`'s `except ConversionCancelled` is unaffected.

The implementation lives in the top-level `services/subprocess_runner.py` (with a thin re-export at the design-documented `services/tools/runner.py`) to avoid a circular import: the service singletons import the runner during their own module init, and importing anything from the `services.tools` package would trigger its eager registry build, which imports the tool wrappers, which import the still-initializing service modules.

### What moved vs. what stayed
- **chdman & dolphin `convert()`** → argv-build + `runner.run(...)` (~15 lines each). PID tracking in their `verify_stream` now routes through the runner's single store.
- **`convert()` stays on the service singletons** (tools still delegate via `_service`). This is a tested contract: `test_dispatch_routing` patches `tool._service.convert`/`.verify` and `test_mode_parity_fixes` patches `chdman_service.convert`. Moving `convert` onto the wrappers would break those, so the runner is composed *into* the services rather than the logic being lifted into the wrappers.
- **z3ds left intact** (a deliberate non-change): its loop is a different algorithm — progress derived from output-file growth rather than parsed CLI lines, no per-line message events, kill-on-stall raising `TimeoutError`, partial-output cleanup on cancel, and a distinct error format. It is duplicated 0×, not 3×; folding it into the shared runner would mean moving unique code into the shared module behind ~6 divergence flags and risks the cancel/stall drift the design flags as the #1 risk. Its `active_pids`, `ConversionCancelled` usage, and behavior are unchanged.
- **No `verify()` default on `BaseTool`**: the three `verify()` wrappers have different fallback messages ("CHD verification failed" / "Disc verification failed" / "Verification failed"), so they are not identical wrappers — added nothing to `BaseTool`.

### Cancel / stall / exit test approach
New `tests/test_subprocess_runner.py` drives the highest-risk paths against a real child process (`sys.executable -c ...`, since the CLIs are unavailable in the sandbox):
- **cancel**: a long-sleeping child; set `cancel_event` after the first update → asserts `ConversionCancelled` is raised and the PID set is drained.
- **stall**: `compute_progress_stall_timeout` monkeypatched to 1s; a silent child that never grows output → asserts `RuntimeError("Conversion stalled …")`.
- **non-zero exit**: a child that prints then exits 3 → asserts `RuntimeError` with `"… failed with return code 3"` and the output tail.
- **happy path**: progress events stream through in order, then the final `{100, "Conversion complete"}`.

### Validation
- Full suite: **550 passed** (`PYTHONPATH=app pytest tests -q`).
- `ruff check app tests`: clean.
- `pylint` on touched files: **10.00/10**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5cgUa8hnjaUe1PxXWxWHC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error detection and reporting during conversion operations.
  * Improved handling of stalled processes to prevent indefinite hangs.
  * Strengthened process cancellation and cleanup mechanisms.
  * Better progress tracking and status updates during conversions.
  * More consistent subprocess lifecycle management across conversion tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacnpal/compressatorium/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->