### PR TITLE
fix(ui): instant feedback + clear label for "Search all"

### DIFF
--- a/src/lib/components/panels/ConvertPanel.svelte
+++ b/src/lib/components/panels/ConvertPanel.svelte
@@ -285,7 +285,6 @@
     font-size: var(--text-sm);
     align-items: flex-start;
   }
-  .warning strong { font-weight: var(--weight-semibold); }
   .warning.info { background: var(--info-muted); color: var(--info); }
 
   .actions {

--- a/src/lib/components/panels/FileList.svelte
+++ b/src/lib/components/panels/FileList.svelte
@@ -31,6 +31,7 @@
   const sortOrder = $derived(fileBrowser.sortOrder);
   const filter = $derived(fileBrowser.filter);
   const loading = $derived(fileBrowser.loading);
+  const searching = $derived(fileBrowser.searching);
   const error = $derived(fileBrowser.entriesError);
   const allSelected = $derived(fileBrowser.allVisibleSelected);
   const selectedCount = $derived(fileBrowser.selectedFiles.size);
@@ -196,14 +197,24 @@
     </form>
 
     <div class="actions">
-      <IconButton
-        label="Search all convertible files (recursive, including inside archives)"
-        size="sm"
-        title="Search all — recursively list every convertible file under this folder, including inside archives"
+      <button
+        type="button"
+        class="search-all"
+        class:busy={searching}
+        disabled={searching}
+        aria-label="Search all convertible files (recursive, including inside archives)"
+        aria-busy={searching}
+        title="Recursively list every convertible file under this folder, including inside archives"
         onclick={() => fileBrowser.searchAll()}
       >
-        <FolderSearch size={14} />
-      </IconButton>
+        {#if searching}
+          <Loader class="spin" size={14} />
+          <span>Searching…</span>
+        {:else}
+          <FolderSearch size={14} />
+          <span>Search all</span>
+        {/if}
+      </button>
       <label class="filter">
         <Filter size={12} />
         <select
@@ -378,6 +389,36 @@
     cursor: pointer;
   }
   .filter select:focus-visible { outline: none; }
+
+  .search-all {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-3);
+    background: var(--surface-2);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    color: var(--text-1);
+    font-size: var(--text-sm);
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease-out),
+      color var(--dur-fast) var(--ease-out),
+      border-color var(--dur-fast) var(--ease-out);
+  }
+  .search-all:hover:not(:disabled) {
+    background: var(--surface-3, var(--surface-2));
+    border-color: var(--border-strong, var(--border-subtle));
+  }
+  .search-all:focus-visible {
+    outline: 2px solid var(--accent, var(--text-1));
+    outline-offset: 1px;
+  }
+  .search-all:disabled,
+  .search-all.busy {
+    cursor: default;
+    color: var(--text-2);
+  }
 
   .selection-bar {
     display: flex;

--- a/src/lib/components/panels/FileList.svelte
+++ b/src/lib/components/panels/FileList.svelte
@@ -10,6 +10,7 @@
   import Pager from '$lib/components/ui/Pager.svelte';
   import EmptyState from '$lib/components/ui/EmptyState.svelte';
   import IconButton from '$lib/components/ui/IconButton.svelte';
+  import Button from '$lib/components/ui/Button.svelte';
   import RefreshCw from '@lucide/svelte/icons/refresh-cw';
   import Search from '@lucide/svelte/icons/search';
   import FolderSearch from '@lucide/svelte/icons/folder-search';
@@ -197,24 +198,18 @@
     </form>
 
     <div class="actions">
-      <button
-        type="button"
-        class="search-all"
-        class:busy={searching}
-        disabled={searching}
-        aria-label="Search all convertible files (recursive, including inside archives)"
-        aria-busy={searching}
+      <Button
+        variant="secondary"
+        size="sm"
+        loading={searching}
         title="Recursively list every convertible file under this folder, including inside archives"
         onclick={() => fileBrowser.searchAll()}
       >
-        {#if searching}
-          <Loader class="spin" size={14} />
-          <span>Searching…</span>
-        {:else}
-          <FolderSearch size={14} />
-          <span>Search all</span>
-        {/if}
-      </button>
+        {#snippet icon()}
+          {#if searching}<Loader class="spin" size={14} />{:else}<FolderSearch size={14} />{/if}
+        {/snippet}
+        {searching ? 'Searching…' : 'Search all'}
+      </Button>
       <label class="filter">
         <Filter size={12} />
         <select
@@ -389,36 +384,6 @@
     cursor: pointer;
   }
   .filter select:focus-visible { outline: none; }
-
-  .search-all {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    padding: var(--space-2) var(--space-3);
-    background: var(--surface-2);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    color: var(--text-1);
-    font-size: var(--text-sm);
-    white-space: nowrap;
-    cursor: pointer;
-    transition: background var(--dur-fast) var(--ease-out),
-      color var(--dur-fast) var(--ease-out),
-      border-color var(--dur-fast) var(--ease-out);
-  }
-  .search-all:hover:not(:disabled) {
-    background: var(--surface-3, var(--surface-2));
-    border-color: var(--border-strong, var(--border-subtle));
-  }
-  .search-all:focus-visible {
-    outline: 2px solid var(--accent, var(--text-1));
-    outline-offset: 1px;
-  }
-  .search-all:disabled,
-  .search-all.busy {
-    cursor: default;
-    color: var(--text-2);
-  }
 
   .selection-bar {
     display: flex;

--- a/src/lib/stores/fileBrowser.svelte.js
+++ b/src/lib/stores/fileBrowser.svelte.js
@@ -335,6 +335,10 @@ class FileBrowserStore {
    */
   async _enterSearch(query) {
     if (!this.currentPath) return;
+    // Drop overlapping searches — a second in-flight call would clear the
+    // `searching` flag when it finishes and let the busy state lift while
+    // an earlier request is still running.
+    if (this.searching) return;
     this.searching = true;
     // Clear any stale error from a prior failed search/load — symmetric
     // with the directory load paths. Otherwise the error banner survives

--- a/src/lib/stores/fileBrowser.svelte.js
+++ b/src/lib/stores/fileBrowser.svelte.js
@@ -336,6 +336,10 @@ class FileBrowserStore {
   async _enterSearch(query) {
     if (!this.currentPath) return;
     this.searching = true;
+    // Clear any stale error from a prior failed search/load — symmetric
+    // with the directory load paths. Otherwise the error banner survives
+    // through a retry and even past a later successful search.
+    this.entriesError = null;
     try {
       const data = await api.searchFiles(this.currentPath, true, true);
       // Flip into search mode only on success. If the request fails,

--- a/src/lib/stores/fileBrowser.svelte.js
+++ b/src/lib/stores/fileBrowser.svelte.js
@@ -33,6 +33,7 @@ class FileBrowserStore {
   searchMode = $state(false);
   searchResults = $state(null);
   searchQuery = $state('');
+  searching = $state(false);
 
   // View state
   filter = $state(null);
@@ -334,6 +335,7 @@ class FileBrowserStore {
    */
   async _enterSearch(query) {
     if (!this.currentPath) return;
+    this.searching = true;
     try {
       const data = await api.searchFiles(this.currentPath, true, true);
       // Flip into search mode only on success. If the request fails,
@@ -352,6 +354,8 @@ class FileBrowserStore {
     } catch (e) {
       this.entriesError = e?.message ?? 'Search failed';
       // Stay out of search mode so the directory listing remains visible.
+    } finally {
+      this.searching = false;
     }
   }
 


### PR DESCRIPTION
## What changed

The "Search all" button (the folder-search icon in the file list toolbar) kicked off a recursive search, including inside archives, with no loading state. Clicking it looked like nothing happened until results came back, which on a big folder is a few seconds of silence. The old frontend gave instant feedback here.

Three changes:

- Added a `searching` flag on the `fileBrowser` store. `_enterSearch` sets it true on entry and clears it in a `finally`, so it's correct on both success and failure.
- The button now shows a spinner and "Searching…" while the search runs and disables itself, same pattern the Refresh button already uses.
- Replaced the icon-only button with a labeled "Search all" button so it's clear what it does.

Also removed a dead `.warning strong` CSS selector in `ConvertPanel.svelte`. It matched nothing and was the only svelte-check warning.

## Testing

`npx svelte-check` is clean: 0 errors, 0 warnings.

To check it by hand: run `npm run dev`, open a folder with archives, and click "Search all". The spinner should fire on click, not after the results land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Search all" button that displays a loading indicator while performing recursive file searches.

* **Style**
  * Updated warning message styling with improved visual treatment and color scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->