### PR TITLE
Change 'Actions' header to be visible

### DIFF
--- a/src/lib/components/panels/FileList.svelte
+++ b/src/lib/components/panels/FileList.svelte
@@ -302,7 +302,7 @@
               </button>
             </th>
             <th>Status</th>
-            <th class="actions"><span class="sr-only">Actions</span></th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>

--- a/src/lib/components/panels/FileList.svelte
+++ b/src/lib/components/panels/FileList.svelte
@@ -302,7 +302,7 @@
               </button>
             </th>
             <th>Status</th>
-            <th>Actions</th>
+            <th class="actions">Actions</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
This pull request makes a minor accessibility-related update to the `FileList.svelte` component. The "Actions" table header now displays the text "Actions" directly instead of using a screen-reader-only span.