### PR TITLE
feat: generate verify routes from the tool registry (Phase 6)

### DIFF
--- a/app/routes/info.py
+++ b/app/routes/info.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from config import settings
@@ -650,7 +651,7 @@ class _VerifyRouteConfig:
     """Per-tool data the verify-route factory needs (no behavior branching)."""
 
     url_prefix: str          # "" -> /verify, "dolphin-" -> /dolphin-verify, ...
-    service_attr: str        # module global the tests monkeypatch
+    service: Callable        # returns the verify service (read at call time)
     sync_name: str           # FastAPI route name == legacy function name
     events_name: str
     batch_name: str
@@ -658,10 +659,13 @@ class _VerifyRouteConfig:
     verify_error_prefix: str  # 500 detail prefix raised by the sync endpoint
 
 
+# Each ``service`` getter resolves the module-global service name at call time
+# (not at import time), so the existing route tests can rebind
+# ``info_routes.<service>`` to a mock and have the factory pick it up.
 _VERIFY_CONFIG: dict[str, _VerifyRouteConfig] = {
     "chdman": _VerifyRouteConfig(
         url_prefix="",
-        service_attr="chdman_service",
+        service=lambda: chdman_service,
         sync_name="verify_chd",
         events_name="verify_chd_events",
         batch_name="verify_batch_events",
@@ -670,7 +674,7 @@ _VERIFY_CONFIG: dict[str, _VerifyRouteConfig] = {
     ),
     "dolphin": _VerifyRouteConfig(
         url_prefix="dolphin-",
-        service_attr="dolphin_tool_service",
+        service=lambda: dolphin_tool_service,
         sync_name="verify_dolphin",
         events_name="verify_dolphin_events",
         batch_name="verify_dolphin_batch_events",
@@ -679,7 +683,7 @@ _VERIFY_CONFIG: dict[str, _VerifyRouteConfig] = {
     ),
     "z3ds": _VerifyRouteConfig(
         url_prefix="z3ds-",
-        service_attr="z3ds_compress_service",
+        service=lambda: z3ds_compress_service,
         sync_name="verify_z3ds",
         events_name="verify_z3ds_events",
         batch_name="verify_z3ds_batch_events",
@@ -687,16 +691,6 @@ _VERIFY_CONFIG: dict[str, _VerifyRouteConfig] = {
         verify_error_prefix="Failed to verify 3DS ROM",
     ),
 }
-
-
-def _verify_service(cfg: _VerifyRouteConfig):
-    """Resolve the verify service via the module global.
-
-    The route tests rebind ``info_routes.<service>`` to a mock, so the factory
-    must read the service through this module's namespace at call time rather
-    than capture the tool's own ``_service`` reference.
-    """
-    return globals()[cfg.service_attr]
 
 
 async def _guard_verify_path(
@@ -741,7 +735,7 @@ def _sse_from_verify_stream(
 
         async def run_verify():
             try:
-                async for update in _verify_service(cfg).verify_stream(path):
+                async for update in cfg.service().verify_stream(path):
                     await queue.put(update)
             except Exception as exc:
                 await queue.put({"type": "error", "valid": False, "message": str(exc)})
@@ -832,7 +826,7 @@ def _sse_batch_from_verify_stream(
                 async def run_verify(path=path):
                     nonlocal final_result
                     try:
-                        async for update in _verify_service(cfg).verify_stream(path):
+                        async for update in cfg.service().verify_stream(path):
                             await queue.put(update)
                             if update.get("type") in ("complete", "error"):
                                 final_result = update
@@ -945,8 +939,8 @@ def _sse_batch_from_verify_stream(
     return EventSourceResponse(wrapped_event_generator())
 
 
-def register_verify_routes(router_: APIRouter, tool: ToolPlugin) -> dict:
-    """Register the verify trio for ``tool`` and return the route functions.
+def register_verify_routes(router_: APIRouter, tool: ToolPlugin) -> tuple:
+    """Register the verify trio for ``tool`` and return ``(sync, events, batch)``.
 
     Paths stay byte-identical via the ``tool_id -> url_prefix`` alias map, and
     each route is named after its legacy handler so OpenAPI operation ids and
@@ -960,7 +954,7 @@ def register_verify_routes(router_: APIRouter, tool: ToolPlugin) -> dict:
         await _guard_verify_path(path, tool, cfg)
         verify_token = await _acquire_verify_lane_or_429()
         try:
-            result = await _verify_service(cfg).verify(path)
+            result = await cfg.service().verify(path)
             if result.get("valid"):
                 await verification_store.mark_verified(path)
             return result
@@ -998,13 +992,18 @@ def register_verify_routes(router_: APIRouter, tool: ToolPlugin) -> dict:
         verify_token = await _acquire_verify_lane_or_429()
         return _sse_batch_from_verify_stream(tool, cfg, valid_paths, verify_token)
 
-    return {
-        cfg.sync_name: _verify,
-        cfg.events_name: _verify_events,
-        cfg.batch_name: _verify_batch,
-    }
+    return _verify, _verify_events, _verify_batch
 
 
-for _tool in registry.all():
-    if _tool.id in _VERIFY_CONFIG:
-        globals().update(register_verify_routes(router, _tool))
+# Explicit (registry-driven) registration. The factory body has no per-tool
+# branching; binding the returned handlers to their legacy names keeps the
+# ``info_routes.verify_*`` attributes the route tests call directly.
+verify_chd, verify_chd_events, verify_batch_events = register_verify_routes(
+    router, registry.get("chdman"),
+)
+verify_dolphin, verify_dolphin_events, verify_dolphin_batch_events = register_verify_routes(
+    router, registry.get("dolphin"),
+)
+verify_z3ds, verify_z3ds_events, verify_z3ds_batch_events = register_verify_routes(
+    router, registry.get("z3ds"),
+)

--- a/app/routes/info.py
+++ b/app/routes/info.py
@@ -827,9 +827,12 @@ def _sse_batch_from_verify_stream(
                     nonlocal final_result
                     try:
                         async for update in cfg.service().verify_stream(path):
-                            await queue.put(update)
+                            # Record the terminal result before enqueueing so a
+                            # consumer that breaks on the "complete"/"error"
+                            # event can't cancel this task mid-update.
                             if update.get("type") in ("complete", "error"):
                                 final_result = update
+                            await queue.put(update)
                     except Exception as exc:
                         final_result = {
                             "type": "error",

--- a/app/routes/info.py
+++ b/app/routes/info.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import time
+from dataclasses import dataclass
 
 from config import settings
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
@@ -26,6 +27,8 @@ from services.dolphin_tool import (
     DOLPHIN_CONVERTIBLE_EXTENSIONS,
     dolphin_tool_service,
 )
+from services.tools import registry
+from services.tools.base import ToolPlugin
 from services.workload_limiter import WorkloadToken, workload_limiter
 from services.job_manager import ExternalJobCancelled, job_manager
 from services.z3ds_compress import Z3DS_CONVERTIBLE_EXTENSIONS, z3ds_compress_service
@@ -347,322 +350,6 @@ def _is_z3ds_info_file(path: str) -> bool:
     return ext in Z3DS_INFO_EXTENSIONS
 
 
-def _is_z3ds_verify_file(path: str) -> bool:
-    ext = os.path.splitext(path)[1].lower()
-    return ext in Z3DS_VERIFY_EXTENSIONS
-
-
-@router.post("/z3ds-verify-batch/events")
-async def verify_z3ds_batch_events(
-    request: BulkVerifyRequest,
-) -> EventSourceResponse:
-    """Stream verification progress for multiple 3DS files."""
-    if not request.paths:
-        raise HTTPException(status_code=400, detail="No paths provided")
-
-    # Validate all paths upfront
-    valid_paths = []
-    for path in request.paths:
-        if not await run_in_threadpool(
-            is_within_configured_volumes, path, treat_archives=False
-        ):
-            continue
-        if not await run_in_threadpool(os.path.isfile, path):
-            continue
-        if not _is_z3ds_verify_file(path):
-            continue
-        valid_paths.append(path)
-
-    verify_token = await _acquire_verify_lane_or_429()
-
-    async def event_generator():
-        try:
-            total = len(valid_paths)
-            verified_count = 0
-            failed_count = 0
-
-            # Send initial status
-            yield {
-                "event": "verify_batch_start",
-                "data": json.dumps({"total": total, "paths": valid_paths}),
-            }
-
-            for idx, path in enumerate(valid_paths):
-                filename = os.path.basename(path)
-                start = time.monotonic()
-
-                # Send file start event
-                yield {
-                    "event": "verify_batch_progress",
-                    "data": json.dumps(
-                        {
-                            "index": idx,
-                            "total": total,
-                            "path": path,
-                            "filename": filename,
-                            "status": "verifying",
-                            "verified": verified_count,
-                            "failed": failed_count,
-                        }
-                    ),
-                }
-
-                try:
-                    queue: asyncio.Queue = asyncio.Queue()
-                    done = asyncio.Event()
-                    final_result = {"valid": False, "message": "Unknown error"}
-
-                    async def run_verify():
-                        nonlocal final_result
-                        try:
-                            async for update in z3ds_compress_service.verify_stream(path):
-                                if update.get("type") in ("complete", "error"):
-                                    final_result = update
-                                await queue.put(update)
-                        except Exception as exc:
-                            final_result = {
-                                "type": "error",
-                                "valid": False,
-                                "message": str(exc),
-                            }
-                            await queue.put(final_result)
-                        finally:
-                            done.set()
-
-                    verify_task = asyncio.create_task(run_verify())
-                    try:
-                        while not done.is_set() or not queue.empty():
-                            try:
-                                update = await asyncio.wait_for(queue.get(), timeout=2)
-                                if update.get("type") == "progress":
-                                    yield {
-                                        "event": "verify_batch_file_progress",
-                                        "data": json.dumps(
-                                            {
-                                                "index": idx,
-                                                "path": path,
-                                                "filename": filename,
-                                                "progress": update.get("progress"),
-                                                "message": update.get("message"),
-                                            }
-                                        ),
-                                    }
-                                elif update.get("type") in ("complete", "error"):
-                                    final_result = update
-                                    break
-                            except asyncio.TimeoutError:
-                                elapsed = int(time.monotonic() - start)
-                                yield {
-                                    "event": "verify_batch_file_progress",
-                                    "data": json.dumps(
-                                        {
-                                            "index": idx,
-                                            "path": path,
-                                            "filename": filename,
-                                            "progress": None,
-                                            "message": f"Verifying... ({elapsed}s)",
-                                        }
-                                    ),
-                                }
-                    finally:
-                        verify_task.cancel()
-                        with contextlib.suppress(asyncio.CancelledError):
-                            await verify_task
-
-                    if final_result.get("valid"):
-                        await verification_store.mark_verified(path)
-                        verified_count += 1
-                        status = "verified"
-                    else:
-                        failed_count += 1
-                        status = "failed"
-
-                    yield {
-                        "event": "verify_batch_file_complete",
-                        "data": json.dumps(
-                            {
-                                "index": idx,
-                                "path": path,
-                                "filename": filename,
-                                "status": status,
-                                "valid": final_result.get("valid", False),
-                                "message": final_result.get("message"),
-                                "verified": verified_count,
-                                "failed": failed_count,
-                            }
-                        ),
-                    }
-
-                except Exception as exc:
-                    failed_count += 1
-                    yield {
-                        "event": "verify_batch_file_complete",
-                        "data": json.dumps(
-                            {
-                                "index": idx,
-                                "path": path,
-                                "filename": filename,
-                                "status": "failed",
-                                "valid": False,
-                                "message": str(exc),
-                                "verified": verified_count,
-                                "failed": failed_count,
-                            }
-                        ),
-                    }
-
-            # Send final completion event
-            yield {
-                "event": "verify_batch_complete",
-                "data": json.dumps(
-                    {"total": total, "verified": verified_count, "failed": failed_count}
-                ),
-            }
-        finally:
-            verify_token.release()
-
-    return EventSourceResponse(event_generator())
-
-
-@router.get("/z3ds-verify")
-async def verify_z3ds(
-    path: str = Query(
-        ..., description="Path to compressed 3DS ROM file to verify",
-    ),
-) -> dict:
-    """Verify the integrity of a compressed 3DS ROM file."""
-    if not await run_in_threadpool(
-        is_within_configured_volumes, path, treat_archives=False,
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail="Access denied: path outside configured volumes",
-        )
-    if not await run_in_threadpool(os.path.isfile, path):
-        raise HTTPException(status_code=404, detail="File not found")
-    if not _is_z3ds_verify_file(path):
-        raise HTTPException(
-            status_code=400,
-            detail="Not a supported compressed 3DS format (.z3ds, .zcci, .zcia)",
-        )
-
-    verify_token = await _acquire_verify_lane_or_429()
-    try:
-        result = await z3ds_compress_service.verify(path)
-        if result.get("valid"):
-            await verification_store.mark_verified(path)
-        return result
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to verify 3DS ROM: {e!s}",
-        ) from None
-    finally:
-        verify_token.release()
-
-
-@router.get("/z3ds-verify/events")
-async def verify_z3ds_events(
-    path: str = Query(
-        ..., description="Path to compressed 3DS ROM file to verify",
-    ),
-) -> EventSourceResponse:
-    """Stream 3DS ROM verification progress updates."""
-    if not await run_in_threadpool(
-        is_within_configured_volumes, path, treat_archives=False,
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail="Access denied: path outside configured volumes",
-        )
-    if not await run_in_threadpool(os.path.isfile, path):
-        raise HTTPException(status_code=404, detail="File not found")
-    if not _is_z3ds_verify_file(path):
-        raise HTTPException(
-            status_code=400,
-            detail="Not a supported compressed 3DS format (.z3ds, .zcci, .zcia)",
-        )
-
-    async def event_generator():
-        verify_token = await workload_limiter.try_acquire("verify")
-        if verify_token is None:
-            yield {
-                "event": "verify_error",
-                "data": json.dumps(
-                    {
-                        "type": "error",
-                        "valid": False,
-                        "message": _verification_backpressure_detail(),
-                    },
-                ),
-            }
-            return
-
-        queue: asyncio.Queue = asyncio.Queue()
-        done = asyncio.Event()
-        start = time.monotonic()
-
-        async def run_verify():
-            try:
-                async for update in z3ds_compress_service.verify_stream(path):
-                    await queue.put(update)
-            except Exception as exc:
-                await queue.put(
-                    {"type": "error", "valid": False, "message": str(exc)},
-                )
-            finally:
-                done.set()
-
-        verify_task = asyncio.create_task(run_verify())
-        try:
-            while True:
-                try:
-                    update = await asyncio.wait_for(
-                        queue.get(), timeout=2,
-                    )
-                except asyncio.TimeoutError:
-                    elapsed = int(time.monotonic() - start)
-                    yield {
-                        "event": "verify_progress",
-                        "data": json.dumps(
-                            {
-                                "progress": None,
-                                "message": f"Verifying... ({elapsed}s)",
-                            },
-                        ),
-                    }
-                    if done.is_set() and queue.empty():
-                        break
-                    continue
-
-                if update.get("type") == "progress":
-                    yield {
-                        "event": "verify_progress",
-                        "data": json.dumps(update),
-                    }
-                elif update.get("type") == "complete":
-                    if update.get("valid"):
-                        await verification_store.mark_verified(path)
-                    yield {
-                        "event": "verify_complete",
-                        "data": json.dumps(update),
-                    }
-                    break
-                elif update.get("type") == "error":
-                    yield {
-                        "event": "verify_error",
-                        "data": json.dumps(update),
-                    }
-                    break
-        finally:
-            verify_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await verify_task
-            verify_token.release()
-
-    return EventSourceResponse(event_generator())
-
-
 @router.get("/info", response_model=CHDInfo)
 async def get_chd_info(path: str = Query(..., description="Path to CHD file")):
     """Get information about a CHD file (cached with mtime-based invalidation)."""
@@ -840,49 +527,198 @@ async def get_scan_status():
     return {"scanning": _is_scanning}
 
 
-@router.get("/verify")
-async def verify_chd(
-    path: str = Query(..., description="Path to CHD file to verify"),
-) -> dict:
-    """Verify the integrity of a CHD file."""
-    if not await run_in_threadpool(is_within_configured_volumes, path, treat_archives=False):
-        raise HTTPException(
-            status_code=403, detail="Access denied: path outside configured volumes",
-        )
+@router.get("/verified")
+async def list_verified() -> dict:
+    """List verified output paths."""
+    await verification_store.prune_missing()
+    verified = []
+    for record in await verification_store.all_records():
+        chd_path = record.get("chd_path")
+        if chd_path and await run_in_threadpool(
+            is_within_configured_volumes, chd_path, treat_archives=False
+        ):
+            verified.append(chd_path)
+    return {"verified": verified}
 
+
+# ============ Dolphin disc image endpoints ============
+
+
+def _is_dolphin_file(path: str) -> bool:
+    from pathlib import Path as _P
+    return _P(path).suffix.lower() in DOLPHIN_INFO_EXTENSIONS
+
+
+@router.get("/dolphin-info", response_model=DolphinDiscInfo)
+async def get_dolphin_info(
+    path: str = Query(..., description="Path to disc image"),
+):
+    """Get header information about a GameCube/Wii disc image."""
+    if not await run_in_threadpool(
+        is_within_configured_volumes, path, treat_archives=False,
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: path outside configured volumes",
+        )
     if not await run_in_threadpool(os.path.isfile, path):
         raise HTTPException(status_code=404, detail="File not found")
+    if not _is_dolphin_file(path):
+        raise HTTPException(
+            status_code=400, detail="Not a supported disc image format",
+        )
 
-    if not path.lower().endswith(".chd"):
-        raise HTTPException(status_code=400, detail="Not a CHD file")
-
-    verify_token = await _acquire_verify_lane_or_429()
     try:
-        result = await chdman_service.verify(path)
-        if result.get("valid"):
-            await verification_store.mark_verified(path)
-        return result
+        info = await dolphin_tool_service.header(path)
+        return DolphinDiscInfo(
+            file=path,
+            game_id=info.get("game_id"),
+            # dolphin-tool outputs "Internal Name:" in its plain-text format;
+            # "game_name" / "name" cover any future JSON-mode keys.
+            game_name=info.get("game_name") or info.get("internal_name") or info.get("name"),
+            title_id=info.get("title_id"),
+            disc_number=info.get("disc_number") or info.get("disc"),
+            revision=info.get("revision"),
+            region=info.get("region"),
+            country=info.get("country"),
+            format=info.get("format"),
+            # dolphin-tool outputs "Compression Method:" in plain-text mode;
+            # "compression" covers any future JSON-mode key.
+            compression=info.get("compression") or info.get("compression_method"),
+            compression_level=info.get("compression_level"),
+            block_size=info.get("block_size"),
+            file_size=info.get("file_size"),
+            raw_data=info.get("raw_data", ""),
+        )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to verify CHD: {e!s}") from None
-    finally:
-        verify_token.release()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to read disc info: {e!s}",
+        ) from None
 
 
-@router.get("/verify/events")
-async def verify_chd_events(
-    path: str = Query(..., description="Path to CHD file to verify"),
-) -> EventSourceResponse:
-    """Stream CHD verification progress updates."""
-    if not await run_in_threadpool(is_within_configured_volumes, path, treat_archives=False):
+@router.get("/z3ds-info", response_model=Z3DSInfo)
+async def get_z3ds_info(
+    path: str = Query(..., description="Path to 3DS ROM file"),
+):
+    """Get basic information about a Nintendo 3DS ROM file."""
+    if not await run_in_threadpool(
+        is_within_configured_volumes, path, treat_archives=False,
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: path outside configured volumes",
+        )
+    if not await run_in_threadpool(os.path.isfile, path):
+        raise HTTPException(status_code=404, detail="File not found")
+    if not _is_z3ds_info_file(path):
+        raise HTTPException(
+            status_code=400,
+            detail="Not a supported 3DS ROM format (.3ds, .cci, .cia, .z3ds, .zcci, .zcia)",
+        )
+
+    try:
+        info = await run_in_threadpool(z3ds_compress_service.info, path)
+        return Z3DSInfo(
+            file=info["file"],
+            size=info["size"],
+            size_display=info["size_display"],
+            format=info.get("format"),
+            extension=info["extension"],
+            compressed=info["compressed"],
+            compression_type=info.get("compression_type"),
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to read 3DS ROM info: {e!s}",
+        ) from None
+
+
+# ============ Generic verify routes (registry-driven) ============
+#
+# The three tools expose identical verify machinery (sync verify, an SSE
+# progress stream, and a batch SSE stream). The only per-tool differences are
+# the URL prefix, the underlying service object, and a couple of error strings.
+# ``register_verify_routes`` generates the trio for any registered tool, and
+# the two ``_sse_*`` adapters hold the queue/heartbeat loop that used to be
+# copy-pasted once per endpoint.
+
+
+@dataclass(frozen=True)
+class _VerifyRouteConfig:
+    """Per-tool data the verify-route factory needs (no behavior branching)."""
+
+    url_prefix: str          # "" -> /verify, "dolphin-" -> /dolphin-verify, ...
+    service_attr: str        # module global the tests monkeypatch
+    sync_name: str           # FastAPI route name == legacy function name
+    events_name: str
+    batch_name: str
+    bad_ext_detail: str      # 400 detail when the extension is unsupported
+    verify_error_prefix: str  # 500 detail prefix raised by the sync endpoint
+
+
+_VERIFY_CONFIG: dict[str, _VerifyRouteConfig] = {
+    "chdman": _VerifyRouteConfig(
+        url_prefix="",
+        service_attr="chdman_service",
+        sync_name="verify_chd",
+        events_name="verify_chd_events",
+        batch_name="verify_batch_events",
+        bad_ext_detail="Not a CHD file",
+        verify_error_prefix="Failed to verify CHD",
+    ),
+    "dolphin": _VerifyRouteConfig(
+        url_prefix="dolphin-",
+        service_attr="dolphin_tool_service",
+        sync_name="verify_dolphin",
+        events_name="verify_dolphin_events",
+        batch_name="verify_dolphin_batch_events",
+        bad_ext_detail="Not a supported disc image format",
+        verify_error_prefix="Failed to verify disc image",
+    ),
+    "z3ds": _VerifyRouteConfig(
+        url_prefix="z3ds-",
+        service_attr="z3ds_compress_service",
+        sync_name="verify_z3ds",
+        events_name="verify_z3ds_events",
+        batch_name="verify_z3ds_batch_events",
+        bad_ext_detail="Not a supported compressed 3DS format (.z3ds, .zcci, .zcia)",
+        verify_error_prefix="Failed to verify 3DS ROM",
+    ),
+}
+
+
+def _verify_service(cfg: _VerifyRouteConfig):
+    """Resolve the verify service via the module global.
+
+    The route tests rebind ``info_routes.<service>`` to a mock, so the factory
+    must read the service through this module's namespace at call time rather
+    than capture the tool's own ``_service`` reference.
+    """
+    return globals()[cfg.service_attr]
+
+
+async def _guard_verify_path(
+    path: str, tool: ToolPlugin, cfg: _VerifyRouteConfig,
+) -> None:
+    """403 (outside volumes) -> 404 (missing) -> 400 (unsupported extension)."""
+    if not await run_in_threadpool(
+        is_within_configured_volumes, path, treat_archives=False,
+    ):
         raise HTTPException(
             status_code=403, detail="Access denied: path outside configured volumes",
         )
-
     if not await run_in_threadpool(os.path.isfile, path):
         raise HTTPException(status_code=404, detail="File not found")
+    if os.path.splitext(path)[1].lower() not in tool.verify_extensions:
+        raise HTTPException(status_code=400, detail=cfg.bad_ext_detail)
 
-    if not path.lower().endswith(".chd"):
-        raise HTTPException(status_code=400, detail="Not a CHD file")
+
+def _sse_from_verify_stream(
+    tool: ToolPlugin, cfg: _VerifyRouteConfig, path: str,
+) -> EventSourceResponse:
+    """Single-file verify SSE stream (verify_progress / verify_complete / verify_error)."""
 
     async def event_generator():
         verify_token = await workload_limiter.try_acquire("verify")
@@ -905,7 +741,7 @@ async def verify_chd_events(
 
         async def run_verify():
             try:
-                async for update in chdman_service.verify_stream(path):
+                async for update in _verify_service(cfg).verify_stream(path):
                     await queue.put(update)
             except Exception as exc:
                 await queue.put({"type": "error", "valid": False, "message": str(exc)})
@@ -948,38 +784,13 @@ async def verify_chd_events(
     return EventSourceResponse(event_generator())
 
 
-@router.get("/verified")
-async def list_verified() -> dict:
-    """List verified output paths."""
-    await verification_store.prune_missing()
-    verified = []
-    for record in await verification_store.all_records():
-        chd_path = record.get("chd_path")
-        if chd_path and await run_in_threadpool(
-            is_within_configured_volumes, chd_path, treat_archives=False
-        ):
-            verified.append(chd_path)
-    return {"verified": verified}
-
-
-@router.post("/verify-batch/events")
-async def verify_batch_events(request: BulkVerifyRequest) -> EventSourceResponse:
-    """Stream verification progress for multiple CHD files."""
-    if not request.paths:
-        raise HTTPException(status_code=400, detail="No paths provided")
-
-    # Validate all paths upfront
-    valid_paths = []
-    for path in request.paths:
-        if not await run_in_threadpool(is_within_configured_volumes, path, treat_archives=False):
-            continue
-        if not await run_in_threadpool(os.path.isfile, path):
-            continue
-        if not path.lower().endswith(".chd"):
-            continue
-        valid_paths.append(path)
-
-    verify_token = await _acquire_verify_lane_or_429()
+def _sse_batch_from_verify_stream(
+    tool: ToolPlugin,
+    cfg: _VerifyRouteConfig,
+    valid_paths: list[str],
+    verify_token: WorkloadToken,
+) -> EventSourceResponse:
+    """Batch verify SSE stream over an already-validated list of paths."""
 
     async def event_generator():
         total = len(valid_paths)
@@ -1018,10 +829,10 @@ async def verify_batch_events(request: BulkVerifyRequest) -> EventSourceResponse
                 done = asyncio.Event()
                 final_result = {"valid": False, "message": "Unknown error"}
 
-                async def run_verify():
+                async def run_verify(path=path):
                     nonlocal final_result
                     try:
-                        async for update in chdman_service.verify_stream(path):
+                        async for update in _verify_service(cfg).verify_stream(path):
                             await queue.put(update)
                             if update.get("type") in ("complete", "error"):
                                 final_result = update
@@ -1134,408 +945,66 @@ async def verify_batch_events(request: BulkVerifyRequest) -> EventSourceResponse
     return EventSourceResponse(wrapped_event_generator())
 
 
-# ============ Dolphin disc image endpoints ============
+def register_verify_routes(router_: APIRouter, tool: ToolPlugin) -> dict:
+    """Register the verify trio for ``tool`` and return the route functions.
 
+    Paths stay byte-identical via the ``tool_id -> url_prefix`` alias map, and
+    each route is named after its legacy handler so OpenAPI operation ids and
+    the module-level attribute names the tests rely on are preserved.
+    """
+    cfg = _VERIFY_CONFIG[tool.id]
+    prefix = cfg.url_prefix
 
-def _is_dolphin_file(path: str) -> bool:
-    from pathlib import Path as _P
-    return _P(path).suffix.lower() in DOLPHIN_INFO_EXTENSIONS
-
-
-@router.post("/dolphin-verify-batch/events")
-async def verify_dolphin_batch_events(
-    request: BulkVerifyRequest,
-) -> EventSourceResponse:
-    """Stream verification progress for multiple disc images."""
-    if not request.paths:
-        raise HTTPException(status_code=400, detail="No paths provided")
-
-    # Validate all paths upfront
-    valid_paths = []
-    for path in request.paths:
-        if not await run_in_threadpool(
-            is_within_configured_volumes, path, treat_archives=False
-        ):
-            continue
-        if not await run_in_threadpool(os.path.isfile, path):
-            continue
-        if not _is_dolphin_file(path):
-            continue
-        valid_paths.append(path)
-
-    verify_token = await _acquire_verify_lane_or_429()
-
-    async def event_generator():
-        total = len(valid_paths)
-        verified_count = 0
-        failed_count = 0
-
-        # Send initial status
-        yield {
-            "event": "verify_batch_start",
-            "data": json.dumps({"total": total, "paths": valid_paths}),
-        }
-
-        for idx, path in enumerate(valid_paths):
-            filename = os.path.basename(path)
-            start = time.monotonic()
-
-            # Send file start event
-            yield {
-                "event": "verify_batch_progress",
-                "data": json.dumps(
-                    {
-                        "index": idx,
-                        "total": total,
-                        "path": path,
-                        "filename": filename,
-                        "status": "verifying",
-                        "verified": verified_count,
-                        "failed": failed_count,
-                    }
-                ),
-            }
-
-            try:
-                queue: asyncio.Queue = asyncio.Queue()
-                done = asyncio.Event()
-                final_result = {"valid": False, "message": "Unknown error"}
-
-                async def run_verify():
-                    nonlocal final_result
-                    try:
-                        async for update in dolphin_tool_service.verify_stream(path):
-                            await queue.put(update)
-                            if update.get("type") in ("complete", "error"):
-                                final_result = update
-                    except Exception as exc:
-                        final_result = {
-                            "type": "error",
-                            "valid": False,
-                            "message": str(exc),
-                        }
-                        await queue.put(final_result)
-                    finally:
-                        done.set()
-
-                verify_task = asyncio.create_task(run_verify())
-                try:
-                    while not done.is_set() or not queue.empty():
-                        try:
-                            update = await asyncio.wait_for(queue.get(), timeout=2)
-                            if update.get("type") == "progress":
-                                yield {
-                                    "event": "verify_batch_file_progress",
-                                    "data": json.dumps(
-                                        {
-                                            "index": idx,
-                                            "path": path,
-                                            "filename": filename,
-                                            "progress": update.get("progress"),
-                                            "message": update.get("message"),
-                                        }
-                                    ),
-                                }
-                            elif update.get("type") in ("complete", "error"):
-                                break
-                        except asyncio.TimeoutError:
-                            elapsed = int(time.monotonic() - start)
-                            yield {
-                                "event": "verify_batch_file_progress",
-                                "data": json.dumps(
-                                    {
-                                        "index": idx,
-                                        "path": path,
-                                        "filename": filename,
-                                        "progress": None,
-                                        "message": f"Verifying... ({elapsed}s)",
-                                    }
-                                ),
-                            }
-                finally:
-                    verify_task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await verify_task
-
-                if final_result.get("valid"):
-                    await verification_store.mark_verified(path)
-                    verified_count += 1
-                    status = "verified"
-                else:
-                    failed_count += 1
-                    status = "failed"
-
-                yield {
-                    "event": "verify_batch_file_complete",
-                    "data": json.dumps(
-                        {
-                            "index": idx,
-                            "path": path,
-                            "filename": filename,
-                            "status": status,
-                            "valid": final_result.get("valid", False),
-                            "message": final_result.get("message"),
-                            "verified": verified_count,
-                            "failed": failed_count,
-                        }
-                    ),
-                }
-
-            except Exception as exc:
-                failed_count += 1
-                yield {
-                    "event": "verify_batch_file_complete",
-                    "data": json.dumps(
-                        {
-                            "index": idx,
-                            "path": path,
-                            "filename": filename,
-                            "status": "failed",
-                            "valid": False,
-                            "message": str(exc),
-                            "verified": verified_count,
-                            "failed": failed_count,
-                        }
-                    ),
-                }
-
-        # Send final completion event
-        yield {
-            "event": "verify_batch_complete",
-            "data": json.dumps(
-                {"total": total, "verified": verified_count, "failed": failed_count}
-            ),
-        }
-
-    async def wrapped_event_generator():
+    @router_.get(f"/{prefix}verify", name=cfg.sync_name)
+    async def _verify(path: str = Query(..., description="Path to file to verify")) -> dict:
+        await _guard_verify_path(path, tool, cfg)
+        verify_token = await _acquire_verify_lane_or_429()
         try:
-            async for event in event_generator():
-                yield event
+            result = await _verify_service(cfg).verify(path)
+            if result.get("valid"):
+                await verification_store.mark_verified(path)
+            return result
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"{cfg.verify_error_prefix}: {e!s}",
+            ) from None
         finally:
             verify_token.release()
 
-    return EventSourceResponse(wrapped_event_generator())
+    @router_.get(f"/{prefix}verify/events", name=cfg.events_name)
+    async def _verify_events(
+        path: str = Query(..., description="Path to file to verify"),
+    ) -> EventSourceResponse:
+        await _guard_verify_path(path, tool, cfg)
+        return _sse_from_verify_stream(tool, cfg, path)
+
+    @router_.post(f"/{prefix}verify-batch/events", name=cfg.batch_name)
+    async def _verify_batch(request: BulkVerifyRequest) -> EventSourceResponse:
+        if not request.paths:
+            raise HTTPException(status_code=400, detail="No paths provided")
+
+        valid_paths = []
+        for path in request.paths:
+            if not await run_in_threadpool(
+                is_within_configured_volumes, path, treat_archives=False,
+            ):
+                continue
+            if not await run_in_threadpool(os.path.isfile, path):
+                continue
+            if os.path.splitext(path)[1].lower() not in tool.verify_extensions:
+                continue
+            valid_paths.append(path)
+
+        verify_token = await _acquire_verify_lane_or_429()
+        return _sse_batch_from_verify_stream(tool, cfg, valid_paths, verify_token)
+
+    return {
+        cfg.sync_name: _verify,
+        cfg.events_name: _verify_events,
+        cfg.batch_name: _verify_batch,
+    }
 
 
-@router.get("/dolphin-info", response_model=DolphinDiscInfo)
-async def get_dolphin_info(
-    path: str = Query(..., description="Path to disc image"),
-):
-    """Get header information about a GameCube/Wii disc image."""
-    if not await run_in_threadpool(
-        is_within_configured_volumes, path, treat_archives=False,
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail="Access denied: path outside configured volumes",
-        )
-    if not await run_in_threadpool(os.path.isfile, path):
-        raise HTTPException(status_code=404, detail="File not found")
-    if not _is_dolphin_file(path):
-        raise HTTPException(
-            status_code=400, detail="Not a supported disc image format",
-        )
-
-    try:
-        info = await dolphin_tool_service.header(path)
-        return DolphinDiscInfo(
-            file=path,
-            game_id=info.get("game_id"),
-            # dolphin-tool outputs "Internal Name:" in its plain-text format;
-            # "game_name" / "name" cover any future JSON-mode keys.
-            game_name=info.get("game_name") or info.get("internal_name") or info.get("name"),
-            title_id=info.get("title_id"),
-            disc_number=info.get("disc_number") or info.get("disc"),
-            revision=info.get("revision"),
-            region=info.get("region"),
-            country=info.get("country"),
-            format=info.get("format"),
-            # dolphin-tool outputs "Compression Method:" in plain-text mode;
-            # "compression" covers any future JSON-mode key.
-            compression=info.get("compression") or info.get("compression_method"),
-            compression_level=info.get("compression_level"),
-            block_size=info.get("block_size"),
-            file_size=info.get("file_size"),
-            raw_data=info.get("raw_data", ""),
-        )
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to read disc info: {e!s}",
-        ) from None
-
-
-@router.get("/dolphin-verify")
-async def verify_dolphin(
-    path: str = Query(
-        ..., description="Path to disc image to verify",
-    ),
-) -> dict:
-    """Verify the integrity of a GameCube/Wii disc image."""
-    if not await run_in_threadpool(
-        is_within_configured_volumes, path, treat_archives=False,
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail="Access denied: path outside configured volumes",
-        )
-    if not await run_in_threadpool(os.path.isfile, path):
-        raise HTTPException(status_code=404, detail="File not found")
-    if not _is_dolphin_file(path):
-        raise HTTPException(
-            status_code=400, detail="Not a supported disc image format",
-        )
-
-    verify_token = await _acquire_verify_lane_or_429()
-    try:
-        result = await dolphin_tool_service.verify(path)
-        if result.get("valid"):
-            await verification_store.mark_verified(path)
-        return result
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to verify disc image: {e!s}",
-        ) from None
-    finally:
-        verify_token.release()
-
-
-@router.get("/dolphin-verify/events")
-async def verify_dolphin_events(
-    path: str = Query(
-        ..., description="Path to disc image to verify",
-    ),
-) -> EventSourceResponse:
-    """Stream disc image verification progress updates."""
-    if not await run_in_threadpool(
-        is_within_configured_volumes, path, treat_archives=False,
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail="Access denied: path outside configured volumes",
-        )
-    if not await run_in_threadpool(os.path.isfile, path):
-        raise HTTPException(status_code=404, detail="File not found")
-    if not _is_dolphin_file(path):
-        raise HTTPException(
-            status_code=400, detail="Not a supported disc image format",
-        )
-
-    async def event_generator():
-        verify_token = await workload_limiter.try_acquire("verify")
-        if verify_token is None:
-            yield {
-                "event": "verify_error",
-                "data": json.dumps(
-                    {
-                        "type": "error",
-                        "valid": False,
-                        "message": _verification_backpressure_detail(),
-                    },
-                ),
-            }
-            return
-
-        queue: asyncio.Queue = asyncio.Queue()
-        done = asyncio.Event()
-        start = time.monotonic()
-
-        async def run_verify():
-            try:
-                async for update in dolphin_tool_service.verify_stream(
-                    path,
-                ):
-                    await queue.put(update)
-            except Exception as exc:
-                await queue.put(
-                    {"type": "error", "valid": False, "message": str(exc)},
-                )
-            finally:
-                done.set()
-
-        verify_task = asyncio.create_task(run_verify())
-        try:
-            while True:
-                try:
-                    update = await asyncio.wait_for(
-                        queue.get(), timeout=2,
-                    )
-                except asyncio.TimeoutError:
-                    elapsed = int(time.monotonic() - start)
-                    yield {
-                        "event": "verify_progress",
-                        "data": json.dumps(
-                            {
-                                "progress": None,
-                                "message": f"Verifying... ({elapsed}s)",
-                            },
-                        ),
-                    }
-                    if done.is_set() and queue.empty():
-                        break
-                    continue
-
-                if update.get("type") == "progress":
-                    yield {
-                        "event": "verify_progress",
-                        "data": json.dumps(update),
-                    }
-                elif update.get("type") == "complete":
-                    if update.get("valid"):
-                        await verification_store.mark_verified(path)
-                    yield {
-                        "event": "verify_complete",
-                        "data": json.dumps(update),
-                    }
-                    break
-                elif update.get("type") == "error":
-                    yield {
-                        "event": "verify_error",
-                        "data": json.dumps(update),
-                    }
-                    break
-        finally:
-            verify_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await verify_task
-            verify_token.release()
-
-    return EventSourceResponse(event_generator())
-
-@router.get("/z3ds-info", response_model=Z3DSInfo)
-async def get_z3ds_info(
-    path: str = Query(..., description="Path to 3DS ROM file"),
-):
-    """Get basic information about a Nintendo 3DS ROM file."""
-    if not await run_in_threadpool(
-        is_within_configured_volumes, path, treat_archives=False,
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail="Access denied: path outside configured volumes",
-        )
-    if not await run_in_threadpool(os.path.isfile, path):
-        raise HTTPException(status_code=404, detail="File not found")
-    if not _is_z3ds_info_file(path):
-        raise HTTPException(
-            status_code=400,
-            detail="Not a supported 3DS ROM format (.3ds, .cci, .cia, .z3ds, .zcci, .zcia)",
-        )
-
-    try:
-        info = await run_in_threadpool(z3ds_compress_service.info, path)
-        return Z3DSInfo(
-            file=info["file"],
-            size=info["size"],
-            size_display=info["size_display"],
-            format=info.get("format"),
-            extension=info["extension"],
-            compressed=info["compressed"],
-            compression_type=info.get("compression_type"),
-        )
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to read 3DS ROM info: {e!s}",
-        ) from None
+for _tool in registry.all():
+    if _tool.id in _VERIFY_CONFIG:
+        globals().update(register_verify_routes(router, _tool))

--- a/tests/test_verify_routes_factory.py
+++ b/tests/test_verify_routes_factory.py
@@ -8,6 +8,7 @@ and the sync 429 / SSE ``verify_error`` backpressure behavior.
 import asyncio
 import json
 import re
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -53,15 +54,21 @@ _TOOLS = {
 }
 
 
+_VERIFY_PATH_RE = re.compile(r"^/(?:dolphin-|z3ds-)?verify(?:-batch)?(?:/events)?$")
+
+
 def test_verify_route_table_is_byte_identical():
-    """Every verify URL path, HTTP method, and route name must be present."""
+    """The verify URL paths, HTTP methods, and route names must match exactly."""
     actual = set()
     for route in info_routes.router.routes:
-        methods = getattr(route, "methods", None) or set()
-        for method in methods:
+        if not _VERIFY_PATH_RE.fullmatch(route.path):
+            continue
+        for method in getattr(route, "methods", None) or set():
             actual.add((route.path, method, route.name))
-    missing = _EXPECTED_VERIFY_ROUTES - actual
-    assert not missing, f"missing verify routes: {missing}"
+    assert actual == _EXPECTED_VERIFY_ROUTES, (
+        f"missing: {_EXPECTED_VERIFY_ROUTES - actual}; "
+        f"unexpected: {actual - _EXPECTED_VERIFY_ROUTES}"
+    )
 
 
 @pytest.fixture
@@ -146,7 +153,7 @@ async def test_batch_sse_event_shape_snapshot(tool_id, verify_env, monkeypatch):
     response = await batch_fn(BulkVerifyRequest(paths=[path]))
     events = await _collect(response)
 
-    filename = path.rsplit("/", 1)[-1]
+    filename = Path(path).name
     assert events == [
         {"event": "verify_batch_start",
          "data": json.dumps({"total": 1, "paths": [path]})},
@@ -174,7 +181,7 @@ async def test_sse_heartbeat_shape(tool_id, verify_env, monkeypatch):
     service = Mock()
 
     async def stalled_stream(path):
-        await asyncio.sleep(5)
+        await asyncio.sleep(2.5)
         yield {"type": "complete", "valid": True, "message": "done"}
 
     service.verify_stream = stalled_stream

--- a/tests/test_verify_routes_factory.py
+++ b/tests/test_verify_routes_factory.py
@@ -1,0 +1,244 @@
+"""Parity tests for the registry-driven verify route factory (Phase 6).
+
+These lock the wire contract that ``register_verify_routes`` regenerates:
+the exact URL paths/methods, the SSE event names + JSON payloads (including
+the 2-second heartbeat), the ``verification_store.mark_verified`` side-effect,
+and the sync 429 / SSE ``verify_error`` backpressure behavior.
+"""
+import asyncio
+import json
+import re
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app.routes import info as info_routes
+
+# (path, method, route_name) for every verify endpoint the factory generates.
+_EXPECTED_VERIFY_ROUTES = {
+    ("/verify", "GET", "verify_chd"),
+    ("/verify/events", "GET", "verify_chd_events"),
+    ("/verify-batch/events", "POST", "verify_batch_events"),
+    ("/dolphin-verify", "GET", "verify_dolphin"),
+    ("/dolphin-verify/events", "GET", "verify_dolphin_events"),
+    ("/dolphin-verify-batch/events", "POST", "verify_dolphin_batch_events"),
+    ("/z3ds-verify", "GET", "verify_z3ds"),
+    ("/z3ds-verify/events", "GET", "verify_z3ds_events"),
+    ("/z3ds-verify-batch/events", "POST", "verify_z3ds_batch_events"),
+}
+
+# tool id -> (verify extension, service module-global, function-name stems)
+_TOOLS = {
+    "chdman": {
+        "ext": ".chd",
+        "service_attr": "chdman_service",
+        "sync": "verify_chd",
+        "events": "verify_chd_events",
+        "batch": "verify_batch_events",
+    },
+    "dolphin": {
+        "ext": ".iso",
+        "service_attr": "dolphin_tool_service",
+        "sync": "verify_dolphin",
+        "events": "verify_dolphin_events",
+        "batch": "verify_dolphin_batch_events",
+    },
+    "z3ds": {
+        "ext": ".z3ds",
+        "service_attr": "z3ds_compress_service",
+        "sync": "verify_z3ds",
+        "events": "verify_z3ds_events",
+        "batch": "verify_z3ds_batch_events",
+    },
+}
+
+
+def test_verify_route_table_is_byte_identical():
+    """Every verify URL path, HTTP method, and route name must be present."""
+    actual = set()
+    for route in info_routes.router.routes:
+        methods = getattr(route, "methods", None) or set()
+        for method in methods:
+            actual.add((route.path, method, route.name))
+    missing = _EXPECTED_VERIFY_ROUTES - actual
+    assert not missing, f"missing verify routes: {missing}"
+
+
+@pytest.fixture
+def verify_env(tmp_path, monkeypatch):
+    """Allow tmp_path as a configured volume and stub the verification store."""
+    monkeypatch.setattr(info_routes.settings, "chd_volumes", str(tmp_path))
+    monkeypatch.setattr(info_routes.settings, "data_mount_root", str(tmp_path))
+    store = Mock()
+    store.mark_verified = AsyncMock()
+    monkeypatch.setattr(info_routes, "verification_store", store)
+    return {"tmp_path": tmp_path, "store": store}
+
+
+def _make_file(tmp_path, ext):
+    target = tmp_path / f"sample{ext}"
+    target.write_text("payload")
+    return str(target)
+
+
+def _install_stream(monkeypatch, service_attr, updates):
+    """Bind a mock service whose verify_stream yields a scripted sequence."""
+    service = Mock()
+
+    async def fake_verify_stream(path):
+        for update in updates:
+            yield update
+
+    async def fake_verify(path):
+        return {"valid": True, "message": "verified successfully"}
+
+    service.verify_stream = fake_verify_stream
+    service.verify = fake_verify
+    monkeypatch.setattr(info_routes, service_attr, service)
+    return service
+
+
+async def _collect(response):
+    events = []
+    async for event in response.body_iterator:
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+@pytest.mark.parametrize("tool_id", list(_TOOLS))
+@pytest.mark.asyncio
+async def test_sse_event_shape_snapshot(tool_id, verify_env, monkeypatch):
+    """The single-file SSE stream emits the exact pre-refactor event sequence."""
+    spec = _TOOLS[tool_id]
+    path = _make_file(verify_env["tmp_path"], spec["ext"])
+    updates = [
+        {"type": "progress", "progress": 42, "message": "working"},
+        {"type": "complete", "valid": True, "message": "done"},
+    ]
+    _install_stream(monkeypatch, spec["service_attr"], updates)
+
+    events_fn = getattr(info_routes, spec["events"])
+    events = await _collect(await events_fn(path=path))
+
+    assert events == [
+        {"event": "verify_progress", "data": json.dumps(updates[0])},
+        {"event": "verify_complete", "data": json.dumps(updates[1])},
+    ]
+    verify_env["store"].mark_verified.assert_called_once_with(path)
+
+
+@pytest.mark.parametrize("tool_id", list(_TOOLS))
+@pytest.mark.asyncio
+async def test_batch_sse_event_shape_snapshot(tool_id, verify_env, monkeypatch):
+    """The batch SSE stream emits the exact pre-refactor event sequence."""
+    from models import BulkVerifyRequest
+
+    spec = _TOOLS[tool_id]
+    path = _make_file(verify_env["tmp_path"], spec["ext"])
+    updates = [
+        {"type": "progress", "progress": 42, "message": "working"},
+        {"type": "complete", "valid": True, "message": "done"},
+    ]
+    _install_stream(monkeypatch, spec["service_attr"], updates)
+
+    batch_fn = getattr(info_routes, spec["batch"])
+    response = await batch_fn(BulkVerifyRequest(paths=[path]))
+    events = await _collect(response)
+
+    filename = path.rsplit("/", 1)[-1]
+    assert events == [
+        {"event": "verify_batch_start",
+         "data": json.dumps({"total": 1, "paths": [path]})},
+        {"event": "verify_batch_progress", "data": json.dumps({
+            "index": 0, "total": 1, "path": path, "filename": filename,
+            "status": "verifying", "verified": 0, "failed": 0})},
+        {"event": "verify_batch_file_progress", "data": json.dumps({
+            "index": 0, "path": path, "filename": filename,
+            "progress": 42, "message": "working"})},
+        {"event": "verify_batch_file_complete", "data": json.dumps({
+            "index": 0, "path": path, "filename": filename, "status": "verified",
+            "valid": True, "message": "done", "verified": 1, "failed": 0})},
+        {"event": "verify_batch_complete", "data": json.dumps({
+            "total": 1, "verified": 1, "failed": 0})},
+    ]
+    verify_env["store"].mark_verified.assert_called_once_with(path)
+
+
+@pytest.mark.parametrize("tool_id", list(_TOOLS))
+@pytest.mark.asyncio
+async def test_sse_heartbeat_shape(tool_id, verify_env, monkeypatch):
+    """A stalled stream emits the 2-second heartbeat with a null progress."""
+    spec = _TOOLS[tool_id]
+    path = _make_file(verify_env["tmp_path"], spec["ext"])
+    service = Mock()
+
+    async def stalled_stream(path):
+        await asyncio.sleep(5)
+        yield {"type": "complete", "valid": True, "message": "done"}
+
+    service.verify_stream = stalled_stream
+    monkeypatch.setattr(info_routes, spec["service_attr"], service)
+
+    events_fn = getattr(info_routes, spec["events"])
+    response = await events_fn(path=path)
+
+    heartbeat = None
+    async for event in response.body_iterator:
+        if isinstance(event, dict) and event.get("event") == "verify_progress":
+            heartbeat = event
+            break
+    await response.body_iterator.aclose()
+
+    assert heartbeat is not None
+    payload = json.loads(heartbeat["data"])
+    assert payload["progress"] is None
+    assert re.fullmatch(r"Verifying\.\.\. \(\d+s\)", payload["message"])
+
+
+@pytest.mark.parametrize("tool_id", list(_TOOLS))
+@pytest.mark.asyncio
+async def test_sync_verify_returns_429_when_lane_saturated(
+    tool_id, verify_env, monkeypatch,
+):
+    """The sync verify endpoint fails fast with 429 when the lane is full."""
+    from fastapi import HTTPException
+
+    spec = _TOOLS[tool_id]
+    path = _make_file(verify_env["tmp_path"], spec["ext"])
+    _install_stream(monkeypatch, spec["service_attr"], [])
+    monkeypatch.setattr(
+        info_routes.workload_limiter, "try_acquire", AsyncMock(return_value=None),
+    )
+
+    sync_fn = getattr(info_routes, spec["sync"])
+    with pytest.raises(HTTPException) as exc_info:
+        await sync_fn(path=path)
+    assert exc_info.value.status_code == 429
+    assert "capacity" in exc_info.value.detail.lower()
+
+
+@pytest.mark.parametrize("tool_id", list(_TOOLS))
+@pytest.mark.asyncio
+async def test_sse_emits_verify_error_when_lane_saturated(
+    tool_id, verify_env, monkeypatch,
+):
+    """The SSE stream emits verify_error (not 429) when the lane is full."""
+    spec = _TOOLS[tool_id]
+    path = _make_file(verify_env["tmp_path"], spec["ext"])
+    _install_stream(monkeypatch, spec["service_attr"], [])
+    monkeypatch.setattr(
+        info_routes.workload_limiter, "try_acquire", AsyncMock(return_value=None),
+    )
+
+    events_fn = getattr(info_routes, spec["events"])
+    events = await _collect(await events_fn(path=path))
+
+    assert len(events) == 1
+    assert events[0]["event"] == "verify_error"
+    payload = json.loads(events[0]["data"])
+    assert payload == {
+        "type": "error",
+        "valid": False,
+        "message": info_routes._verification_backpressure_detail(),
+    }


### PR DESCRIPTION
## Summary

Phase 6 of the tool-plugin refactor (`DESIGN_tool_plugin_architecture.md` §3.5). The three near-identical verify endpoint **trios** in `app/routes/info.py` (chdman / dolphin / z3ds — sync verify, SSE stream, batch SSE) are collapsed into **one registry-driven factory** plus two shared SSE adapters. Net `info.py` delta: **+250 / −781** (≈ −531 LOC).

### What changed

- **`register_verify_routes(router, tool)`** — generates the `/<prefix>verify`, `/<prefix>verify/events`, and `/<prefix>verify-batch/events` trio for any registered tool, and returns the route functions so they stay bound to their legacy module-level names.
- **`_sse_from_verify_stream` / `_sse_batch_from_verify_stream`** — the queue / done-event / 2-second-heartbeat machinery that was copy-pasted ~6× now lives in one place each.
- Registration is driven by the registry: `for tool in registry.all(): register_verify_routes(router, tool)`.

### `tool_id → url_prefix` alias map (paths stay byte-identical)

```
chdman  -> ""         => /verify, /verify/events, /verify-batch/events
dolphin -> "dolphin-" => /dolphin-verify, /dolphin-verify/events, /dolphin-verify-batch/events
z3ds    -> "z3ds-"    => /z3ds-verify, /z3ds-verify/events, /z3ds-verify-batch/events
```

### Parity confirmed (behavior-preserving)

- **URLs / methods / route names**: snapshotted before vs after — identical (new `test_verify_route_table_is_byte_identical`). CHD keeps the bare `/verify` (no `chd-` prefix).
- **SSE event names + payloads**: `verify_progress` / `verify_complete` / `verify_error`, the heartbeat `{"progress": null, "message": "Verifying... (Ns)"}`, and the batch events (`verify_batch_start` / `…_progress` / `…_file_progress` / `…_file_complete` / `…_complete`) are reproduced exactly — locked by per-tool snapshot tests.
- **`verification_store.mark_verified(path)`** fires on valid completion in all three code paths (sync, SSE complete branch, batch) for all tools.
- **Backpressure**: sync → `429` via `_acquire_verify_lane_or_429()`; SSE → `workload_limiter.try_acquire("verify")` returning `None` emits a `verify_error` with the same lane-capacity detail. Lane name and detail text unchanged.
- **Guards**: `is_within_configured_volumes(..., treat_archives=False)` → 403, `os.path.isfile` → 404, extension → 400, in the same order with the same status codes. The extension check now reads `tool.verify_extensions` (verified equivalent to the old `.chd` / dolphin-set / `.z3ds/.zcci/.zcia` checks). Per-tool 400 / 500 detail strings preserved.

### `info_routes.*_service` monkeypatch contract (nuance #1)

`tests/test_z3ds_routes.py` and `tests/test_dolphin_routes.py` rebind the **module global** (`monkeypatch.setattr(info_routes, "z3ds_compress_service", mock)`), not the tool's `self._service`. The factory therefore resolves the service through this module's namespace at call time (`_verify_service(cfg)` → `globals()[cfg.service_attr]`) rather than via `tool._service`. `test_metadata.py` patches `info_routes.chdman_service.info` (attribute on the shared singleton) and is unaffected. **No test edits were needed** — all existing route suites pass unchanged.

### Info endpoints — deferred

The three `info` endpoints (`/info`, `/dolphin-info`, `/z3ds-info`) are **left untouched**. They are not structurally identical (CHD's carries the metadata-cache + disc-ID logic; dolphin maps header fields; z3ds runs in a threadpool), so collapsing them would not be byte-identical and is out of scope for the −600 LOC verify win. The dead `_is_z3ds_verify_file` helper (only the verify routes used it) was removed; `_is_dolphin_file` / `_is_z3ds_info_file` remain for the info endpoints.

## Test plan

- [x] `PYTHONPATH=app pytest tests -q` — 566 passed (550 existing + 16 new)
- [x] Existing route suites pass unchanged: `test_z3ds_routes.py`, `test_dolphin_routes.py`, `test_metadata.py`, `test_dispatch_routing.py`, `test_external_job_api.py`
- [x] New `tests/test_verify_routes_factory.py`: route-table parity, per-tool single + batch SSE shape snapshots, heartbeat shape, sync 429, SSE `verify_error` on saturation
- [x] `ruff check app tests` clean
- [x] `pylint app/routes/info.py tests/test_verify_routes_factory.py` → 10.00/10

https://claude.ai/code/session_016iKoDpSqHWTYjQC7ft41xp

---
_Generated by [Claude Code](https://claude.ai/code/session_016iKoDpSqHWTYjQC7ft41xp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/verified` endpoint to list all verified files within configured volumes, automatically removing missing records

* **Improvements**
  * Unified verification system across all supported tools for consistent operation and behavior
  * Enhanced verification request handling during periods of high load

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacnpal/compressatorium/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->