### PR TITLE
feat(jobs): live toast for every running job + restore one-click "Search all"

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -93,9 +93,9 @@
     const list = jobs.jobs;
     const showExternalScan = jobs.showExternalScanJobs;
     for (const j of list) {
-      void j.status;
-      void j.progress;
-      void j.message;
+      void j?.status;
+      void j?.progress;
+      void j?.message;
     }
     jobToasts.reconcile(list, { showExternalScan });
   });

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,6 +12,7 @@
   import EmptyState from '$lib/components/ui/EmptyState.svelte';
   import Button from '$lib/components/ui/Button.svelte';
   import { jobs } from '$lib/stores/jobs.svelte.js';
+  import { jobToasts } from '$lib/stores/jobToasts.svelte.js';
   import { conversion } from '$lib/stores/conversion.svelte.js';
   import { verification } from '$lib/stores/verification.svelte.js';
   import { datMatching } from '$lib/stores/datMatching.svelte.js';
@@ -82,6 +83,23 @@
     fileBrowser.refresh().catch(() => {});
   });
 
+  // Surface a live toast for every RUNNING job and resolve it on
+  // completion. Iterating the list (and touching status/progress/message)
+  // subscribes the effect at index granularity, so SSE progress frames —
+  // which replace a job slot via index assignment in jobs._applyJob —
+  // re-run the reconcile. jobToasts keys each toast by job id, so this is
+  // idempotent across re-runs.
+  $effect(() => {
+    const list = jobs.jobs;
+    const showExternalScan = jobs.showExternalScanJobs;
+    for (const j of list) {
+      void j.status;
+      void j.progress;
+      void j.message;
+    }
+    jobToasts.reconcile(list, { showExternalScan });
+  });
+
   function handleSkip(e) {
     e.preventDefault();
     mainEl?.focus({ preventScroll: false });
@@ -103,6 +121,7 @@
     return () => {
       stopRouter();
       jobs.dispose();
+      jobToasts.dispose();
     };
   });
 </script>

--- a/src/lib/components/panels/FileList.svelte
+++ b/src/lib/components/panels/FileList.svelte
@@ -12,6 +12,7 @@
   import IconButton from '$lib/components/ui/IconButton.svelte';
   import RefreshCw from '@lucide/svelte/icons/refresh-cw';
   import Search from '@lucide/svelte/icons/search';
+  import FolderSearch from '@lucide/svelte/icons/folder-search';
   import XIcon from '@lucide/svelte/icons/x';
   import ChevronUp from '@lucide/svelte/icons/chevron-up';
   import ChevronDown from '@lucide/svelte/icons/chevron-down';
@@ -195,6 +196,14 @@
     </form>
 
     <div class="actions">
+      <IconButton
+        label="Search all convertible files (recursive, including inside archives)"
+        size="sm"
+        title="Search all — recursively list every convertible file under this folder, including inside archives"
+        onclick={() => fileBrowser.searchAll()}
+      >
+        <FolderSearch size={14} />
+      </IconButton>
       <label class="filter">
         <Filter size={12} />
         <select
@@ -246,7 +255,9 @@
     {#if searchMode}
       <EmptyState
         title="No matches"
-        description={`Nothing here matched "${fileBrowser.searchQuery}". Try a different query, or clear search to browse normally.`}
+        description={fileBrowser.searchQuery
+          ? `Nothing here matched "${fileBrowser.searchQuery}". Try a different query, or clear search to browse normally.`
+          : 'No convertible files were found anywhere under this folder (including inside archives). Clear search to browse normally.'}
         glyph="∅"
       />
     {:else}

--- a/src/lib/stores/fileBrowser.svelte.js
+++ b/src/lib/stores/fileBrowser.svelte.js
@@ -264,8 +264,12 @@ class FileBrowserStore {
     // and the user can re-act on them. When forced, re-run the
     // search instead of dropping the call entirely.
     if (this.searchMode) {
-      if (force && this.searchQuery) {
-        await this.search(this.searchQuery);
+      // Re-run the recursive scan, preserving the active filter — which
+      // is an empty string for a one-click "Search all" view, so we
+      // re-fetch on any forced refresh rather than gating on a non-empty
+      // query (the legacy "Search All" behaviour).
+      if (force && this.currentPath) {
+        await this._enterSearch(this.searchQuery);
       }
       return;
     }
@@ -320,14 +324,15 @@ class FileBrowserStore {
     if (this.page > max) this.page = max;
   }
 
-  async search(query) {
-    // /api/files/search has no query parameter — it returns every
-    // convertible file under the current path. The `query` is used
-    // client-side to filter the returned set (see sourceEntries).
-    if (!query) {
-      this.exitSearch();
-      return;
-    }
+  /**
+   * Run the recursive `/api/files/search` scan (subdirectories + inside
+   * archives) and flip into search mode on success, applying `query` as
+   * the client-side filter. An empty `query` is valid — it surfaces every
+   * convertible file in the tree (the legacy "Search All" view); see
+   * sourceEntries, which returns the full flattened set when searchQuery
+   * is blank.
+   */
+  async _enterSearch(query) {
     if (!this.currentPath) return;
     try {
       const data = await api.searchFiles(this.currentPath, true, true);
@@ -348,6 +353,31 @@ class FileBrowserStore {
       this.entriesError = e?.message ?? 'Search failed';
       // Stay out of search mode so the directory listing remains visible.
     }
+  }
+
+  /**
+   * Text-box search: filters the recursive result set by `query`. An
+   * empty query exits search and returns to the plain directory listing
+   * (the X / clear-search contract).
+   */
+  async search(query) {
+    // /api/files/search has no query parameter — it returns every
+    // convertible file under the current path. The `query` is used
+    // client-side to filter the returned set (see sourceEntries).
+    if (!query) {
+      this.exitSearch();
+      return;
+    }
+    await this._enterSearch(query);
+  }
+
+  /**
+   * One-click "Search all" — recursively list every convertible file
+   * under the current path, including files inside archives, with no
+   * text filter. Restores the legacy "🔍 Search All" action.
+   */
+  async searchAll() {
+    await this._enterSearch('');
   }
 
   exitSearch() {

--- a/src/lib/stores/jobToasts.svelte.js
+++ b/src/lib/stores/jobToasts.svelte.js
@@ -1,0 +1,151 @@
+// Per-job toast tracker. Surfaces a live toast for every RUNNING
+// (processing) job and resolves it to success/failure/cancelled when the
+// job reaches a terminal state.
+//
+// Why a dedicated module rather than inlining in JobRow: a job row only
+// exists while the Jobs panel is mounted and the job is on the visible
+// page. Toasts must follow the job across navigation, pagination, and the
+// queue/completed tab split — so the lifecycle is driven by reconciling
+// against the jobs store from a single long-lived $effect (wired in
+// App.svelte), keyed by job id so each running job owns exactly one toast.
+
+import { toast } from 'svelte-sonner';
+import { registry } from '$lib/tools/registry.js';
+
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
+// Mirror jobs.svelte.js: metadata_scan / dat_match are background
+// housekeeping jobs the queue hides by default. They run constantly as a
+// side-effect of browsing (FileList hydration kicks dat_match jobs), so
+// toasting them would flood the surface. They're only toasted when the
+// user has opted to show external-scan jobs in the queue.
+const EXTERNAL_SCAN_MODES = new Set(['metadata_scan', 'dat_match']);
+
+function filenameOf(job) {
+  return job?.file_path?.split(/[/\\]/).pop() ?? job?.file_path ?? 'Job';
+}
+
+/** Short "Tool · Mode" subtitle, e.g. "CHDMAN · Create CD". */
+function descriptorOf(job) {
+  const tool = registry.toolForMode(job?.mode);
+  const spec = registry.specFor(job?.mode);
+  const parts = [tool?.label, spec?.label ?? job?.mode].filter(Boolean);
+  return parts.join(' · ');
+}
+
+function runningDescription(job) {
+  const base = descriptorOf(job);
+  const pct =
+    typeof job?.progress === 'number' && job.progress > 0
+      ? `${Math.round(job.progress)}%`
+      : null;
+  // The backend message (e.g. "Cancelling…", "Verifying output") is the
+  // most useful line when present; fall back to the descriptor + percent.
+  const lead = job?.message || base;
+  if (pct && lead) return `${lead} · ${pct}`;
+  return pct ?? lead ?? 'Processing…';
+}
+
+class JobToastTracker {
+  // jobId → { toastId } for jobs that currently own a live toast.
+  //
+  // A plain null-prototype object, NOT a Map/SvelteMap. reconcile() runs
+  // inside the App.svelte $effect and both reads and writes this
+  // collection: a reactive SvelteMap would subscribe the effect to its
+  // own writes and loop (effect_update_depth_exceeded), while a plain Map
+  // trips the svelte/prefer-svelte-reactivity lint rule. The object map is
+  // the same non-reactive escape jobs.svelte.js uses for its transient
+  // id→state lookups — correct here and lint-clean.
+  _active = Object.create(null);
+
+  /**
+   * Reconcile the live toast set against the current jobs list.
+   *
+   * Called from a reactive $effect, so it re-runs on every job mutation
+   * (SSE progress frame, terminal event, snapshot hydration). Idempotent:
+   * re-running with unchanged input is a no-op beyond refreshing the
+   * in-place loading description.
+   *
+   * @param {Array<any>} jobList - jobs.jobs
+   * @param {{ showExternalScan?: boolean }} [opts]
+   */
+  reconcile(jobList, { showExternalScan = false } = {}) {
+    // Transient id→true membership scratch for this pass. Plain object for
+    // the same reason as _active (see the field comment).
+    const present = Object.create(null);
+
+    for (const job of jobList) {
+      const id = job?.id;
+      if (id == null) continue;
+      if (!showExternalScan && EXTERNAL_SCAN_MODES.has(job.mode)) continue;
+      present[id] = true;
+
+      const rec = this._active[id];
+
+      if (job.status === 'processing') {
+        const title = filenameOf(job);
+        const description = runningDescription(job);
+        if (rec) {
+          // Refresh the existing loading toast in place (progress bump,
+          // message change like "Cancelling…").
+          toast.loading(title, { id: rec.toastId, description });
+        } else {
+          const toastId = toast.loading(title, {
+            description,
+            duration: Number.POSITIVE_INFINITY,
+          });
+          this._active[id] = { toastId };
+        }
+      } else if (TERMINAL_STATUSES.has(job.status) && rec) {
+        this._resolve(job, rec.toastId);
+        delete this._active[id];
+      }
+      // queued / unknown: no toast yet — a job earns its toast when it
+      // starts processing, and historical terminal jobs we never tracked
+      // (rec === undefined) are skipped so a page reload doesn't replay
+      // "completed" toasts for old history.
+    }
+
+    // A running job can vanish from the list without a terminal frame —
+    // another tab clears it, or the backend prunes it. Dismiss its stale
+    // loading toast so it doesn't spin forever.
+    for (const id of Object.keys(this._active)) {
+      if (!present[id]) {
+        toast.dismiss(this._active[id].toastId);
+        delete this._active[id];
+      }
+    }
+  }
+
+  _resolve(job, toastId) {
+    const title = filenameOf(job);
+    if (job.status === 'completed') {
+      toast.success(title, {
+        id: toastId,
+        description: job.output_path ? `→ ${job.output_path}` : 'Completed',
+        duration: 4000,
+      });
+    } else if (job.status === 'failed') {
+      toast.error(title, {
+        id: toastId,
+        description: job.error_message || 'Failed',
+        duration: 6000,
+      });
+    } else {
+      toast.warning(title, {
+        id: toastId,
+        description: 'Cancelled',
+        duration: 3000,
+      });
+    }
+  }
+
+  /** Dismiss every live toast (called on app teardown). */
+  dispose() {
+    for (const id of Object.keys(this._active)) {
+      toast.dismiss(this._active[id].toastId);
+      delete this._active[id];
+    }
+  }
+}
+
+export const jobToasts = new JobToastTracker();

--- a/src/lib/stores/jobToasts.svelte.js
+++ b/src/lib/stores/jobToasts.svelte.js
@@ -40,9 +40,12 @@ function runningDescription(job) {
       : null;
   // The backend message (e.g. "Cancelling…", "Verifying output") is the
   // most useful line when present; fall back to the descriptor + percent.
+  // Use truthiness (not ??) for the fallbacks: `descriptorOf` returns ''
+  // for an unknown mode, and '' is not nullish — so `?? 'Processing…'`
+  // would surface a blank description instead of the fallback.
   const lead = job?.message || base;
-  if (pct && lead) return `${lead} · ${pct}`;
-  return pct ?? lead ?? 'Processing…';
+  if (lead && pct) return `${lead} · ${pct}`;
+  return lead || pct || 'Processing…';
 }
 
 class JobToastTracker {


### PR DESCRIPTION
## Summary

Two changes, both addressing UX that the Svelte 5 rebuild dropped from the previous (Preact) UI.

### 1. A live toast for every RUNNING job

The rebuild had no per-job notifications — only submit/connection/recovery toasts. Now every job in the `processing` state owns a live toast:

- New `src/lib/stores/jobToasts.svelte.js` tracker surfaces a svelte-sonner **loading** toast per running job, keyed by job id, updated in place with the backend message + progress %, and resolved to **success / error / cancelled** on the terminal frame.
- Driven by a single reconcile `$effect` in `App.svelte` against `jobs.jobs`, so it covers **every** running job — ones started in this tab, ones already running when the page loads (snapshot), and ones queued by other clients (30s poll) — not just freshly-submitted ones.
- Background `metadata_scan` / `dat_match` jobs are excluded unless the user has opted to show external-scan jobs in the queue (matches the queue's default visibility, avoids flooding the toast surface during browsing).
- The tracker uses null-prototype object maps (non-reactive on purpose): `reconcile` both reads and writes the collection from inside an effect, so a `SvelteMap` would self-trigger an `effect_update_depth_exceeded` loop. The object map is also clean under `svelte/prefer-svelte-reactivity` — the same escape `jobs.svelte.js` already uses.

### 2. Restore the one-click "Search all" (recursive, incl. archives)

**Investigation:** The previous web UI had a **🔍 Search All** button (_"Search recursively for all convertible files"_) that called `/api/files/search?recursive=true&include_archives=true` and listed every convertible file under the folder, including files inside archives. The backend endpoint is fully intact and the Svelte UI still calls it — but the rebuild rewired it behind the **"Search this folder…"** text box: the recursive scan only runs when you type a query, results are then filtered to substring matches, and an **empty query just exits search**. So the "show me everything convertible recursively, including inside archives" capability had no UI affordance anymore.

**Fix (purely additive):**
- `fileBrowser`: extracted `_enterSearch(query)`; `search('')` still exits (the text-box / clear-X contract), added `searchAll()` (empty filter ⇒ show the full recursive set), and forced refresh in search mode now re-runs the scan for the all-files view too.
- `FileList.svelte`: added a `FolderSearch` toolbar button — _"Search all — recursively list every convertible file under this folder, including inside archives"_ — and a tailored empty-state message for the no-filter case.

## Verification
- `npm run build` ✓ (only the pre-existing ConvertPanel unused-CSS warning)
- `npx eslint` ✓ clean on all changed files
- Svelte MCP `svelte-autofixer` ✓ no issues on the new module and the changed components

## Files
- `src/lib/stores/jobToasts.svelte.js` (new)
- `src/App.svelte` (reconcile effect + teardown)
- `src/lib/stores/fileBrowser.svelte.js` (`_enterSearch` / `searchAll` / refresh)
- `src/lib/components/panels/FileList.svelte` (Search all button + empty state)

https://claude.ai/code/session_01XrnBU9ApWLULCwcuV8ce7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrnBU9ApWLULCwcuV8ce7b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Search all convertible files" button for recursive searching, including inside archives
  * Job status notifications now display as toast messages during processing

* **Improvements**
  * Enhanced empty state messaging to clarify whether no files were found due to search query or unavailable convertible files in the directory

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pacnpal/compressatorium/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->