### PR TITLE
feat: frontend tool descriptor table; FileList reads outputs/convertible_by (Phase 8)

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,5 +1,17 @@
 // Main Compressatorium App
 import { api, formatSize, getFileIcon, isDolphinFile } from './api.js';
+import {
+    TOOLS,
+    MODE_GROUPS,
+    getTool,
+    getToolByVerifyKind,
+    entryOutputExists,
+    entryOutputReady,
+    entryOutputPath,
+    entryConvertibleBy,
+    resolveSourceProduct,
+    synthesizeArchiveOutputs
+} from './tools.js';
 
 const { html, render, useState, useEffect, useRef, useCallback, useMemo } = window;
 const ISO_TOOL_STORAGE_KEY = 'primary_tool_preference';
@@ -53,22 +65,7 @@ const get3dsProductPath = (path) => {
     return `${path.slice(0, -ext.length)}${outExt}`;
 };
 
-const getDolphinProductPath = (entry) => {
-    if (
-        !entry
-        || typeof entry.path !== 'string'
-        || (!entry.has_rvz && !entry.dolphin_ready)
-    ) return null;
-    if (typeof entry.dolphin_path === 'string' && entry.dolphin_path) {
-        return entry.dolphin_path;
-    }
-    const ext = getFileExtension(entry.path);
-    if (!ext || !entry.path.toLowerCase().endsWith(ext)) return null;
-    if (ext === '.iso') {
-        return `${entry.path.slice(0, -ext.length)}.rvz`;
-    }
-    return entry.path;
-};
+const getDolphinProductPath = (entry) => getTool('dolphin')?.productPath(entry) || null;
 
 const getModeTerm = (isoHandling, kind) => {
     if (kind === 'file') return 'file';
@@ -94,112 +91,21 @@ const normalizeDolphinLevel = (value) => {
     return raw;
 };
 
-const getPrimaryToolLabel = (toolSelection) => {
-    if (toolSelection === 'chdman') return 'CHDMAN';
-    if (toolSelection === 'dolphin') return 'Dolphin';
-    if (toolSelection === 'z3ds') return '3DS';
-    return 'None selected';
+const getPrimaryToolLabel = (toolSelection) => getTool(toolSelection)?.label || 'None selected';
+
+const getFilterOptions = (toolSelection) => {
+    const tool = getTool(toolSelection);
+    return tool?.filters || getTool('chdman').filters;
 };
-
-const getFilterOptions = (tool) => {
-    const common = [
-        { value: '', label: 'All Types' },
-        { value: '.zip,.7z,.rar', label: 'Archives' },
-        { value: '.chd', label: 'CHD Files' }
-    ];
-
-    if (tool === 'dolphin') {
-        return [
-            ...common,
-            { value: '.iso,.rvz,.wia,.gcz,.wbfs', label: 'GameCube/Wii Images' },
-            { value: '.iso', label: 'ISO Files' },
-            { value: 'custom', label: 'Custom...' }
-        ];
-    }
-
-    if (tool === 'z3ds') {
-        return [
-            ...common,
-            { value: '.cci,.cia,.3ds', label: '3DS ROMs' },
-            { value: 'custom', label: 'Custom...' }
-        ];
-    }
-
-    // Default (CHDMAN)
-    return [
-        ...common,
-        { value: '.cue,.bin,.gdi,.iso', label: 'Disc Images' },
-        { value: '.iso', label: 'ISO Files' },
-        { value: 'custom', label: 'Custom...' }
-    ];
-};
-
-
 
 const getPrimaryToolHint = (toolSelection) => {
     if (toolSelection === null) {
         return html`<span role="img" aria-label="Warning">⚠️</span> Please select your primary tool above to get started`;
     }
-    if (toolSelection === 'chdman') {
-        return html`Convert disc images to CHD format • Supports CD/DVD/LaserDisc`;
-    }
-    if (toolSelection === 'dolphin') {
-        return html`Convert GameCube/Wii disc images • Supports RVZ, WIA, GCZ, ISO formats`;
-    }
-    if (toolSelection === 'z3ds') {
-        return html`Compress Nintendo 3DS ROMs • Supports .cci/.cia/.3ds (cart & CIA) → .zcci/.zcia/.z3ds • ~50% size reduction • <strong>Decrypted ROMs only</strong>`;
-    }
+    const tool = getTool(toolSelection);
+    if (tool) return tool.hint({ html });
     return html`Current: ${getPrimaryToolLabel(toolSelection)}`;
 };
-
-const MODE_GROUPS = [
-    {
-        id: 'create',
-        label: 'Create CHD',
-        options: [
-            { value: 'createcd', label: 'Create CD CHD (Dreamcast, PS1, Sega CD)' },
-            { value: 'createdvd', label: 'Create DVD CHD (PSP, PS2)' },
-            { value: 'createraw', label: 'Create Raw CHD' },
-            { value: 'createhd', label: 'Create HD CHD' },
-            { value: 'createld', label: 'Create LaserDisc CHD' }
-        ]
-    },
-    {
-        id: 'extract',
-        label: 'Extract from CHD',
-        options: [
-            { value: 'extractcd', label: 'Extract CD (cue/bin)' },
-            { value: 'extractdvd', label: 'Extract DVD (iso)' },
-            { value: 'extractraw', label: 'Extract Raw' },
-            { value: 'extracthd', label: 'Extract HD' },
-            { value: 'extractld', label: 'Extract LaserDisc (avi)' }
-        ]
-    },
-    {
-        id: 'copy',
-        label: 'Copy / Recompress',
-        options: [
-            { value: 'copy', label: 'Copy / Recompress CHD' }
-        ]
-    },
-    {
-        id: 'dolphin',
-        label: 'Dolphin (GameCube/Wii)',
-        options: [
-            { value: 'dolphin_rvz', label: 'Convert to RVZ' },
-            { value: 'dolphin_wia', label: 'Convert to WIA' },
-            { value: 'dolphin_gcz', label: 'Convert to GCZ' },
-            { value: 'dolphin_iso', label: 'Convert to ISO (extract)' }
-        ]
-    },
-    {
-        id: 'z3ds',
-        label: 'Nintendo 3DS',
-        options: [
-            { value: 'z3ds_compress', label: 'Compress to ZCCI/ZCIA/Z3DS' }
-        ]
-    }
-];
 
 // ============ DAT Panel Component ============
 
@@ -622,9 +528,9 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
         } else if (entry.extension === '.chd' && !isArchiveItem(entry)) {
             // For CHD files, show info (but checkbox still works for selection)
             onShowInfo(entry.path);
-        } else if (isArchiveItem(entry) && entry.chd_ready && entry.chd_path) {
+        } else if (isArchiveItem(entry) && entryOutputReady(entry, 'chdman') && entryOutputPath(entry, 'chdman')) {
             // For archive members with a converted CHD, show info for the output file
-            onShowInfo?.(entry.chd_path);
+            onShowInfo?.(entryOutputPath(entry, 'chdman'));
         } else if (isDolphinInfo && !isArchiveItem(entry)) {
             onShowInfo?.(entry.path);
         } else if (is3dsInfo && !isArchiveItem(entry)) {
@@ -637,8 +543,9 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
 
     const getVerifiablePath = (entry) => {
         const ext = entry.extension?.toLowerCase();
-        if (entry.chd_path && entry.chd_ready) return entry.chd_path;
-        if (!isArchiveItem(entry) && entry.dolphin_ready) {
+        const chdReadyPath = entryOutputReady(entry, 'chdman') ? entryOutputPath(entry, 'chdman') : null;
+        if (chdReadyPath) return chdReadyPath;
+        if (!isArchiveItem(entry) && entryOutputReady(entry, 'dolphin')) {
             const dolphinPath = getDolphinProductPath(entry);
             if (dolphinPath) return dolphinPath;
         }
@@ -651,8 +558,8 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
         if (!isArchiveItem(entry) && is3dsVerifyFile(entry.path)) {
             return entry.path;
         }
-        if (!isArchiveItem(entry) && entry.z3ds_ready) {
-            return entry.z3ds_path || get3dsProductPath(entry.path);
+        if (!isArchiveItem(entry) && entryOutputReady(entry, 'z3ds')) {
+            return entryOutputPath(entry, 'z3ds') || get3dsProductPath(entry.path);
         }
         if (ext === '.chd') return entry.path;
         return null;
@@ -687,8 +594,8 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
             return `Archive: ${entry.name} - Click to browse contents`;
         }
         if (ext === '.chd' && !isArchiveItem(entry)) return 'Click to view CHD info';
-        if (isArchiveItem(entry) && entry.chd_ready && entry.chd_path) return 'Click to view output CHD info';
-        if (isArchiveItem(entry) && entry.has_chd && !entry.chd_ready) return 'CHD conversion in progress';
+        if (isArchiveItem(entry) && entryOutputReady(entry, 'chdman') && entryOutputPath(entry, 'chdman')) return 'Click to view output CHD info';
+        if (isArchiveItem(entry) && entryOutputExists(entry, 'chdman') && !entryOutputReady(entry, 'chdman')) return 'CHD conversion in progress';
         if (!isArchiveItem(entry) && ext === '.iso' && !isoIsDolphin) {
             return 'ISO info uses Dolphin tools. Switch Primary Tool to Dolphin for disc info/verify.';
         }
@@ -699,7 +606,7 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
         ) return 'Click to view disc info';
         if (!isArchiveItem(entry) && is3dsFile(entry.path)) return 'Click to view 3DS ROM info';
         if (canSelect(entry)) return 'Click to select';
-        if (entry.convertible) return entry.has_chd ? 'Already converted' : entry.name;
+        if (entryConvertibleBy(entry, 'chdman')) return entryOutputExists(entry, 'chdman') ? 'Already converted' : entry.name;
         return entry.name;
     };
 
@@ -797,13 +704,13 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
 
                 const canInlineCompress =
                     // CHDMAN create modes only: source images -> CHD
-                    (isCreateMode && isoHandling === 'chdman' && entry.convertible && !entry.has_chd) ||
+                    (isCreateMode && isoHandling === 'chdman' && entryConvertibleBy(entry, 'chdman') && !entryOutputExists(entry, 'chdman')) ||
                     // CHDMAN extract/copy modes: CHD inputs only
                     ((isExtractMode || conversionMode === 'copy') && entryExt === '.chd') ||
                     // Dolphin modes only
-                    (isDolphinMode && isoHandling === 'dolphin' && entry.dolphin_convertible) ||
+                    (isDolphinMode && isoHandling === 'dolphin' && entryConvertibleBy(entry, 'dolphin')) ||
                     // 3DS mode only
-                    (isZ3dsMode && isoHandling === 'z3ds' && entry.z3ds_convertible && !entry.has_z3ds);
+                    (isZ3dsMode && isoHandling === 'z3ds' && entryConvertibleBy(entry, 'z3ds') && !entryOutputExists(entry, 'z3ds'));
 
                 const isIsoEntry = entryExt === '.iso';
                 const isDolphinExt = ['.rvz', '.wia', '.gcz', '.wbfs'].includes(entryExt)
@@ -812,7 +719,7 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
                     entry.extension === '.chd'
                     || (isDolphinExt && !isArchiveItem(entry))
                     || (!isArchiveItem(entry) && is3dsVerifyFile(chdPath))
-                    || (isArchiveItem(entry) && entry.chd_ready)
+                    || (isArchiveItem(entry) && entryOutputReady(entry, 'chdman'))
                 );
                 const archiveItems = entry.archive_items;
                 const archiveHasChd = entry.archive_has_chd;
@@ -845,18 +752,16 @@ function FileList({ entries, selectedFiles, canSelect, onNavigate, onToggleSelec
                         ${entry.size != null && entry.size !== undefined ? formatSize(entry.size) : ''}
                     </div>
                     <div class="file-cell file-status">
-                        ${entry.type !== 'archive' && entry.has_chd && html`
-                            <span class="status has-chd" title="A CHD file already exists for this source">CHD exists</span>
-                        `}
-                        ${entry.type !== 'archive' && entry.has_z3ds && html`
-                            <span class="status has-chd" title="A compressed 3DS file (.zcci/.zcia/.z3ds) already exists">Z3DS exists</span>
-                        `}
-                        ${entry.type !== 'archive' && entry.convertible && !entry.has_chd && html`
-                            <span class="status convertible" title="Can be converted to CHD">Convertible</span>
-                        `}
-                        ${entry.type !== 'archive' && entry.z3ds_convertible && !entry.has_z3ds && html`
-                            <span class="status convertible" title="Nintendo 3DS ROM - Can be compressed to ZCCI/ZCIA/Z3DS format">3DS ROM</span>
-                        `}
+                        ${entry.type !== 'archive' && TOOLS.map(tool => {
+                            const badge = tool.badges?.exists;
+                            if (!badge || !entryOutputExists(entry, tool.id)) return null;
+                            return html`<span key=${`${tool.id}-exists`} class="status has-chd" title=${badge.title}>${badge.label}</span>`;
+                        })}
+                        ${entry.type !== 'archive' && TOOLS.map(tool => {
+                            const badge = tool.badges?.convertible;
+                            if (!badge || !entryConvertibleBy(entry, tool.id) || entryOutputExists(entry, tool.id)) return null;
+                            return html`<span key=${`${tool.id}-conv`} class="status convertible" title=${badge.title}>${badge.label}</span>`;
+                        })}
                         ${entry.type === 'archive' && archiveItems != null && archiveItems > 0 && html`
                             <span class="status convertible" title="Convertible images inside this archive">
                                 ${archiveItems} image${archiveItems === 1 ? '' : 's'}
@@ -1126,17 +1031,14 @@ function CHDInfoModal({ path, onClose, infoMode, useDolphin }) {
         if (path) {
             setLoading(true);
             setError(null);
-            const fetchInfo = dolphin
-                ? api.getDolphinInfo(path)
-                : z3ds
-                    ? api.getZ3DSInfo(path)
-                    : api.getCHDInfo(path);
+            const tool = getToolByVerifyKind(mode);
+            const fetchInfo = tool ? tool.getInfo(path) : api.getCHDInfo(path);
             fetchInfo
                 .then(setInfo)
                 .catch(e => setError(e.message))
                 .finally(() => setLoading(false));
         }
-    }, [path, dolphin, z3ds]);
+    }, [path, mode]);
 
     if (!path) return null;
 
@@ -1589,40 +1491,8 @@ function DeleteModal({ entry, verifiedCHDs, verifyProgress, onDelete, onVerify, 
     ].includes(entryExt) : false;
     const isArchive = entry ? entry.type === 'archive' : false;
     const fileTerm = getModeTerm(isoHandling, 'file');
-    const resolveSourceProduct = (sourceEntry) => {
-        if (!sourceEntry?.path) return null;
 
-        const getChdPath = () => (
-            sourceEntry.has_chd ? sourceEntry.path.replace(/\.[^.]+$/, '.chd') : null
-        );
-        const getDolphinPath = () => (
-            sourceEntry.dolphin_ready ? getDolphinProductPath(sourceEntry) : null
-        );
-        const getZ3dsPath = () => (
-            sourceEntry.z3ds_ready ? (sourceEntry.z3ds_path || get3dsProductPath(sourceEntry.path)) : null
-        );
-
-        const preferredKinds = isoHandling === 'dolphin'
-            ? ['dolphin', 'chd', 'z3ds']
-            : isoHandling === 'z3ds'
-                ? ['z3ds', 'chd', 'dolphin']
-                : ['chd', 'dolphin', 'z3ds'];
-
-        for (const kind of preferredKinds) {
-            const productPath = kind === 'dolphin'
-                ? getDolphinPath()
-                : kind === 'z3ds'
-                    ? getZ3dsPath()
-                    : getChdPath();
-            if (productPath) {
-                return { path: productPath, kind };
-            }
-        }
-
-        return null;
-    };
-
-    const resolvedProduct = (isSourceFile && entry && !isArchive) ? resolveSourceProduct(entry) : null;
+    const resolvedProduct = (isSourceFile && entry && !isArchive) ? resolveSourceProduct(entry, isoHandling) : null;
     const productPath = resolvedProduct?.path || null;
     const termsIsoHandling = resolvedProduct?.kind === 'dolphin'
         ? 'dolphin'
@@ -1993,38 +1863,6 @@ function BulkDeleteModal({ entries, verifiedCHDs, onVerify, onClose, onRefresh, 
     const fileTerm = getModeTerm(isoHandling, 'file');
     const verifyTerm = getModeTerm(isoHandling, 'verification');
     const productTerm = getModeTerm(isoHandling, 'product');
-    const resolveSourceProduct = (entry) => {
-        if (!entry?.path) return null;
-
-        const getChdPath = () => (
-            entry.has_chd ? entry.path.replace(/\.[^.]+$/, '.chd') : null
-        );
-        const getDolphinPath = () => (
-            entry.dolphin_ready ? getDolphinProductPath(entry) : null
-        );
-        const getZ3dsPath = () => (
-            entry.z3ds_ready ? (entry.z3ds_path || get3dsProductPath(entry.path)) : null
-        );
-
-        const preferredKinds = isoHandling === 'dolphin'
-            ? ['dolphin', 'chd', 'z3ds']
-            : isoHandling === 'z3ds'
-                ? ['z3ds', 'chd', 'dolphin']
-                : ['chd', 'dolphin', 'z3ds'];
-
-        for (const kind of preferredKinds) {
-            const productPath = kind === 'dolphin'
-                ? getDolphinPath()
-                : kind === 'z3ds'
-                    ? getZ3dsPath()
-                    : getChdPath();
-            if (productPath) {
-                return { path: productPath, kind };
-            }
-        }
-
-        return null;
-    };
 
     // Categorize files
     const sourceFiles = entries.filter(e =>
@@ -2039,7 +1877,7 @@ function BulkDeleteModal({ entries, verifiedCHDs, onVerify, onClose, onRefresh, 
     );
     const sourceProductByPath = new Map();
     for (const entry of sourceFiles) {
-        const product = resolveSourceProduct(entry);
+        const product = resolveSourceProduct(entry, isoHandling);
         if (product) {
             sourceProductByPath.set(entry.path, product);
         }
@@ -2078,80 +1916,24 @@ function BulkDeleteModal({ entries, verifiedCHDs, onVerify, onClose, onRefresh, 
             let currentVerified = 0;
             let currentFailed = 0;
 
-            if (chdPaths.length > 0) {
-                let chdStartHandled = false;
-                await api.verifyBatchCHDs(chdPaths, {
-                    onProgress: (update) => {
-                        if (update.type === 'start') {
-                            if (!chdStartHandled && Number.isFinite(update.total)) {
-                                chdStartHandled = true;
-                                setVerifyState(prev => ({
-                                    ...prev,
-                                    total: prev.total - chdPaths.length + update.total
-                                }));
-                            }
-                        } else if (update.type === 'progress' || update.type === 'file_progress') {
-                            setVerifyState(prev => ({ ...prev, current: update.filename || update.path }));
-                        }
-                    },
-                    onFileComplete: (data) => {
-                        currentVerified += data.valid ? 1 : 0;
-                        currentFailed += data.valid ? 0 : 1;
-                        setVerifyState(prev => ({
-                            ...prev,
-                            verified: currentVerified,
-                            failed: currentFailed,
-                            current: null
-                        }));
-                        if (data.valid && onVerify) {
-                            onVerify(data.path);
-                        }
-                    }
-                });
-            }
+            const batches = [
+                { kind: 'chd', paths: chdPaths },
+                { kind: 'dolphin', paths: dolphinPaths },
+                { kind: 'z3ds', paths: z3dsPaths }
+            ];
 
-            if (dolphinPaths.length > 0) {
-                let dolphinStartHandled = false;
-                await api.verifyBatchDolphin(dolphinPaths, {
+            for (const { kind, paths } of batches) {
+                if (paths.length === 0) continue;
+                const tool = getToolByVerifyKind(kind);
+                let startHandled = false;
+                await tool.verifyBatch(paths, {
                     onProgress: (update) => {
                         if (update.type === 'start') {
-                            if (!dolphinStartHandled && Number.isFinite(update.total)) {
-                                dolphinStartHandled = true;
+                            if (!startHandled && Number.isFinite(update.total)) {
+                                startHandled = true;
                                 setVerifyState(prev => ({
                                     ...prev,
-                                    total: prev.total - dolphinPaths.length + update.total
-                                }));
-                            }
-                        } else if (update.type === 'progress' || update.type === 'file_progress') {
-                            setVerifyState(prev => ({ ...prev, current: update.filename || update.path }));
-                        }
-                    },
-                    onFileComplete: (data) => {
-                        currentVerified += data.valid ? 1 : 0;
-                        currentFailed += data.valid ? 0 : 1;
-                        setVerifyState(prev => ({
-                            ...prev,
-                            verified: currentVerified,
-                            failed: currentFailed,
-                            current: null
-                        }));
-                        if (data.valid && onVerify) {
-                            onVerify(data.path);
-                        }
-                    }
-                });
-            }
-
-            if (z3dsPaths.length > 0) {
-                let z3dsStartHandled = false;
-                await api.verifyBatchZ3DS(z3dsPaths, {
-                    onProgress: (update) => {
-                        if (update.type === 'start') {
-                            if (!z3dsStartHandled && Number.isFinite(update.total)) {
-                                z3dsStartHandled = true;
-                                setVerifyState(prev => ({
-                                    ...prev,
-                                    total: prev.total - z3dsPaths.length + update.total
+                                    total: prev.total - paths.length + update.total
                                 }));
                             }
                         } else if (update.type === 'progress' || update.type === 'file_progress') {
@@ -2446,22 +2228,24 @@ function BulkVerifyModal({ verifyItems, onComplete, onClose }) {
                 const allZ3DS = verifyItems.every(item => item.kind === 'z3ds');
                 let result = { verified: 0, failed: 0, total: verifyItems.length };
 
-                if (allChd) {
-                    const chdPaths = verifyItems.map(item => item.path);
-                    result = await api.verifyBatchCHDs(chdPaths, {
-                        onProgress: (update) => {
-                            if (cancelled) return;
-                            if (update.type === 'start') {
-                                // Use server-validated total (may be less than client count if paths were filtered)
-                                setState(prev => ({
-                                    ...prev,
-                                    total: update.total
-                                }));
-                            } else if (update.type === 'progress') {
-                                setState(prev => ({
-                                    ...prev,
-                                    current: update.filename
-                                }));
+                if (allChd || allDolphin || allZ3DS) {
+                    const kind = allChd ? 'chd' : (allDolphin ? 'dolphin' : 'z3ds');
+                    const tool = getToolByVerifyKind(kind);
+                    const paths = verifyItems.map(item => item.path);
+                    // The three tools used slightly different progress shapes
+                    // historically: chdman split progress/file_progress to gate
+                    // currentProgress on file_progress, dolphin ignored
+                    // currentProgress, z3ds always set it. Preserve those
+                    // tool-specific shapes here.
+                    const onProgress = (update) => {
+                        if (cancelled) return;
+                        if (update.type === 'start') {
+                            setState(prev => ({ ...prev, total: update.total }));
+                            return;
+                        }
+                        if (kind === 'chd') {
+                            if (update.type === 'progress') {
+                                setState(prev => ({ ...prev, current: update.filename }));
                             } else if (update.type === 'file_progress') {
                                 setState(prev => ({
                                     ...prev,
@@ -2469,67 +2253,22 @@ function BulkVerifyModal({ verifyItems, onComplete, onClose }) {
                                     currentProgress: update.progress
                                 }));
                             }
-                        },
-                        onFileComplete: (data) => {
-                            if (cancelled) return;
-                            setState(prev => ({
-                                ...prev,
-                                verified: data.verified,
-                                failed: data.failed,
-                                current: null,
-                                currentProgress: null,
-                                results: [...prev.results, data]
-                            }));
-                        }
-                    });
-                } else if (allDolphin) {
-                    const dolphinPaths = verifyItems.map(item => item.path);
-                    result = await api.verifyBatchDolphin(dolphinPaths, {
-                        onProgress: (update) => {
-                            if (cancelled) return;
-                            if (update.type === 'start') {
-                                // Use server-validated total (may be less than client count if paths were filtered)
-                                setState(prev => ({
-                                    ...prev,
-                                    total: update.total
-                                }));
-                            } else if (update.type === 'progress' || update.type === 'file_progress') {
-                                setState(prev => ({
-                                    ...prev,
-                                    current: update.filename || update.path
-                                }));
+                        } else if (kind === 'dolphin') {
+                            if (update.type === 'progress' || update.type === 'file_progress') {
+                                setState(prev => ({ ...prev, current: update.filename || update.path }));
                             }
-                        },
-                        onFileComplete: (data) => {
-                            if (cancelled) return;
-                            setState(prev => ({
-                                ...prev,
-                                verified: data.verified,
-                                failed: data.failed,
-                                current: null,
-                                currentProgress: null,
-                                results: [...prev.results, data]
-                            }));
-                        }
-                    });
-                } else if (allZ3DS) {
-                    const z3dsPaths = verifyItems.map(item => item.path);
-                    result = await api.verifyBatchZ3DS(z3dsPaths, {
-                        onProgress: (update) => {
-                            if (cancelled) return;
-                            if (update.type === 'start') {
-                                setState(prev => ({
-                                    ...prev,
-                                    total: update.total
-                                }));
-                            } else if (update.type === 'progress' || update.type === 'file_progress') {
+                        } else {
+                            if (update.type === 'progress' || update.type === 'file_progress') {
                                 setState(prev => ({
                                     ...prev,
                                     current: update.filename || update.path,
                                     currentProgress: update.progress
                                 }));
                             }
-                        },
+                        }
+                    };
+                    result = await tool.verifyBatch(paths, {
+                        onProgress,
                         onFileComplete: (data) => {
                             if (cancelled) return;
                             setState(prev => ({
@@ -2557,12 +2296,8 @@ function BulkVerifyModal({ verifyItems, onComplete, onClose }) {
                         const baseVerified = verified;
                         const baseFailed = failed;
 
-                        let verifyFn;
-                        if (kind === 'dolphin') verifyFn = api.verifyBatchDolphin.bind(api);
-                        else if (kind === 'z3ds') verifyFn = api.verifyBatchZ3DS.bind(api);
-                        else verifyFn = api.verifyBatchCHDs.bind(api);
-
-                        const batchResult = await verifyFn(paths, {
+                        const tool = getToolByVerifyKind(kind) || getTool('chdman');
+                        const batchResult = await tool.verifyBatch(paths, {
                             onProgress: (update) => {
                                 if (cancelled) return;
                                 if (update.type === 'start') {
@@ -2940,17 +2675,8 @@ function App() {
                         type: 'file',
                         size: file.size,
                         extension: file.extension,
-                        convertible: file.convertible,
-                        has_chd: file.has_chd || false,
-                        has_rvz: false,
-                        dolphin_ready: false,
-                        dolphin_path: null,
-                        has_z3ds: false,
-                        z3ds_ready: false,
-                        z3ds_path: null,
-                        chd_ready: Boolean(file.chd_ready),
+                        ...synthesizeArchiveOutputs(file),
                         output_stem: file.output_stem,
-                        chd_path: file.chd_path,
                         is_archive_item: true,
                         archive_path: archivePath
                     }));
@@ -2963,9 +2689,9 @@ function App() {
                                 return oldEntry.name !== newEntry.name ||
                                     oldEntry.path !== newEntry.path ||
                                     oldEntry.size !== newEntry.size ||
-                                    oldEntry.convertible !== newEntry.convertible ||
-                                    oldEntry.has_chd !== newEntry.has_chd ||
-                                    oldEntry.chd_ready !== newEntry.chd_ready;
+                                    entryConvertibleBy(oldEntry, 'chdman') !== entryConvertibleBy(newEntry, 'chdman') ||
+                                    entryOutputExists(oldEntry, 'chdman') !== entryOutputExists(newEntry, 'chdman') ||
+                                    entryOutputReady(oldEntry, 'chdman') !== entryOutputReady(newEntry, 'chdman');
                             });
                             if (!hasChanges) return prevEntries;
                         }
@@ -2994,21 +2720,17 @@ function App() {
                         if (prevEntries.length === newEntries.length) {
                             const hasChanges = newEntries.some((newEntry, i) => {
                                 const oldEntry = prevEntries[i];
-                                return oldEntry.name !== newEntry.name ||
+                                if (oldEntry.name !== newEntry.name ||
                                     oldEntry.path !== newEntry.path ||
                                     oldEntry.size !== newEntry.size ||
-                                    oldEntry.type !== newEntry.type ||
-                                    oldEntry.convertible !== newEntry.convertible ||
-                                    oldEntry.dolphin_convertible !== newEntry.dolphin_convertible ||
-                                    oldEntry.z3ds_convertible !== newEntry.z3ds_convertible ||
-                                    oldEntry.has_chd !== newEntry.has_chd ||
-                                    oldEntry.has_rvz !== newEntry.has_rvz ||
-                                    oldEntry.dolphin_ready !== newEntry.dolphin_ready ||
-                                    oldEntry.dolphin_path !== newEntry.dolphin_path ||
-                                    oldEntry.has_z3ds !== newEntry.has_z3ds ||
-                                    oldEntry.z3ds_ready !== newEntry.z3ds_ready ||
-                                    oldEntry.z3ds_path !== newEntry.z3ds_path ||
-                                    oldEntry.chd_ready !== newEntry.chd_ready;
+                                    oldEntry.type !== newEntry.type) return true;
+                                return TOOLS.some(tool => {
+                                    if (entryConvertibleBy(oldEntry, tool.id) !== entryConvertibleBy(newEntry, tool.id)) return true;
+                                    if (entryOutputExists(oldEntry, tool.id) !== entryOutputExists(newEntry, tool.id)) return true;
+                                    if (entryOutputReady(oldEntry, tool.id) !== entryOutputReady(newEntry, tool.id)) return true;
+                                    if (entryOutputPath(oldEntry, tool.id) !== entryOutputPath(newEntry, tool.id)) return true;
+                                    return false;
+                                });
                             });
                             // Only update if there are actual changes
                             if (!hasChanges) return prevEntries;
@@ -3089,8 +2811,8 @@ function App() {
         const getStatusPriority = (entry) => {
             if (entry.type === 'directory') return 0;
             if (entry.type === 'archive') return 1;
-            if (entry.has_chd || entry.has_rvz || entry.has_z3ds) return 2;
-            if (entry.convertible || entry.dolphin_convertible || entry.z3ds_convertible) return 3;
+            if (TOOLS.some(t => entryOutputExists(entry, t.id))) return 2;
+            if (TOOLS.some(t => entryConvertibleBy(entry, t.id))) return 3;
             return 4;
         };
 
@@ -4045,17 +3767,8 @@ function App() {
                 type: 'file',
                 size: file.size,
                 extension: file.extension,
-                convertible: file.convertible,
-                has_chd: file.has_chd || false,
-                has_rvz: false,
-                dolphin_ready: false,
-                dolphin_path: null,
-                has_z3ds: false,
-                z3ds_ready: false,
-                z3ds_path: null,
-                chd_ready: Boolean(file.chd_ready),
+                ...synthesizeArchiveOutputs(file),
                 output_stem: file.output_stem,
-                chd_path: file.chd_path,
                 is_archive_item: true,
                 archive_path: archivePath
             }));
@@ -4233,16 +3946,16 @@ function App() {
         }
 
         const verifyPath = force3ds && is3dsSourceFile(productPath)
-            ? (entry?.z3ds_path || get3dsProductPath(productPath) || productPath)
+            ? (entryOutputPath(entry, 'z3ds') || get3dsProductPath(productPath) || productPath)
             : productPath;
         const dolphin = forceDolphin || isDolphinFile(verifyPath);
         const z3ds = force3ds || is3dsFile(verifyPath);
-        const verifyFn = dolphin ? api.verifyDolphin.bind(api) : (z3ds ? api.verify3DS.bind(api) : api.verifyCHD.bind(api));
+        const verifyTool = dolphin ? getTool('dolphin') : (z3ds ? getTool('z3ds') : getTool('chdman'));
         const label = dolphin ? 'Disc' : (z3ds ? '3DS ROM' : 'CHD');
 
         setVerifyProgress(prev => new Map(prev).set(verifyPath, { progress: 0, message: 'Starting verification...' }));
         try {
-            const result = await verifyFn(verifyPath, {
+            const result = await verifyTool.verify(verifyPath, {
                 onProgress: (update) => {
                     setVerifyProgress(prev => {
                         const next = new Map(prev);
@@ -4294,8 +4007,9 @@ function App() {
             const isArchiveItem = entry.is_archive_item || entry.in_archive;
             const filename = entry.name || path.split('/').pop();
 
-            if (entry.chd_path && entry.chd_ready) {
-                items.push({ path: entry.chd_path, filename, kind: 'chd' });
+            const chdReadyPath = entryOutputReady(entry, 'chdman') ? entryOutputPath(entry, 'chdman') : null;
+            if (chdReadyPath) {
+                items.push({ path: chdReadyPath, filename, kind: 'chd' });
                 continue;
             }
             if (ext === '.chd') {
@@ -4306,7 +4020,7 @@ function App() {
                 items.push({ path, filename, kind: 'dolphin' });
                 continue;
             }
-            if (!isArchiveItem && entry.dolphin_ready) {
+            if (!isArchiveItem && entryOutputReady(entry, 'dolphin')) {
                 const dolphinPath = getDolphinProductPath(entry);
                 if (dolphinPath) {
                     items.push({ path: dolphinPath, filename, kind: 'dolphin' });
@@ -4320,8 +4034,8 @@ function App() {
                 items.push({ path, filename, kind: 'z3ds' });
                 continue;
             }
-            if (!isArchiveItem && is3dsSourceFile(path) && entry.z3ds_ready) {
-                const productPath = entry.z3ds_path || get3dsProductPath(path);
+            if (!isArchiveItem && is3dsSourceFile(path) && entryOutputReady(entry, 'z3ds')) {
+                const productPath = entryOutputPath(entry, 'z3ds') || get3dsProductPath(path);
                 if (productPath) {
                     items.push({ path: productPath, filename, kind: 'z3ds' });
                 }
@@ -4770,13 +4484,13 @@ function App() {
             const isIso = ext === '.iso';
             const isChd = ext === '.chd';
             const inArchive = Boolean(entry.is_archive_item || entry.in_archive || entry.path?.includes('::'));
-            const canDolphin = entry.dolphin_convertible === true
+            const canDolphin = entryConvertibleBy(entry, 'dolphin')
                 && !inArchive
                 && (!isIso || isoHandling === 'dolphin');
-            const canChdCreate = entry.convertible === true
+            const canChdCreate = entryConvertibleBy(entry, 'chdman')
                 && !isChd
                 && (!isIso || isoHandling !== 'dolphin');
-            const canZ3ds = entry.z3ds_convertible === true && !inArchive;
+            const canZ3ds = entryConvertibleBy(entry, 'z3ds') && !inArchive;
             allowCreate = allowCreate && canChdCreate;
             allowExtract = allowExtract && isChd;
             allowCopy = allowCopy && isChd;
@@ -4955,16 +4669,16 @@ function App() {
             if (!isDolphinMode && isoHandling === 'dolphin') return false;
         }
         if (isDolphinMode) {
-            return entry.dolphin_convertible === true;
+            return entryConvertibleBy(entry, 'dolphin');
         }
         if (isZ3dsMode) {
-            return entry.z3ds_convertible === true;
+            return entryConvertibleBy(entry, 'z3ds');
         }
         if (isExtractMode || isCopyMode) {
             return entry.extension === '.chd';
         }
         if (conversionMode === 'createcd' || conversionMode === 'createdvd') {
-            return entry.convertible;
+            return entryConvertibleBy(entry, 'chdman');
         }
         if (isCreateMode) {
             return entry.extension !== '.chd';
@@ -5045,35 +4759,19 @@ function App() {
             setCurrentPage(1);
 
             const combined = [
-                ...results.files.map(f => ({
-                    ...f,
-                    type: 'file',
-                    convertible: Boolean(f.convertible),
-                    dolphin_convertible: Boolean(f.dolphin_convertible),
-                    has_rvz: Boolean(f.has_rvz),
-                    dolphin_ready: Boolean(f.dolphin_ready),
-                    dolphin_path: f.dolphin_path || null,
-                    z3ds_convertible: Boolean(f.z3ds_convertible),
-                    has_z3ds: Boolean(f.has_z3ds),
-                    z3ds_ready: Boolean(f.z3ds_ready),
-                    z3ds_path: f.z3ds_path || null,
-                    chd_ready: Boolean(f.chd_ready)
-                })),
+                // /api/files/search files[] already carry convertible_by /
+                // outputs from the registry-driven backend (Phase 7), so
+                // spread them through unchanged.
+                ...results.files.map(f => ({ ...f, type: 'file' })),
+                // archives[] members keep the legacy CHD-only dict shape;
+                // synthesize the unified outputs/convertible_by shape so the
+                // FE doesn't need to special-case archive rows.
                 ...results.archives.map(a => ({
                     ...a,
                     name: `${a.name} (in ${a.archive_path.split('/').pop()})`,
                     type: 'file',
-                    convertible: Boolean(a.convertible),
-                    dolphin_convertible: Boolean(a.dolphin_convertible),
-                    has_rvz: false,
-                    dolphin_ready: false,
-                    dolphin_path: null,
-                    has_z3ds: false,
-                    z3ds_ready: false,
-                    z3ds_path: null,
-                    chd_ready: Boolean(a.chd_ready),
-                    is_archive_item: true,
-                    chd_path: a.chd_path
+                    ...synthesizeArchiveOutputs(a),
+                    is_archive_item: true
                 }))
             ];
             setEntries(combined);

--- a/static/js/tools.js
+++ b/static/js/tools.js
@@ -1,0 +1,268 @@
+// Tool descriptor table for the frontend.
+//
+// app.js / api.js used to branch on per-tool identity (chdman / dolphin /
+// z3ds) at ~10 sites — primary-tool label/hint/filters, MODE_GROUPS, the
+// CHDInfoModal info-method routing, FileList badges + selectability, the
+// resolveSourceProduct preferredKinds ladder (duplicated in DeleteModal +
+// BulkDeleteModal), and the verify-batch dispatch. Phase 8 lifts those
+// branches into this descriptor + a small set of helpers.
+//
+// The helpers also drive the new (Phase 7) FileEntry.outputs /
+// FileEntry.convertible_by fields the backend now ships alongside the
+// legacy per-tool booleans, so app.js can drop the booleans entirely.
+
+import { api } from './api.js';
+
+const COMMON_FILTERS = [
+    { value: '', label: 'All Types' },
+    { value: '.zip,.7z,.rar', label: 'Archives' },
+    { value: '.chd', label: 'CHD Files' }
+];
+const CUSTOM_FILTER = { value: 'custom', label: 'Custom...' };
+
+const Z3DS_OUTPUT_EXTENSION_BY_SOURCE = {
+    '.3ds': '.z3ds',
+    '.cci': '.zcci',
+    '.cia': '.zcia'
+};
+
+function _ext(path) {
+    if (typeof path !== 'string') return '';
+    const lower = path.toLowerCase();
+    const lastSlash = Math.max(lower.lastIndexOf('/'), lower.lastIndexOf('\\'));
+    const filename = lastSlash >= 0 ? lower.slice(lastSlash + 1) : lower;
+    const dot = filename.lastIndexOf('.');
+    if (dot <= 0) return '';
+    return filename.slice(dot);
+}
+
+// --- outputs / convertible_by helpers -------------------------------------
+
+export function outputFor(entry, toolId) {
+    if (!entry || !Array.isArray(entry.outputs)) return null;
+    return entry.outputs.find(o => o?.tool_id === toolId) || null;
+}
+
+export function entryOutputExists(entry, toolId) {
+    return outputFor(entry, toolId) !== null;
+}
+
+export function entryOutputReady(entry, toolId) {
+    return outputFor(entry, toolId)?.exists === true;
+}
+
+export function entryOutputPath(entry, toolId) {
+    return outputFor(entry, toolId)?.path || null;
+}
+
+export function entryConvertibleBy(entry, toolId) {
+    return Array.isArray(entry?.convertible_by) && entry.convertible_by.includes(toolId);
+}
+
+// /api/files/archive (and the archives[] members in /api/files/search)
+// keep the legacy CHD-only dict shape — they don't carry outputs /
+// convertible_by. Convert that shape to the unified one when synthesizing
+// archive-member entries on the FE.
+export function synthesizeArchiveOutputs(file) {
+    const convertible_by = file?.convertible ? ['chdman'] : [];
+    const outputs = [];
+    if (file?.has_chd && file?.chd_path) {
+        const ready = Boolean(file.chd_ready);
+        outputs.push({
+            tool_id: 'chdman',
+            exists: ready,
+            ready,
+            path: file.chd_path
+        });
+    }
+    return { convertible_by, outputs };
+}
+
+function get3dsProductFromPath(path) {
+    const ext = _ext(path);
+    const outExt = Z3DS_OUTPUT_EXTENSION_BY_SOURCE[ext];
+    if (!outExt || typeof path !== 'string' || !path.toLowerCase().endsWith(ext)) {
+        return null;
+    }
+    return `${path.slice(0, -ext.length)}${outExt}`;
+}
+
+// --- TOOLS descriptor table -----------------------------------------------
+//
+// Each entry pairs a backend tool id with the FE-side bits app.js used to
+// inline. Source/verify/info extension lists mirror the backend tool's
+// input_extensions / verify_extensions / info-route accept-set. productPath
+// consults entry.outputs first and falls back to deriving from the source
+// path so callers that synthesize entries without outputs[] still work.
+
+export const TOOLS = [
+    {
+        id: 'chdman',
+        verifyKind: 'chd',
+        label: 'CHDMAN',
+        sourceExts: ['.gdi', '.iso', '.cue', '.bin'],
+        verifyExts: ['.chd'],
+        infoExts: ['.chd'],
+        hint: ({ html }) => html`Convert disc images to CHD format • Supports CD/DVD/LaserDisc`,
+        filters: [
+            ...COMMON_FILTERS,
+            { value: '.cue,.bin,.gdi,.iso', label: 'Disc Images' },
+            { value: '.iso', label: 'ISO Files' },
+            CUSTOM_FILTER
+        ],
+        modeGroups: [
+            { id: 'create', label: 'Create CHD', options: [
+                { value: 'createcd', label: 'Create CD CHD (Dreamcast, PS1, Sega CD)' },
+                { value: 'createdvd', label: 'Create DVD CHD (PSP, PS2)' },
+                { value: 'createraw', label: 'Create Raw CHD' },
+                { value: 'createhd', label: 'Create HD CHD' },
+                { value: 'createld', label: 'Create LaserDisc CHD' }
+            ]},
+            { id: 'extract', label: 'Extract from CHD', options: [
+                { value: 'extractcd', label: 'Extract CD (cue/bin)' },
+                { value: 'extractdvd', label: 'Extract DVD (iso)' },
+                { value: 'extractraw', label: 'Extract Raw' },
+                { value: 'extracthd', label: 'Extract HD' },
+                { value: 'extractld', label: 'Extract LaserDisc (avi)' }
+            ]},
+            { id: 'copy', label: 'Copy / Recompress', options: [
+                { value: 'copy', label: 'Copy / Recompress CHD' }
+            ]}
+        ],
+        getInfo: (path) => api.getCHDInfo(path),
+        verify: (path, opts) => api.verifyCHD(path, opts),
+        verifyBatch: (paths, opts) => api.verifyBatchCHDs(paths, opts),
+        productPath: (entry) => {
+            const out = outputFor(entry, 'chdman');
+            if (!out) return null;
+            if (out.path) return out.path;
+            if (typeof entry?.path !== 'string') return null;
+            return entry.path.replace(/\.[^.]+$/, '.chd');
+        },
+        badges: {
+            exists: { label: 'CHD exists', title: 'A CHD file already exists for this source' },
+            convertible: { label: 'Convertible', title: 'Can be converted to CHD' }
+        }
+    },
+    {
+        id: 'dolphin',
+        verifyKind: 'dolphin',
+        label: 'Dolphin',
+        sourceExts: ['.iso', '.gcz', '.wia', '.rvz', '.wbfs'],
+        verifyExts: ['.rvz', '.wia', '.gcz', '.wbfs', '.iso'],
+        infoExts: ['.rvz', '.wia', '.gcz', '.wbfs'],
+        hint: ({ html }) => html`Convert GameCube/Wii disc images • Supports RVZ, WIA, GCZ, ISO formats`,
+        filters: [
+            ...COMMON_FILTERS,
+            { value: '.iso,.rvz,.wia,.gcz,.wbfs', label: 'GameCube/Wii Images' },
+            { value: '.iso', label: 'ISO Files' },
+            CUSTOM_FILTER
+        ],
+        modeGroups: [
+            { id: 'dolphin', label: 'Dolphin (GameCube/Wii)', options: [
+                { value: 'dolphin_rvz', label: 'Convert to RVZ' },
+                { value: 'dolphin_wia', label: 'Convert to WIA' },
+                { value: 'dolphin_gcz', label: 'Convert to GCZ' },
+                { value: 'dolphin_iso', label: 'Convert to ISO (extract)' }
+            ]}
+        ],
+        getInfo: (path) => api.getDolphinInfo(path),
+        verify: (path, opts) => api.verifyDolphin(path, opts),
+        verifyBatch: (paths, opts) => api.verifyBatchDolphin(paths, opts),
+        productPath: (entry) => {
+            const out = outputFor(entry, 'dolphin');
+            if (!out || typeof entry?.path !== 'string') return null;
+            if (out.path) return out.path;
+            const ext = _ext(entry.path);
+            if (!ext || !entry.path.toLowerCase().endsWith(ext)) return null;
+            if (ext === '.iso') return `${entry.path.slice(0, -ext.length)}.rvz`;
+            return entry.path;
+        },
+        badges: {}
+    },
+    {
+        id: 'z3ds',
+        verifyKind: 'z3ds',
+        label: '3DS',
+        sourceExts: ['.3ds', '.cci', '.cia'],
+        verifyExts: ['.z3ds', '.zcci', '.zcia'],
+        infoExts: ['.3ds', '.cci', '.cia', '.z3ds', '.zcci', '.zcia'],
+        hint: ({ html }) => html`Compress Nintendo 3DS ROMs • Supports .cci/.cia/.3ds (cart & CIA) → .zcci/.zcia/.z3ds • ~50% size reduction • <strong>Decrypted ROMs only</strong>`,
+        filters: [
+            ...COMMON_FILTERS,
+            { value: '.cci,.cia,.3ds', label: '3DS ROMs' },
+            CUSTOM_FILTER
+        ],
+        modeGroups: [
+            { id: 'z3ds', label: 'Nintendo 3DS', options: [
+                { value: 'z3ds_compress', label: 'Compress to ZCCI/ZCIA/Z3DS' }
+            ]}
+        ],
+        getInfo: (path) => api.getZ3DSInfo(path),
+        verify: (path, opts) => api.verify3DS(path, opts),
+        verifyBatch: (paths, opts) => api.verifyBatchZ3DS(paths, opts),
+        productPath: (entry) => {
+            const out = outputFor(entry, 'z3ds');
+            if (!out) return null;
+            if (out.path) return out.path;
+            return get3dsProductFromPath(entry?.path);
+        },
+        badges: {
+            exists: { label: 'Z3DS exists', title: 'A compressed 3DS file (.zcci/.zcia/.z3ds) already exists' },
+            convertible: { label: '3DS ROM', title: 'Nintendo 3DS ROM - Can be compressed to ZCCI/ZCIA/Z3DS format' }
+        }
+    }
+];
+
+const TOOLS_BY_ID = Object.fromEntries(TOOLS.map(t => [t.id, t]));
+const TOOLS_BY_VERIFY_KIND = Object.fromEntries(TOOLS.map(t => [t.verifyKind, t]));
+
+export function getTool(id) {
+    return TOOLS_BY_ID[id] || null;
+}
+
+export function getToolByVerifyKind(kind) {
+    return TOOLS_BY_VERIFY_KIND[kind] || null;
+}
+
+export function getToolByMode(mode) {
+    for (const tool of TOOLS) {
+        for (const group of tool.modeGroups) {
+            if (group.options.some(opt => opt.value === mode)) return tool;
+        }
+    }
+    return null;
+}
+
+export function getToolByVerifyExt(path) {
+    const ext = _ext(path);
+    if (!ext) return null;
+    return TOOLS.find(t => t.verifyExts.includes(ext)) || null;
+}
+
+// Flat MODE_GROUPS, derived from each tool's modeGroups in TOOLS order
+// (chdman → dolphin → z3ds), so the rendered group order matches the
+// pre-migration literal in app.js.
+export const MODE_GROUPS = TOOLS.flatMap(t => t.modeGroups);
+
+// Tool ordering for preferredKinds resolution. When picking which output
+// to surface for a source entry (DeleteModal / BulkDeleteModal), prefer
+// the tool that matches the current primary-tool ("isoHandling") setting,
+// then fall through to the others.
+export const TOOL_ORDER_BY_ISO_HANDLING = {
+    dolphin: ['dolphin', 'chdman', 'z3ds'],
+    z3ds: ['z3ds', 'chdman', 'dolphin'],
+    chdman: ['chdman', 'dolphin', 'z3ds']
+};
+
+export function resolveSourceProduct(entry, isoHandling) {
+    if (!entry?.path) return null;
+    const order = TOOL_ORDER_BY_ISO_HANDLING[isoHandling] || TOOL_ORDER_BY_ISO_HANDLING.chdman;
+    for (const toolId of order) {
+        const tool = getTool(toolId);
+        if (!tool) continue;
+        const path = tool.productPath(entry);
+        if (path) return { path, kind: tool.verifyKind, toolId };
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary

Phase 8 of the tool plugin architecture refactor (design §3.7, §5 Phase 8): adds a single FE descriptor table and moves `app.js`/`api.js` off per-tool `if (tool === 'dolphin') …` chains and off the legacy per-tool `FileEntry` booleans onto the generic `entry.outputs` / `entry.convertible_by` fields that Phase 7 (#108) already ships.

Behavior-preserving and frontend-only — `routes/files.py` keeps emitting both shapes; this PR just changes what the JS reads.

### What changed

- **New `static/js/tools.js`**: exports `TOOLS` descriptor array (one row per tool: `id`, `label`, `hint`, `sourceExts`, `verifyExts`, `infoExts`, `filters`, `modeGroups`, `getInfo`, `verify`, `verifyBatch`, `productPath`, `badges`) and lookup helpers (`getTool`, `getToolByVerifyKind`, `getToolByMode`, `getToolByVerifyExt`, `resolveSourceProduct`). Also exports `outputs`/`convertible_by` accessors (`outputFor`, `entryOutputExists`, `entryOutputReady`, `entryOutputPath`, `entryConvertibleBy`) and a `synthesizeArchiveOutputs(file)` helper that bridges the legacy CHD-only archive-member dict shape into the unified one. `MODE_GROUPS` is now derived: `TOOLS.flatMap(t => t.modeGroups)` (chdman → dolphin → z3ds), so the rendered group order is unchanged.

- **Migrated `app.js` branch sites** (all → descriptor lookups):
  - `getPrimaryToolLabel` / `getPrimaryToolHint` / `getFilterOptions` (lifted into `TOOLS`)
  - `MODE_GROUPS` literal (now derived from descriptors)
  - `CHDInfoModal` info routing (`getToolByVerifyKind(mode).getInfo`)
  - `getDolphinProductPath` (thin wrapper over `getTool('dolphin').productPath`)
  - `FileList` `canInlineCompress`, `canSelectEntry`, `modeVisibility`, `getStatusPriority`, `getVerifiablePath`, `getVerifiableItems` — all read `outputs` / `convertible_by`
  - The three badge code paths (`CHD exists` / `Z3DS exists` / `Convertible` / `3DS ROM`) collapse into one parameterized `TOOLS.map(...)` pair (exists badges first, convertible badges second), preserving the legacy render order
  - The two duplicated `preferredKinds` / product-path blocks (`DeleteModal.resolveSourceProduct` + `BulkDeleteModal.resolveSourceProduct`) collapse into shared `resolveSourceProduct(entry, isoHandling)` in `tools.js`
  - `BulkDeleteModal.handleVerifyAll`'s three near-identical `api.verifyBatch{CHDs,Dolphin,Z3DS}` blocks loop over `getToolByVerifyKind(kind).verifyBatch`
  - `BulkVerifyModal` `all*` branches + `runBatch` route via `tool.verifyBatch`; the per-tool progress shapes (chdman splits `progress`/`file_progress`, dolphin ignores `currentProgress`, z3ds always sets it) are preserved
  - `handleVerify` routes through `verifyTool.verify` instead of binding `api.verifyCHD`/`verifyDolphin`/`verify3DS`
  - `refreshFileList` / `handleBrowseArchive` / `handleSearch` synthesize `outputs` / `convertible_by` for archive-member entries via `synthesizeArchiveOutputs`
  - The directory-listing diff check (debounces unchanged refreshes) now iterates `TOOLS` and compares per-tool `convertible_by` + each output's `exists`/`ready`/`path`

- **Archives** keep their special-cased badge code (`archive_has_chd` / `has_chd` on the archive entry itself); only archive *members* — which arrive without `outputs`/`convertible_by` — get synthesized into the unified shape.

- **`api.js` is untouched** — `tools.js` references existing methods.

- **Backend is untouched** — both legacy `FileEntry` booleans and `outputs`/`convertible_by` continue to ship on the wire (removal is Phase 9). Verified via a live request: `GET /api/files?path=…` returns both shapes consistently for `.iso` (chdman + dolphin convertible, dolphin output detected), `.3ds` (z3ds convertible), and `.rvz` (dolphin convertible + dolphin output).

### Test plan

- [x] `PYTHONPATH=app python -m pytest tests -q` → **570 passed** (no Python changes; backend is byte-identical)
- [x] `ruff check app tests` → **All checks passed!**
- [x] `npx eslint static/js/tools.js static/js/app.js` → clean (no errors, no warnings)
- [x] `node --check` both `static/js/tools.js` and `static/js/app.js` → parse clean
- [x] **Boot smoke test** in sandbox: `uvicorn main:app` starts cleanly, serves `/static/js/tools.js`, `/static/js/app.js`, `/static/js/api.js`, and `/` with HTTP 200
- [x] **API smoke test**: hit `/api/files` against a fixture dir with `.iso`/`.3ds`/`.rvz` files and confirmed `convertible_by` / `outputs` are populated correctly alongside the legacy booleans
- [ ] **Manual browser UI checklist per tool** (chdman, dolphin, z3ds): browse a directory containing a convertible source with no output, a source with a finished output, a mid-conversion source, a self-format dolphin input (`.rvz`), a `.3ds`, and an archive — confirm badges, row selectability, sort priority, and filter dropdown match `latest`; run the golden-path conversion and confirm SSE progress + the post-convert badge flip; run single + batch verify; open the info modal; confirm filters and the primary-tool label/hint. **Not executed in this sandbox** — the environment has no `chdman` / `dolphin-tool` / `z3ds_compressor` binaries or real media fixtures, so the full conversion/verify/info round-trips couldn't be exercised here. The descriptor-driven sites are 1:1 with the legacy branches they replace and the JS parses + lints + loads; a reviewer with a local environment per `ADDING_PLATFORMS_AND_TOOLS.md` §15 should walk the checklist before merging.

### LOC

`app.js`: −432 / +130 (net −302). `tools.js`: +268. Net −34 lines.

https://claude.ai/code/session_01NGxUBbx2JCgMrkyW1yWvYP

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGxUBbx2JCgMrkyW1yWvYP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated tool integration logic for more consistent output management and verification workflows across CHD, Dolphin, and 3DS formats. Improved output path resolution and status tracking for better reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacnpal/compressatorium/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->