### PR TITLE
feat: registry-driven FileEntry outputs in files.py (Phase 7)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -39,6 +39,14 @@ class JobStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
+class OutputStatus(BaseModel):
+    """A sibling output a tool could produce for a given input file."""
+    tool_id: str
+    exists: bool          # finished output file present on disk
+    ready: bool           # present and not mid-conversion
+    path: str | None = None
+
+
 class FileEntry(BaseModel):
     name: str
     path: str
@@ -60,6 +68,8 @@ class FileEntry(BaseModel):
     archive_has_chd: int | None = None
     archive_truncated: bool | None = None
     media_type: str | None = None  # "dvd", "cd", or None - for CHD files
+    convertible_by: list[str] = []   # tool ids whose input_extensions accept this file
+    outputs: list[OutputStatus] = []  # detected sibling outputs, one per producing tool
 
 
 class DirectoryListing(BaseModel):

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -5,14 +5,12 @@ from pathlib import Path
 from config import settings
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.concurrency import run_in_threadpool
-from models import BulkDeleteRequest, DirectoryListing, FileEntry, Volume
+from models import BulkDeleteRequest, DirectoryListing, FileEntry, OutputStatus, Volume
 from services.archive import ARCHIVE_EXTENSIONS, archive_service
 from services.chd_metadata_store import chd_metadata_store
-from services.chdman import CONVERTIBLE_EXTENSIONS
-from services.dolphin_tool import DOLPHIN_CONVERTIBLE_EXTENSIONS, DOLPHIN_OUTPUT_FORMATS
-from services.z3ds_compress import Z3DS_CONVERTIBLE_EXTENSIONS, Z3DS_OUTPUT_FORMATS
 from services.job_manager import job_manager
 from services.lock_manager import lock_manager
+from services.tools import registry
 from services.verification_store import verification_store
 from utils.path_utils import (
     ensure_path_within_volumes,
@@ -22,58 +20,32 @@ from utils.path_utils import (
 
 router = APIRouter()
 logger = logging.getLogger("chd.files")
-DOLPHIN_OUTPUT_EXTENSIONS = tuple(
-    dict.fromkeys(ext for _, ext in DOLPHIN_OUTPUT_FORMATS.values()),
-)
 
 
 def _is_macos_metadata_entry(name: str) -> bool:
     return name == ".DS_Store" or name.startswith("._") or name == "__MACOSX"
 
 
-def _detect_z3ds_output_path(
-    item_path: str, source_ext: str,
-) -> tuple[bool, bool, str | None]:
-    """Check mapped 3DS output suffix and report presence + readiness."""
-    source = Path(item_path)
-    expected_ext = Z3DS_OUTPUT_FORMATS.get(source_ext)
-    if not expected_ext:
-        return False, False, None
+def _detect_file_outputs(
+    item_path: str, ext: str,
+) -> tuple[list[str], list[OutputStatus], dict[str, OutputStatus]]:
+    """Drive convertibility + output detection off the tool registry.
 
-    candidate_path = str(source.with_suffix(expected_ext))
-    file_exists, is_converting = lock_manager.check_file_status(candidate_path)
-    if file_exists or is_converting:
-        return True, file_exists, candidate_path
-
-    return False, False, None
-
-
-def _detect_dolphin_output_path(
-    item_path: str, source_ext: str,
-) -> tuple[bool, bool, str | None]:
-    """Check for Dolphin output siblings and report presence + readiness."""
-    source = Path(item_path)
-    candidate_paths: list[str] = []
-
-    if source_ext in DOLPHIN_OUTPUT_EXTENSIONS and source_ext != ".iso":
-        candidate_paths.append(str(source))
-
-    for output_ext in DOLPHIN_OUTPUT_EXTENSIONS:
-        if output_ext == source_ext:
-            continue
-        candidate_paths.append(str(source.with_suffix(output_ext)))
-
-    converting_path: str | None = None
-    for candidate_path in candidate_paths:
-        file_exists, is_converting = lock_manager.check_file_status(candidate_path)
-        if file_exists:
-            return True, True, candidate_path
-        if is_converting and converting_path is None:
-            converting_path = candidate_path
-
-    if converting_path:
-        return True, False, converting_path
-    return False, False, None
+    Returns the tool ids that accept this input, the detected sibling
+    outputs, and a ``{tool_id: OutputStatus}`` index used to derive the
+    legacy per-tool booleans from a single source of truth.
+    """
+    convertible_by: list[str] = []
+    outputs: list[OutputStatus] = []
+    by_tool: dict[str, OutputStatus] = {}
+    for tool in registry.all():
+        if ext in tool.input_extensions:
+            convertible_by.append(tool.id)
+        status = tool.detect_output(item_path)
+        if status is not None:
+            outputs.append(status)
+            by_tool[tool.id] = status
+    return convertible_by, outputs, by_tool
 
 
 async def _assert_path_not_in_use(path: str, *, is_dir: bool = False) -> None:
@@ -166,42 +138,31 @@ async def list_files(
                         )
                     elif os.path.isfile(item_path):
                         size = os.path.getsize(item_path)
-                        is_convertible = ext in CONVERTIBLE_EXTENSIONS
-                        is_dolphin_convertible = ext in DOLPHIN_CONVERTIBLE_EXTENSIONS
-                        is_z3ds_convertible = ext in Z3DS_CONVERTIBLE_EXTENSIONS
                         is_archive = ext in ARCHIVE_EXTENSIONS
                         archive_truncated = None
                         if is_archive and not show_archives_flag:
                             continue
 
-                        # Check if CHD already exists or is being converted (atomic check)
-                        has_chd = False
-                        has_rvz = False
-                        dolphin_ready = False
-                        dolphin_path = None
-                        chd_ready = False
-                        if is_convertible:
-                            chd_path = str(Path(item_path).with_suffix(".chd"))
-                            file_exists, is_converting = lock_manager.check_file_status(
-                                chd_path,
-                            )
-                            has_chd = file_exists or is_converting
-                            chd_ready = file_exists
-                        if is_dolphin_convertible:
-                            has_rvz, dolphin_ready, dolphin_path = _detect_dolphin_output_path(
-                                item_path,
-                                ext,
-                            )
-
-                        # Check if compressed 3DS file already exists or is being converted
-                        has_z3ds = False
-                        z3ds_ready = False
-                        z3ds_path = None
-                        if is_z3ds_convertible:
-                            has_z3ds, z3ds_ready, z3ds_path = _detect_z3ds_output_path(
-                                item_path,
-                                ext,
-                            )
+                        # Registry-driven convertibility + sibling-output
+                        # detection; the legacy booleans below are derived
+                        # from these so they can't drift.
+                        convertible_by, outputs, by_tool = _detect_file_outputs(
+                            item_path, ext,
+                        )
+                        is_convertible = "chdman" in convertible_by
+                        is_dolphin_convertible = "dolphin" in convertible_by
+                        is_z3ds_convertible = "z3ds" in convertible_by
+                        chd_status = by_tool.get("chdman")
+                        dolphin_status = by_tool.get("dolphin")
+                        z3ds_status = by_tool.get("z3ds")
+                        has_chd = chd_status is not None
+                        chd_ready = chd_status.exists if chd_status else False
+                        has_rvz = dolphin_status is not None
+                        dolphin_ready = dolphin_status.exists if dolphin_status else False
+                        dolphin_path = dolphin_status.path if dolphin_status else None
+                        has_z3ds = z3ds_status is not None
+                        z3ds_ready = z3ds_status.exists if z3ds_status else False
+                        z3ds_path = z3ds_status.path if z3ds_status else None
 
                         archive_items = None
                         archive_has_chd = None
@@ -251,6 +212,8 @@ async def list_files(
                             archive_truncated=archive_truncated
                             if is_archive and summarize_archives_flag
                             else None,
+                            convertible_by=convertible_by,
+                            outputs=outputs,
                         )
                         entries.append(entry)
                 except OSError:
@@ -312,45 +275,33 @@ async def search_files(
                             if recursive_scan and not os.path.islink(item_path):
                                 _scan(item_path)
                         elif os.path.isfile(item_path):
-                            if (
-                                ext in CONVERTIBLE_EXTENSIONS
-                                or ext in DOLPHIN_CONVERTIBLE_EXTENSIONS
-                                or ext in Z3DS_CONVERTIBLE_EXTENSIONS
-                            ):
-                                is_chd_convertible = ext in CONVERTIBLE_EXTENSIONS
-                                is_dolphin_convertible = (
-                                    ext in DOLPHIN_CONVERTIBLE_EXTENSIONS
+                            convertible_by, outputs, by_tool = _detect_file_outputs(
+                                item_path, ext,
+                            )
+                            if convertible_by:
+                                is_chd_convertible = "chdman" in convertible_by
+                                is_dolphin_convertible = "dolphin" in convertible_by
+                                is_z3ds_convertible = "z3ds" in convertible_by
+                                chd_status = by_tool.get("chdman")
+                                dolphin_status = by_tool.get("dolphin")
+                                z3ds_status = by_tool.get("z3ds")
+                                chd_path = (
+                                    str(Path(item_path).with_suffix(".chd"))
+                                    if is_chd_convertible
+                                    else None
                                 )
-                                is_z3ds_convertible = ext in Z3DS_CONVERTIBLE_EXTENSIONS
-                                chd_path = None
-                                has_chd = False
-                                has_rvz = False
-                                dolphin_ready = False
-                                dolphin_path = None
-                                chd_ready = False
-                                has_z3ds = False
-                                z3ds_ready = False
-                                z3ds_path = None
-                                if is_chd_convertible:
-                                    chd_path = str(Path(item_path).with_suffix(".chd"))
-                                    # Use atomic check to get both file existence and lock status
-                                    file_exists, is_converting = (
-                                        lock_manager.check_file_status(chd_path)
-                                    )
-                                    has_chd = file_exists or is_converting
-                                    chd_ready = file_exists
-                                if is_dolphin_convertible:
-                                    has_rvz, dolphin_ready, dolphin_path = (
-                                        _detect_dolphin_output_path(
-                                            item_path,
-                                            ext,
-                                        )
-                                    )
-                                if is_z3ds_convertible:
-                                    has_z3ds, z3ds_ready, z3ds_path = _detect_z3ds_output_path(
-                                        item_path,
-                                        ext,
-                                    )
+                                has_chd = chd_status is not None
+                                chd_ready = chd_status.exists if chd_status else False
+                                has_rvz = dolphin_status is not None
+                                dolphin_ready = (
+                                    dolphin_status.exists if dolphin_status else False
+                                )
+                                dolphin_path = (
+                                    dolphin_status.path if dolphin_status else None
+                                )
+                                has_z3ds = z3ds_status is not None
+                                z3ds_ready = z3ds_status.exists if z3ds_status else False
+                                z3ds_path = z3ds_status.path if z3ds_status else None
                                 files.append(
                                     {
                                         "name": item,
@@ -370,6 +321,8 @@ async def search_files(
                                         "z3ds_ready": z3ds_ready,
                                         "z3ds_path": z3ds_path,
                                         "in_archive": False,
+                                        "convertible_by": convertible_by,
+                                        "outputs": outputs,
                                     },
                                 )
                             elif include_archive_scan and ext in ARCHIVE_EXTENSIONS:
@@ -408,7 +361,8 @@ async def search_files(
                                             "dolphin_path": None,
                                             "chd_ready": file_exists,
                                             "convertible": (
-                                                entry.get("extension") in CONVERTIBLE_EXTENSIONS
+                                                entry.get("extension")
+                                                in registry.get("chdman").input_extensions
                                             ),
                                             "dolphin_convertible": False,
                                             "z3ds_ready": False,

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -145,10 +145,15 @@ async def list_files(
 
                         # Registry-driven convertibility + sibling-output
                         # detection; the legacy booleans below are derived
-                        # from these so they can't drift.
-                        convertible_by, outputs, by_tool = _detect_file_outputs(
-                            item_path, ext,
-                        )
+                        # from these so they can't drift. Archives are never
+                        # directly convertible (only their members are), so
+                        # skip detection for them.
+                        if is_archive:
+                            convertible_by, outputs, by_tool = [], [], {}
+                        else:
+                            convertible_by, outputs, by_tool = _detect_file_outputs(
+                                item_path, ext,
+                            )
                         is_convertible = "chdman" in convertible_by
                         is_dolphin_convertible = "dolphin" in convertible_by
                         is_z3ds_convertible = "z3ds" in convertible_by
@@ -275,9 +280,13 @@ async def search_files(
                             if recursive_scan and not os.path.islink(item_path):
                                 _scan(item_path)
                         elif os.path.isfile(item_path):
-                            convertible_by, outputs, by_tool = _detect_file_outputs(
-                                item_path, ext,
-                            )
+                            is_archive = ext in ARCHIVE_EXTENSIONS
+                            if is_archive:
+                                convertible_by, outputs, by_tool = [], [], {}
+                            else:
+                                convertible_by, outputs, by_tool = _detect_file_outputs(
+                                    item_path, ext,
+                                )
                             if convertible_by:
                                 is_chd_convertible = "chdman" in convertible_by
                                 is_dolphin_convertible = "dolphin" in convertible_by
@@ -325,7 +334,7 @@ async def search_files(
                                         "outputs": outputs,
                                     },
                                 )
-                            elif include_archive_scan and ext in ARCHIVE_EXTENSIONS:
+                            elif include_archive_scan and is_archive:
                                 # List archive contents
                                 archive_result = archive_service.list_archive_contents(
                                     item_path, include_meta=True,

--- a/app/services/tools/base.py
+++ b/app/services/tools/base.py
@@ -14,6 +14,8 @@ from typing import Protocol, runtime_checkable
 
 from pydantic import BaseModel
 
+from models import OutputStatus
+
 from .spec import ModeSpec
 
 
@@ -39,6 +41,13 @@ class ToolPlugin(Protocol):
         treat_as_stem: bool = False,
     ) -> str:
         """Resolve the output path for a conversion."""
+
+    def detect_output(self, input_path: str) -> OutputStatus | None:
+        """Detect an existing sibling output this tool could produce.
+
+        Returns ``None`` when the tool cannot produce an output for this
+        input or no output is present (neither finished nor mid-conversion).
+        """
 
     def convert(
         self,
@@ -95,6 +104,9 @@ class BaseTool:
             if m.mode == mode:
                 return m
         raise KeyError(mode)
+
+    def detect_output(self, input_path: str) -> OutputStatus | None:
+        return None
 
     async def post_convert(
         self, input_path: str, output_path: str, mode: str,

--- a/app/services/tools/chdman.py
+++ b/app/services/tools/chdman.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
-from models import CHDInfo
+from models import CHDInfo, OutputStatus
 from services.chdman import CHDMAN_CONVERTIBLE_EXTENSIONS, chdman_service
+from services.lock_manager import lock_manager
 
 from .base import BaseTool
 from .spec import ModeKind, ModeSpec
@@ -96,6 +98,20 @@ class ChdmanTool(BaseTool):
     @property
     def input_extensions(self) -> frozenset[str]:
         return frozenset(CHDMAN_CONVERTIBLE_EXTENSIONS)
+
+    def detect_output(self, input_path: str) -> OutputStatus | None:
+        if Path(input_path).suffix.lower() not in self.input_extensions:
+            return None
+        candidate = str(Path(input_path).with_suffix(".chd"))
+        file_exists, is_locked = lock_manager.check_file_status(candidate)
+        if not (file_exists or is_locked):
+            return None
+        return OutputStatus(
+            tool_id=self.id,
+            exists=file_exists,
+            ready=file_exists and not is_locked,
+            path=candidate,
+        )
 
     def output_path(
         self,

--- a/app/services/tools/dolphin.py
+++ b/app/services/tools/dolphin.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
-from models import DolphinDiscInfo
+from models import DolphinDiscInfo, OutputStatus
 from services.dolphin_tool import (
     DOLPHIN_CONVERTIBLE_EXTENSIONS,
+    DOLPHIN_OUTPUT_FORMATS,
     dolphin_tool_service,
 )
+from services.lock_manager import lock_manager
 
 from .base import BaseTool
 from .spec import ModeKind, ModeSpec
@@ -20,6 +23,12 @@ _MODES = {
     "dolphin_gcz": ("Dolphin GCZ", ".gcz", ModeKind.COMPRESS, False, False),
     "dolphin_iso": ("Dolphin ISO", ".iso", ModeKind.EXTRACT, False, False),
 }
+
+# Ordered, de-duplicated output extensions; iteration order decides which
+# sibling wins when several candidates exist.
+_DOLPHIN_OUTPUT_EXTENSIONS = tuple(
+    dict.fromkeys(ext for _, ext in DOLPHIN_OUTPUT_FORMATS.values()),
+)
 
 
 def _build_modes() -> list[ModeSpec]:
@@ -51,6 +60,39 @@ class DolphinTool(BaseTool):
     def __init__(self, binary_path: str) -> None:
         super().__init__(binary_path)
         self._service = dolphin_tool_service
+
+    def detect_output(self, input_path: str) -> OutputStatus | None:
+        source = Path(input_path)
+        source_ext = source.suffix.lower()
+        if source_ext not in self.input_extensions:
+            return None
+
+        candidate_paths: list[str] = []
+        if source_ext in _DOLPHIN_OUTPUT_EXTENSIONS and source_ext != ".iso":
+            candidate_paths.append(str(source))
+        for output_ext in _DOLPHIN_OUTPUT_EXTENSIONS:
+            if output_ext == source_ext:
+                continue
+            candidate_paths.append(str(source.with_suffix(output_ext)))
+
+        converting_path: str | None = None
+        for candidate_path in candidate_paths:
+            file_exists, is_converting = lock_manager.check_file_status(candidate_path)
+            if file_exists:
+                return OutputStatus(
+                    tool_id=self.id,
+                    exists=True,
+                    ready=not is_converting,
+                    path=candidate_path,
+                )
+            if is_converting and converting_path is None:
+                converting_path = candidate_path
+
+        if converting_path:
+            return OutputStatus(
+                tool_id=self.id, exists=False, ready=False, path=converting_path,
+            )
+        return None
 
     def output_path(
         self,

--- a/app/services/tools/z3ds.py
+++ b/app/services/tools/z3ds.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
 from fastapi.concurrency import run_in_threadpool
 
-from models import Z3DSInfo
+from models import OutputStatus, Z3DSInfo
+from services.lock_manager import lock_manager
 from services.z3ds_compress import (
     Z3DS_CONVERTIBLE_EXTENSIONS,
     Z3DS_OUTPUT_FORMATS,
@@ -44,6 +46,22 @@ class Z3dsTool(BaseTool):
     def __init__(self, binary_path: str) -> None:
         super().__init__(binary_path)
         self._service = z3ds_compress_service
+
+    def detect_output(self, input_path: str) -> OutputStatus | None:
+        source = Path(input_path)
+        expected_ext = Z3DS_OUTPUT_FORMATS.get(source.suffix.lower())
+        if not expected_ext:
+            return None
+        candidate = str(source.with_suffix(expected_ext))
+        file_exists, is_converting = lock_manager.check_file_status(candidate)
+        if not (file_exists or is_converting):
+            return None
+        return OutputStatus(
+            tool_id=self.id,
+            exists=file_exists,
+            ready=file_exists and not is_converting,
+            path=candidate,
+        )
 
     def output_path(
         self,

--- a/tests/test_files_outputs_parity.py
+++ b/tests/test_files_outputs_parity.py
@@ -1,0 +1,207 @@
+"""Phase 7: registry-driven FileEntry outputs must stay in lock-step with the
+legacy per-tool booleans, and the legacy JSON contract must not drift.
+
+These tests are the safety net for the refactor that replaced the six
+hand-written flag blocks in ``routes/files.py`` with a single registry loop.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from app.routes import files as files_routes
+from app.services.lock_manager import lock_manager
+
+# The exact legacy field surface that frontend (Phase 8) still reads. Phase 7
+# only adds ``convertible_by``/``outputs`` on top of these.
+LEGACY_FILEENTRY_KEYS = {
+    "name", "path", "type", "size", "extension", "convertible", "has_chd",
+    "has_rvz", "dolphin_ready", "dolphin_path", "chd_ready",
+    "dolphin_convertible", "z3ds_convertible", "has_z3ds", "z3ds_ready",
+    "z3ds_path", "archive_items", "archive_has_chd", "archive_truncated",
+    "media_type",
+}
+LEGACY_SEARCH_KEYS = {
+    "name", "path", "size", "extension", "chd_path", "has_chd", "has_rvz",
+    "dolphin_ready", "dolphin_path", "chd_ready", "convertible",
+    "dolphin_convertible", "z3ds_convertible", "has_z3ds", "z3ds_ready",
+    "z3ds_path", "in_archive",
+}
+NEW_KEYS = {"convertible_by", "outputs"}
+
+
+@pytest.fixture(name="parity_env")
+def _parity_env(tmp_path: Path, monkeypatch):
+    """A tree exercising every detection branch across the three tools."""
+    # chdman-only source with no output.
+    (tmp_path / "lonely.cue").write_bytes(b"cue")
+    # chdman-only source with a finished output.
+    (tmp_path / "done.cue").write_bytes(b"cue")
+    (tmp_path / "done.chd").write_bytes(b"chd")
+    # chdman-only source with a mid-conversion (locked, no file) output.
+    (tmp_path / "prog.cue").write_bytes(b"cue")
+    # dolphin-only source with a finished sibling output.
+    (tmp_path / "disc.wbfs").write_bytes(b"wbfs")
+    (tmp_path / "disc.rvz").write_bytes(b"rvz")
+    # self-format dolphin input (.rvz is itself a dolphin output format).
+    (tmp_path / "movie.rvz").write_bytes(b"rvz")
+    # z3ds source with a finished output.
+    (tmp_path / "rom.3ds").write_bytes(b"3ds")
+    (tmp_path / "rom.z3ds").write_bytes(b"z3ds")
+
+    # Archive whose member maps to an existing sibling .chd.
+    archive = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("inner.iso", b"iso-bytes")
+    (tmp_path / "inner.chd").write_bytes(b"chd")
+
+    monkeypatch.setattr(files_routes.settings, "chd_volumes", str(tmp_path))
+    monkeypatch.setattr(files_routes.settings, "data_mount_root", str(tmp_path))
+
+    lock_path = str(tmp_path / "prog.chd")
+    assert lock_manager.acquire_lock(lock_path) is True
+    try:
+        yield {"root": str(tmp_path)}
+    finally:
+        lock_manager.release_lock(lock_path)
+
+
+def _assert_agreement(legacy: dict, outputs: list, convertible_by: list[str]) -> None:
+    """The legacy booleans must be reconstructable from outputs/convertible_by."""
+    by_tool = {o.tool_id: o for o in outputs}
+
+    assert legacy["has_chd"] == ("chdman" in by_tool)
+    assert legacy["chd_ready"] == (
+        by_tool["chdman"].exists if "chdman" in by_tool else False
+    )
+
+    assert legacy["has_rvz"] == ("dolphin" in by_tool)
+    assert legacy["dolphin_ready"] == (
+        by_tool["dolphin"].exists if "dolphin" in by_tool else False
+    )
+    assert legacy["dolphin_path"] == (
+        by_tool["dolphin"].path if "dolphin" in by_tool else None
+    )
+
+    assert legacy["has_z3ds"] == ("z3ds" in by_tool)
+    assert legacy["z3ds_ready"] == (
+        by_tool["z3ds"].exists if "z3ds" in by_tool else False
+    )
+    assert legacy["z3ds_path"] == (
+        by_tool["z3ds"].path if "z3ds" in by_tool else None
+    )
+
+    assert legacy["convertible"] == ("chdman" in convertible_by)
+    assert legacy["dolphin_convertible"] == ("dolphin" in convertible_by)
+    assert legacy["z3ds_convertible"] == ("z3ds" in convertible_by)
+
+
+@pytest.mark.asyncio
+async def test_list_files_outputs_agree_with_legacy(parity_env):
+    listing = await files_routes.list_files(path=parity_env["root"])
+    by_name = {e.name: e for e in listing.entries}
+    root = parity_env["root"]
+
+    # Archives are a documented exception: has_chd is set from archive-member
+    # scanning, not from registry outputs, so the agreement invariant applies
+    # only to plain files.
+    for entry in listing.entries:
+        if entry.type != "file":
+            continue
+        _assert_agreement(entry.model_dump(), entry.outputs, entry.convertible_by)
+
+    # No output present.
+    lonely = by_name["lonely.cue"]
+    assert lonely.convertible_by == ["chdman"]
+    assert lonely.outputs == []
+    assert lonely.has_chd is False and lonely.chd_ready is False
+
+    # Finished chdman output.
+    done = by_name["done.cue"]
+    assert done.has_chd is True and done.chd_ready is True
+    assert [o.tool_id for o in done.outputs] == ["chdman"]
+    assert done.outputs[0].exists is True and done.outputs[0].ready is True
+
+    # Mid-conversion chdman output (locked, file absent).
+    prog = by_name["prog.cue"]
+    assert prog.has_chd is True and prog.chd_ready is False
+    assert prog.outputs[0].tool_id == "chdman"
+    assert prog.outputs[0].exists is False and prog.outputs[0].ready is False
+    assert prog.outputs[0].path == str(Path(root) / "prog.chd")
+
+    # Finished dolphin output for a dolphin-only input.
+    disc = by_name["disc.wbfs"]
+    assert disc.has_rvz is True and disc.dolphin_ready is True
+    assert disc.dolphin_path == str(Path(root) / "disc.rvz")
+    assert disc.convertible is False  # .wbfs is not chdman-convertible
+
+    # Self-format dolphin input detects itself.
+    movie = by_name["movie.rvz"]
+    assert movie.has_rvz is True and movie.dolphin_ready is True
+    assert movie.dolphin_path == str(Path(root) / "movie.rvz")
+
+    # Finished z3ds output.
+    rom = by_name["rom.3ds"]
+    assert rom.has_z3ds is True and rom.z3ds_ready is True
+    assert rom.z3ds_path == str(Path(root) / "rom.z3ds")
+    assert [o.tool_id for o in rom.outputs] == ["z3ds"]
+
+    # Archive: CHD-only detection via the archive special-casing; the new
+    # registry-driven fields stay empty (archives never emit tool outputs).
+    bundle = by_name["bundle.zip"]
+    assert bundle.type == "archive"
+    assert bundle.has_chd is True  # inner.chd exists for the member stem
+    assert bundle.has_rvz is False and bundle.z3ds_ready is False
+    assert bundle.convertible_by == []
+    assert bundle.outputs == []
+
+
+@pytest.mark.asyncio
+async def test_search_files_outputs_agree_with_legacy(parity_env):
+    results = await files_routes.search_files(
+        path=parity_env["root"], recursive=True, include_archives=True,
+    )
+    by_name = {Path(item["path"]).name: item for item in results["files"]}
+
+    for item in results["files"]:
+        _assert_agreement(item, item["outputs"], item["convertible_by"])
+
+    assert by_name["lonely.cue"]["outputs"] == []
+    assert by_name["lonely.cue"]["convertible_by"] == ["chdman"]
+    assert by_name["done.cue"]["chd_ready"] is True
+    assert by_name["prog.cue"]["has_chd"] is True
+    assert by_name["prog.cue"]["chd_ready"] is False
+    assert by_name["disc.wbfs"]["dolphin_path"].endswith("disc.rvz")
+    assert by_name["movie.rvz"]["dolphin_ready"] is True
+    assert by_name["rom.3ds"]["z3ds_ready"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_files_json_keys_are_additive(parity_env):
+    """Every legacy FileEntry key is preserved; only convertible_by/outputs added."""
+    listing = await files_routes.list_files(path=parity_env["root"])
+    for entry in listing.entries:
+        keys = set(entry.model_dump().keys())
+        assert LEGACY_FILEENTRY_KEYS <= keys
+        assert keys - LEGACY_FILEENTRY_KEYS == NEW_KEYS
+
+
+@pytest.mark.asyncio
+async def test_search_files_json_keys_are_additive(parity_env):
+    """Search file dicts keep every legacy key; archive dicts stay untouched."""
+    results = await files_routes.search_files(
+        path=parity_env["root"], recursive=True, include_archives=True,
+    )
+    for item in results["files"]:
+        keys = set(item.keys())
+        assert LEGACY_SEARCH_KEYS <= keys
+        assert keys - LEGACY_SEARCH_KEYS == NEW_KEYS
+
+    # Archive member dicts retain their distinct legacy shape unchanged.
+    for item in results["archives"]:
+        assert item["in_archive"] is True
+        assert "convertible_by" not in item
+        assert item["has_rvz"] is False


### PR DESCRIPTION
## Summary

Phase 7 of the tool-plugin refactor (DESIGN §3.6 + §5). Adds registry-driven `convertible_by` / `outputs` to `FileEntry`, populated by a single `registry.all()` loop, while keeping every legacy boolean byte-identical so the frontend keeps working untouched.

### New model
- `OutputStatus(tool_id, exists, ready, path)` in `app/models.py` — one detected sibling output per producing tool.
- `FileEntry.convertible_by: list[str]` (tool ids whose `input_extensions` accept the file) and `FileEntry.outputs: list[OutputStatus]`, both defaulting to `[]` (pure additions).

### Detection moved onto the tools
- Added `detect_output(input_path) -> OutputStatus | None` to the `ToolPlugin` protocol and a `None` default in `BaseTool`.
- `ChdmanTool`, `DolphinTool`, `Z3dsTool` each implement it by moving (not reinventing) the exact detection logic that previously lived in `files.py`:
  - chdman: `.chd` sibling; `has = exists or locked`, `ready == exists`.
  - dolphin: ordered `.rvz/.wia/.gcz/.iso` candidates + self when input is already a dolphin format (excluding `.iso`); first finished wins, else first converting.
  - z3ds: the single mapped output suffix.

### files.py
- The six hand-written flag blocks across `scan_directory` and `search_files` are replaced by one `_detect_file_outputs()` helper that loops `registry.all()`.
- Every legacy boolean (`has_chd`, `chd_ready`, `has_rvz`, `dolphin_ready`, `dolphin_path`, `has_z3ds`, `z3ds_ready`, `z3ds_path`, `convertible`, `dolphin_convertible`, `z3ds_convertible`) is **derived** from `outputs`/`convertible_by` — single source of truth, no third copy of the logic.
- The `scan_directory` archive special-casing (CHD-only via member scan, other flags forced false) and the `search_files` dict-vs-model distinction are preserved exactly. Archive member dicts keep their distinct shape (no new keys).
- Removed now-dead helpers (`_detect_dolphin_output_path`, `_detect_z3ds_output_path`, module-level `DOLPHIN_OUTPUT_EXTENSIONS`) and the now-unused extension-constant imports (grep-confirmed no other callers in the file; the one remaining archive `convertible` check now reads `registry.get("chdman").input_extensions`).

### Frontend contract
Untouched (Phase 8 migrates `static/js/app.js`). `convertible_by`/`outputs` are purely additive.

## Test plan
- [x] `tests/test_mode_parity_fixes.py`, `test_volume_discovery.py`, `test_tool_registry.py` and all listing/search tests pass unchanged.
- [x] New `tests/test_files_outputs_parity.py`:
  - **Parallel-agreement**: for a synthetic tree, the new `outputs[i].exists/ready/path` and `convertible_by` agree with every legacy boolean across no-output, finished, mid-conversion (lock_manager lock), self-format dolphin, z3ds, and archive cases.
  - **JSON-stability**: asserts the legacy `FileEntry` and search-dict key sets are preserved exactly and the only additions are `convertible_by`/`outputs`.
- [x] Full suite: 570 passed.
- [x] `ruff check app tests` clean; `pylint` 10.00/10 on all touched files.

https://claude.ai/code/session_01DH5irbajtiJr8XWccJbLJh

---
_Generated by [Claude Code](https://claude.ai/code/session_01DH5irbajtiJr8XWccJbLJh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced file and output detection: the system now more accurately identifies which conversion tools can process each file and provides improved status tracking for conversion outputs.

* **Refactor**
  * Modernized the internal file conversion detection system for improved reliability.

* **Tests**
  * Added comprehensive test suite verifying output detection accuracy across all supported conversion tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacnpal/compressatorium/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->