### PR TITLE
release: 4.0.0-beta-2 (archive conversion for every tool)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,6 @@
 # Release Notes
 
-## Unreleased
-
-### Archive conversion for every tool (issue #113)
+## 4.0.0-beta-2 — Archive conversion for every tool (issue #113) (2026-05-31)
 
 #### 🐛 Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compressatorium",
-  "version": "4.0.0-beta-1",
+  "version": "4.0.0-beta-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compressatorium",
-      "version": "4.0.0-beta-1",
+      "version": "4.0.0-beta-2",
       "dependencies": {
         "@lucide/svelte": "^1.17.0",
         "bits-ui": "^2.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compressatorium",
-  "version": "4.0.0-beta-1",
+  "version": "4.0.0-beta-2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Cuts **4.0.0-beta-2**.

- Bump `package.json` + `package-lock.json` to `4.0.0-beta-2`.
- Promote the `Unreleased` RELEASE_NOTES section (issue #113 — archive conversion for every tool) to a versioned `4.0.0-beta-2` heading.

Backend / REST / SSE contract unchanged from beta-1; this beta folds in the archive-conversion fix (#114 / #113).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archive conversion support is now available for every tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->