### PR TITLE
feat(ui): resizable panels + table columns with server-stored widths

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ from config import settings
 from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
-from routes import convert, dat, files, info
+from routes import convert, dat, files, info, preferences
 from services.job_manager import job_manager
 
 
@@ -283,6 +283,7 @@ app.include_router(files.router, prefix="/api", tags=["files"])
 app.include_router(convert.router, prefix="/api", tags=["convert"])
 app.include_router(info.router, prefix="/api", tags=["info"])
 app.include_router(dat.router, prefix="/api", tags=["dat"])
+app.include_router(preferences.router, prefix="/api", tags=["preferences"])
 
 
 @app.get("/health")

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class ConversionMode(str, Enum):
@@ -209,3 +209,18 @@ class Z3DSInfo(BaseModel):
     extension: str
     compressed: bool
     compression_type: str | None = None
+
+
+class LayoutPreferences(BaseModel):
+    """Workspace layout widths persisted across sessions.
+
+    ``panels`` holds the global panel-split widths (px); ``columns`` holds
+    per-tool table column widths keyed by tool id. Extra keys are allowed
+    so the client can evolve the shape without a schema change here — the
+    server just stores and returns the JSON.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    panels: dict | None = None
+    columns: dict | None = None

--- a/app/routes/preferences.py
+++ b/app/routes/preferences.py
@@ -1,0 +1,33 @@
+"""Preferences routes — server-stored UI layout widths.
+
+Single-user app, no auth. The workspace layout (panel split + per-tool
+table column widths) lives under the ``layout`` preference key so it
+survives a browser/cache wipe.
+"""
+
+import logging
+
+from fastapi import APIRouter
+from models import LayoutPreferences
+from services.preferences_store import preferences_store
+
+logger = logging.getLogger("chd.routes.preferences")
+
+router = APIRouter()
+
+# The single key the workspace layout is stored under.
+LAYOUT_KEY = "layout"
+
+
+@router.get("/preferences")
+async def get_preferences() -> dict:
+    """Return the stored workspace layout, or an empty object if unset."""
+    stored = await preferences_store.get(LAYOUT_KEY)
+    return stored or {}
+
+
+@router.put("/preferences")
+async def put_preferences(prefs: LayoutPreferences) -> dict:
+    """Upsert the workspace layout and return the saved object."""
+    payload = prefs.model_dump(exclude_none=True)
+    return await preferences_store.put(LAYOUT_KEY, payload)

--- a/app/services/db.py
+++ b/app/services/db.py
@@ -131,6 +131,20 @@ class Verification(Base):
     verified_at = Column(String, nullable=False, default="")
 
 
+class Preference(Base):
+    """Generic key/value store for app preferences (UI layout, etc.).
+
+    A single row per key holds an arbitrary JSON blob.  Kept generic so
+    future preferences reuse the same table instead of growing a column
+    per setting.
+    """
+
+    __tablename__ = "preferences"
+    key = Column(String, primary_key=True)
+    value = Column(JSON, nullable=False, default=dict)
+    updated_at = Column(String, nullable=False, default="")
+
+
 # Additional index on dat_matches.dat_id so cascade-on-DAT-delete is
 # O(rows-in-that-DAT) rather than a full table scan.
 Index("ix_dat_matches_dat_id", DATMatch.dat_id)

--- a/app/services/preferences_store.py
+++ b/app/services/preferences_store.py
@@ -1,0 +1,93 @@
+"""SQLite-backed preferences store.
+
+A generic key/value store for app preferences (UI layout widths, etc.).
+Each key holds an arbitrary JSON object.  Mirrors the session-handling
+pattern of the other stores so it drops into the same engine lifecycle.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi.concurrency import run_in_threadpool
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from services import db as _db
+
+logger = logging.getLogger("chd.preferences_store")
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class PreferencesStore:
+    """Persists arbitrary JSON preference blobs keyed by a string."""
+
+    def __init__(
+        self,
+        store_path: str | None = None,
+        *,
+        session_factory: sessionmaker[Session] | None = None,
+    ) -> None:
+        if session_factory is not None:
+            self._session_factory = session_factory
+            self._own_engine: Engine | None = None
+        elif store_path is not None:
+            self._own_engine = _db.make_engine(str(store_path))
+            _db.Base.metadata.create_all(self._own_engine)
+            self._session_factory = sessionmaker(
+                bind=self._own_engine, expire_on_commit=False, future=True,
+            )
+        else:
+            self._own_engine = None
+            self._session_factory = None
+
+    def _session(self) -> Session:
+        if self._session_factory is not None:
+            return self._session_factory()
+        if _db.SessionLocal is None:
+            raise RuntimeError(
+                "PreferencesStore: db.SessionLocal not initialized — call "
+                "db.init_engine() before using the store.",
+            )
+        return _db.SessionLocal()
+
+    # ------------------------------------------------------------------
+
+    def _get_sync(self, key: str) -> dict | None:
+        with self._session() as session:
+            row = session.get(_db.Preference, key)
+            return dict(row.value) if row is not None and row.value is not None else None
+
+    async def get(self, key: str) -> dict | None:
+        """Return the stored JSON object for *key*, or None if unset."""
+        return await run_in_threadpool(self._get_sync, key)
+
+    def _put_sync(self, key: str, value: dict) -> dict:
+        stmt = sqlite_insert(_db.Preference).values(
+            key=key,
+            value=value,
+            updated_at=_utcnow_iso(),
+        )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["key"],
+            set_={
+                "value": stmt.excluded.value,
+                "updated_at": stmt.excluded.updated_at,
+            },
+        )
+        with self._session() as session:
+            session.execute(stmt)
+            session.commit()
+        return value
+
+    async def put(self, key: str, value: dict) -> dict:
+        """Upsert *value* under *key*, stamping updated_at. Returns value."""
+        return await run_in_threadpool(self._put_sync, key, value)
+
+
+preferences_store = PreferencesStore()

--- a/app/services/preferences_store.py
+++ b/app/services/preferences_store.py
@@ -61,7 +61,12 @@ class PreferencesStore:
     def _get_sync(self, key: str) -> dict | None:
         with self._session() as session:
             row = session.get(_db.Preference, key)
-            return dict(row.value) if row is not None and row.value is not None else None
+            if row is None or row.value is None:
+                return None
+            # SQLAlchemy decodes the JSON column to a fresh object per
+            # query, so returning it directly is safe (no shared state)
+            # and avoids coercing a non-dict blob through dict().
+            return row.value
 
     async def get(self, key: str) -> dict | None:
         """Return the stored JSON object for *key*, or None if unset."""

--- a/migrations/versions/0002_add_preferences_table.py
+++ b/migrations/versions/0002_add_preferences_table.py
@@ -21,6 +21,15 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # Tolerate a pre-created table. apply_migrations() documents the
+    # create_all-then-stamp path as supported: a DB built from the current
+    # ORM metadata (which already includes the Preference model) gets
+    # stamped at baseline 0001, then this migration runs. An unconditional
+    # CREATE TABLE would raise "table preferences already exists" there, so
+    # only create it when missing.
+    bind = op.get_bind()
+    if 'preferences' in sa.inspect(bind).get_table_names():
+        return
     op.create_table('preferences',
     sa.Column('key', sa.String(), nullable=False),
     sa.Column('value', sa.JSON(), nullable=False),

--- a/migrations/versions/0002_add_preferences_table.py
+++ b/migrations/versions/0002_add_preferences_table.py
@@ -1,0 +1,34 @@
+"""add_preferences_table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-05-31 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0002'
+down_revision: Union[str, Sequence[str], None] = '0001'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('preferences',
+    sa.Column('key', sa.String(), nullable=False),
+    sa.Column('value', sa.JSON(), nullable=False),
+    sa.Column('updated_at', sa.String(), nullable=False),
+    sa.PrimaryKeyConstraint('key')
+    )
+
+
+def downgrade() -> None:
+    # Downgrade migrations are not supported in this project — forward-only.
+    raise NotImplementedError("downgrade not supported")

--- a/src/lib/api/endpoints.js
+++ b/src/lib/api/endpoints.js
@@ -67,6 +67,21 @@ export const api = {
   // ─── Volumes ──────────────────────────────────────────────────────────
   getVolumes: () => fetchJson(`${API_BASE}/volumes`, undefined, 'Failed to fetch volumes'),
 
+  // ─── Preferences (server-stored UI layout) ─────────────────────────────
+  getPreferences: () =>
+    fetchJson(`${API_BASE}/preferences`, undefined, 'Failed to fetch preferences'),
+  putPreferences(layout) {
+    return fetchJson(
+      `${API_BASE}/preferences`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(layout),
+      },
+      'Failed to save preferences',
+    );
+  },
+
   // ─── Files ────────────────────────────────────────────────────────────
   listFiles(path, showArchives = true) {
     const params = new URLSearchParams({ path, show_archives: String(showArchives) });

--- a/src/lib/components/panels/FileList.svelte
+++ b/src/lib/components/panels/FileList.svelte
@@ -11,6 +11,8 @@
   import EmptyState from '$lib/components/ui/EmptyState.svelte';
   import IconButton from '$lib/components/ui/IconButton.svelte';
   import Button from '$lib/components/ui/Button.svelte';
+  import Splitter from '$lib/components/ui/Splitter.svelte';
+  import { layout } from '$lib/stores/layout.svelte.js';
   import RefreshCw from '@lucide/svelte/icons/refresh-cw';
   import Search from '@lucide/svelte/icons/search';
   import FolderSearch from '@lucide/svelte/icons/folder-search';
@@ -33,6 +35,23 @@
   const filter = $derived(fileBrowser.filter);
   const loading = $derived(fileBrowser.loading);
   const searching = $derived(fileBrowser.searching);
+
+  // Resizable table columns, stored per tool. `cols` carries the
+  // effective widths (defaults filled in); `nameSet` is the explicit
+  // Name width if the user has dragged it — when unset, Name has no fixed
+  // width so it absorbs the table's slack. The table min-width forces the
+  // horizontal scrollbar once the fixed columns outgrow the container.
+  const colTool = $derived(ui.workspaceTool);
+  const cols = $derived(layout.columnsFor(colTool));
+  const nameSet = $derived(layout.columns[colTool]?.name ?? null);
+  const tableMinWidth = $derived(32 + 40 + cols.size + cols.ext + cols.status + (nameSet ?? 160));
+
+  // Snapshot of a column's width at drag start; the move handler applies
+  // the cumulative delta on top of it.
+  let dragColStart = 0;
+  function startColDrag(col) {
+    dragColStart = cols[col];
+  }
   const error = $derived(fileBrowser.entriesError);
   const allSelected = $derived(fileBrowser.allVisibleSelected);
   const selectedCount = $derived(fileBrowser.selectedFiles.size);
@@ -275,7 +294,28 @@
     {/if}
   {:else}
     <div class="table-wrap">
-      <table class="table" aria-label={searchMode ? 'Search results' : 'Files'}>
+      {#snippet colHandle(col, label)}
+        <span class="col-resize">
+          <Splitter
+            variant="column"
+            label={label}
+            value={cols[col]}
+            onstart={() => startColDrag(col)}
+            onmove={(d) => layout.setColumnWidth(colTool, col, dragColStart + d)}
+            onstep={(d) => layout.setColumnWidth(colTool, col, cols[col] + d)}
+            onreset={() => layout.resetColumn(colTool, col)}
+          />
+        </span>
+      {/snippet}
+      <table class="table" style="min-width: {tableMinWidth}px;" aria-label={searchMode ? 'Search results' : 'Files'}>
+        <colgroup>
+          <col class="col-sel" />
+          <col style={nameSet ? `width: ${nameSet}px` : undefined} />
+          <col style="width: {cols.size}px" />
+          <col style="width: {cols.ext}px" />
+          <col style="width: {cols.status}px" />
+          <col class="col-actions" />
+        </colgroup>
         <thead>
           <tr>
             <th class="sel">
@@ -286,22 +326,28 @@
                 aria-label={allSelected ? 'Deselect all' : 'Select all visible'}
               />
             </th>
-            <th aria-sort={sortAria('name')}>
+            <th class="resizable" aria-sort={sortAria('name')}>
               <button type="button" class="th-button" onclick={() => fileBrowser.setSort('name')}>
                 Name {#if sortBy === 'name'}{@const Icon = sortIcon('name')}<Icon size={12} class="sort-i" />{:else}<ChevronsUpDown size={12} class="sort-i muted" />{/if}
               </button>
+              {@render colHandle('name', 'Resize Name column')}
             </th>
-            <th class="size" aria-sort={sortAria('size')}>
+            <th class="size resizable" aria-sort={sortAria('size')}>
               <button type="button" class="th-button" onclick={() => fileBrowser.setSort('size')}>
                 Size {#if sortBy === 'size'}{@const Icon = sortIcon('size')}<Icon size={12} class="sort-i" />{:else}<ChevronsUpDown size={12} class="sort-i muted" />{/if}
               </button>
+              {@render colHandle('size', 'Resize Size column')}
             </th>
-            <th class="ext" aria-sort={sortAria('extension')}>
+            <th class="ext resizable" aria-sort={sortAria('extension')}>
               <button type="button" class="th-button" onclick={() => fileBrowser.setSort('extension')}>
                 Ext {#if sortBy === 'extension'}{@const Icon = sortIcon('extension')}<Icon size={12} class="sort-i" />{:else}<ChevronsUpDown size={12} class="sort-i muted" />{/if}
               </button>
+              {@render colHandle('ext', 'Resize Ext column')}
             </th>
-            <th>Status</th>
+            <th class="resizable">
+              Status
+              {@render colHandle('status', 'Resize Status column')}
+            </th>
             <th class="actions"><span class="sr-only">Actions</span></th>
           </tr>
         </thead>
@@ -444,9 +490,16 @@
   .table {
     width: 100%;
     border-collapse: collapse;
-    table-layout: auto;
+    /* Fixed layout so column widths come from the <colgroup> (driven by
+       the per-tool layout store) instead of content. min-width on the
+       table (set inline) lets .table-wrap scroll horizontally once the
+       columns outgrow the panel. */
+    table-layout: fixed;
   }
+  .table col.col-sel { width: 32px; }
+  .table col.col-actions { width: 40px; }
   thead th {
+    position: relative;
     text-align: left;
     padding: var(--space-2) var(--space-3);
     background: var(--surface-2);
@@ -458,10 +511,21 @@
     border-bottom: 1px solid var(--border-subtle);
     white-space: nowrap;
   }
-  thead th.sel { width: 32px; text-align: center; padding: var(--space-2); }
-  thead th.size { width: 80px; text-align: right; }
-  thead th.ext { width: 60px; }
-  thead th.actions { width: 40px; }
+  thead th.sel { text-align: center; padding: var(--space-2); }
+  thead th.size { text-align: right; }
+  thead th.actions { text-align: center; }
+  /* The resize handle straddles the right border of a header cell. */
+  .col-resize {
+    position: absolute;
+    top: 0;
+    right: -5px;
+    height: 100%;
+    display: flex;
+    z-index: 2;
+  }
+  /* The Size column's sort button is right-aligned, so its handle would
+     overlap the label; nudge the button clear of the grab area. */
+  thead th.size .th-button { margin-right: var(--space-1); }
   .th-button {
     background: none;
     border: none;

--- a/src/lib/components/panels/FileList.svelte
+++ b/src/lib/components/panels/FileList.svelte
@@ -49,8 +49,19 @@
   // Snapshot of a column's width at drag start; the move handler applies
   // the cumulative delta on top of it.
   let dragColStart = 0;
+  let tableEl = $state(null);
   function startColDrag(col) {
-    dragColStart = cols[col];
+    // Measure the actual rendered header width rather than trusting the
+    // stored value. The Name column flexes when unset, so its real width
+    // is wider than the default — without this it would jump to the
+    // default on the first drag. Pin that measured width so Name keeps
+    // its place and resizing continues smoothly from there.
+    const th = tableEl?.querySelector(`th[data-col="${col}"]`);
+    const measured = th?.offsetWidth;
+    dragColStart = measured ?? cols[col];
+    if (col === 'name' && nameSet == null && measured) {
+      layout.setColumnWidth(colTool, 'name', measured);
+    }
   }
   const error = $derived(fileBrowser.entriesError);
   const allSelected = $derived(fileBrowser.allVisibleSelected);
@@ -300,6 +311,8 @@
             variant="column"
             label={label}
             value={cols[col]}
+            min={layout.columnLimit(col).min}
+            max={layout.columnLimit(col).max}
             onstart={() => startColDrag(col)}
             onmove={(d) => layout.setColumnWidth(colTool, col, dragColStart + d)}
             onstep={(d) => layout.setColumnWidth(colTool, col, cols[col] + d)}
@@ -307,7 +320,7 @@
           />
         </span>
       {/snippet}
-      <table class="table" style="min-width: {tableMinWidth}px;" aria-label={searchMode ? 'Search results' : 'Files'}>
+      <table bind:this={tableEl} class="table" style="min-width: {tableMinWidth}px;" aria-label={searchMode ? 'Search results' : 'Files'}>
         <colgroup>
           <col class="col-sel" />
           <col style={nameSet ? `width: ${nameSet}px` : undefined} />
@@ -326,25 +339,25 @@
                 aria-label={allSelected ? 'Deselect all' : 'Select all visible'}
               />
             </th>
-            <th class="resizable" aria-sort={sortAria('name')}>
+            <th class="resizable" data-col="name" aria-sort={sortAria('name')}>
               <button type="button" class="th-button" onclick={() => fileBrowser.setSort('name')}>
                 Name {#if sortBy === 'name'}{@const Icon = sortIcon('name')}<Icon size={12} class="sort-i" />{:else}<ChevronsUpDown size={12} class="sort-i muted" />{/if}
               </button>
               {@render colHandle('name', 'Resize Name column')}
             </th>
-            <th class="size resizable" aria-sort={sortAria('size')}>
+            <th class="size resizable" data-col="size" aria-sort={sortAria('size')}>
               <button type="button" class="th-button" onclick={() => fileBrowser.setSort('size')}>
                 Size {#if sortBy === 'size'}{@const Icon = sortIcon('size')}<Icon size={12} class="sort-i" />{:else}<ChevronsUpDown size={12} class="sort-i muted" />{/if}
               </button>
               {@render colHandle('size', 'Resize Size column')}
             </th>
-            <th class="ext resizable" aria-sort={sortAria('extension')}>
+            <th class="ext resizable" data-col="ext" aria-sort={sortAria('extension')}>
               <button type="button" class="th-button" onclick={() => fileBrowser.setSort('extension')}>
                 Ext {#if sortBy === 'extension'}{@const Icon = sortIcon('extension')}<Icon size={12} class="sort-i" />{:else}<ChevronsUpDown size={12} class="sort-i muted" />{/if}
               </button>
               {@render colHandle('ext', 'Resize Ext column')}
             </th>
-            <th class="resizable">
+            <th class="resizable" data-col="status">
               Status
               {@render colHandle('status', 'Resize Status column')}
             </th>
@@ -551,18 +564,6 @@
     padding: var(--space-1);
   }
   .muted { color: var(--text-3); font-size: var(--text-sm); }
-
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0,0,0,0);
-    white-space: nowrap;
-    border: 0;
-  }
 
   :global(.filelist .spin) { animation: spin 0.9s linear infinite; }
   @keyframes spin { to { transform: rotate(360deg); } }

--- a/src/lib/components/ui/Splitter.svelte
+++ b/src/lib/components/ui/Splitter.svelte
@@ -59,7 +59,13 @@
   function endDrag(e) {
     if (!dragging) return;
     dragging = false;
-    e.currentTarget.releasePointerCapture?.(e.pointerId);
+    // releasePointerCapture throws (NotFoundError) if capture was never
+    // established or was already lost; we only care that the drag ends.
+    try {
+      e.currentTarget.releasePointerCapture?.(e.pointerId);
+    } catch {
+      // ignore — capture already gone
+    }
     onend?.();
   }
 

--- a/src/lib/components/ui/Splitter.svelte
+++ b/src/lib/components/ui/Splitter.svelte
@@ -1,0 +1,138 @@
+<script>
+  /**
+   * A draggable vertical separator. Generic enough to drive both the
+   * workspace panel split and individual table-column widths.
+   *
+   * It owns no width itself. During a drag it reports the cumulative
+   * pointer delta (px, positive = moved right) via `onmove`; the parent
+   * snapshots the starting width on `onstart` and applies the delta in
+   * whichever direction makes sense for that edge. Arrow keys nudge via
+   * `onstep`; double-click asks the parent to reset via `onreset`.
+   *
+   * @typedef {Object} Props
+   * @property {string} label - accessible name for the separator
+   * @property {number} [value] - current width, for aria-valuenow
+   * @property {number} [min] - for aria-valuemin
+   * @property {number} [max] - for aria-valuemax
+   * @property {number} [step] - keyboard nudge in px (default 8)
+   * @property {() => void} [onstart]
+   * @property {(delta: number) => void} [onmove]
+   * @property {() => void} [onend]
+   * @property {(delta: number) => void} [onstep]
+   * @property {() => void} [onreset]
+   * @property {'panel'|'column'} [variant]
+   */
+
+  /** @type {Props} */
+  let {
+    label,
+    value,
+    min,
+    max,
+    step = 8,
+    onstart,
+    onmove,
+    onend,
+    onstep,
+    onreset,
+    variant = 'panel',
+  } = $props();
+
+  let dragging = $state(false);
+  let startX = 0;
+
+  function pointerdown(e) {
+    // Left button / primary pointer only.
+    if (e.button != null && e.button !== 0) return;
+    e.preventDefault();
+    startX = e.clientX;
+    dragging = true;
+    e.currentTarget.setPointerCapture?.(e.pointerId);
+    onstart?.();
+  }
+
+  function pointermove(e) {
+    if (!dragging) return;
+    onmove?.(e.clientX - startX);
+  }
+
+  function endDrag(e) {
+    if (!dragging) return;
+    dragging = false;
+    e.currentTarget.releasePointerCapture?.(e.pointerId);
+    onend?.();
+  }
+
+  function keydown(e) {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      onstep?.(-step);
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      onstep?.(step);
+    } else if (e.key === 'Home' || e.key === 'Enter') {
+      // Enter/Home both reset to default — a discoverable keyboard path.
+      e.preventDefault();
+      onreset?.();
+    }
+  }
+</script>
+
+<!--
+  A focusable resizable separator is the WAI-ARIA "window splitter"
+  pattern (role=separator + tabindex + aria-valuenow). The a11y linter
+  treats `separator` as non-interactive and so flags the tabindex and
+  the pointer/key handlers; for this widget they're correct and required.
+-->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div
+  class="splitter {variant}"
+  class:dragging
+  role="separator"
+  aria-orientation="vertical"
+  aria-label={label}
+  aria-valuenow={value}
+  aria-valuemin={min}
+  aria-valuemax={max}
+  tabindex="0"
+  onpointerdown={pointerdown}
+  onpointermove={pointermove}
+  onpointerup={endDrag}
+  onpointercancel={endDrag}
+  ondblclick={() => onreset?.()}
+  onkeydown={keydown}
+></div>
+
+<style>
+  .splitter {
+    /* The visible bar is thin; the grab/hit area is wider via padding so
+       it's easy to land on without a precise mouse. */
+    align-self: stretch;
+    box-sizing: border-box;
+    background-clip: content-box;
+    cursor: col-resize;
+    touch-action: none;
+    user-select: none;
+    background-color: transparent;
+    transition: background-color var(--dur-fast) var(--ease-out);
+  }
+  .splitter.panel {
+    width: 9px;
+    padding-inline: 3px; /* 3px visible bar centered in a 9px hit area */
+  }
+  .splitter.column {
+    /* Sits on the right edge of a table header cell. */
+    width: 11px;
+    padding-inline: 5px;
+  }
+  .splitter:hover,
+  .splitter:focus-visible,
+  .splitter.dragging {
+    background-color: var(--accent, var(--text-2));
+  }
+  .splitter:focus-visible {
+    outline: 2px solid var(--accent, var(--text-1));
+    outline-offset: 1px;
+  }
+</style>

--- a/src/lib/components/views/WorkArea.svelte
+++ b/src/lib/components/views/WorkArea.svelte
@@ -1,12 +1,21 @@
 <script>
   import { ui } from '$lib/stores/ui.svelte.js';
   import { registry } from '$lib/tools/registry.js';
+  import { layout } from '$lib/stores/layout.svelte.js';
   import VolumeList from '$lib/components/panels/VolumeList.svelte';
   import FileList from '$lib/components/panels/FileList.svelte';
   import ConvertPanel from '$lib/components/panels/ConvertPanel.svelte';
   import JobsPanel from '$lib/components/panels/JobsPanel.svelte';
+  import Splitter from '$lib/components/ui/Splitter.svelte';
 
   const tool = $derived(registry.forTool(ui.workspaceTool));
+
+  // Snapshot the panel width at drag start; each move applies the
+  // cumulative delta. The left divider grows .side as it moves right;
+  // the right divider shrinks .right as it moves right (so the middle
+  // file list always absorbs the slack).
+  let dragStartLeft = 0;
+  let dragStartRight = 0;
 </script>
 
 <section class="view" aria-labelledby="workspace-title">
@@ -17,14 +26,38 @@
     </div>
   </header>
 
-  <div class="grid">
+  <div class="grid" style="--ws-left: {layout.panels.left}px; --ws-right: {layout.panels.right}px;">
     <aside class="side">
       <VolumeList />
     </aside>
 
+    <Splitter
+      variant="panel"
+      label="Resize volumes panel"
+      value={layout.panels.left}
+      min={160}
+      max={360}
+      onstart={() => (dragStartLeft = layout.panels.left)}
+      onmove={(d) => layout.setPanelWidth('left', dragStartLeft + d)}
+      onstep={(d) => layout.setPanelWidth('left', layout.panels.left + d)}
+      onreset={() => layout.resetPanel('left')}
+    />
+
     <article class="main">
       <FileList />
     </article>
+
+    <Splitter
+      variant="panel"
+      label="Resize convert and jobs panel"
+      value={layout.panels.right}
+      min={280}
+      max={640}
+      onstart={() => (dragStartRight = layout.panels.right)}
+      onmove={(d) => layout.setPanelWidth('right', dragStartRight - d)}
+      onstep={(d) => layout.setPanelWidth('right', layout.panels.right - d)}
+      onreset={() => layout.resetPanel('right')}
+    />
 
     <article class="right">
       <ConvertPanel />
@@ -40,7 +73,10 @@
     flex-direction: column;
     gap: var(--space-4);
     padding: var(--space-5);
-    max-width: var(--container-max);
+    /* Wider than the default --container-max: the file table needs the
+       room so all its columns show on a big monitor instead of scrolling
+       horizontally. Other views keep the narrower reading-width cap. */
+    max-width: 1760px;
     margin: 0 auto;
     width: 100%;
     min-width: 0;
@@ -62,11 +98,20 @@
     gap: var(--space-4);
     min-width: 0;
   }
+  /* Splitters only make sense in the 3-column desktop layout. Hidden
+     (and so removed from grid flow) below 1280px, where the right panel
+     stacks and the left rail is a fixed width. */
+  .grid :global(.splitter) { display: none; }
   @media (min-width: 900px) {
     .grid { grid-template-columns: 220px minmax(0, 1fr); }
   }
   @media (min-width: 1280px) {
-    .grid { grid-template-columns: 220px minmax(0, 1.5fr) minmax(320px, 1fr); }
+    .grid {
+      grid-template-columns:
+        var(--ws-left, 220px) auto minmax(0, 1fr) auto var(--ws-right, 360px);
+      gap: var(--space-2);
+    }
+    .grid :global(.splitter) { display: block; }
   }
 
   .side, .main, .right {

--- a/src/lib/components/views/WorkArea.svelte
+++ b/src/lib/components/views/WorkArea.svelte
@@ -98,10 +98,12 @@
     gap: var(--space-4);
     min-width: 0;
   }
-  /* Splitters only make sense in the 3-column desktop layout. Hidden
-     (and so removed from grid flow) below 1280px, where the right panel
-     stacks and the left rail is a fixed width. */
-  .grid :global(.splitter) { display: none; }
+  /* The panel splitters only make sense in the 3-column desktop layout.
+     Hidden (and so removed from grid flow) below 1280px, where the right
+     panel stacks and the left rail is a fixed width. Direct-child only:
+     the file table's column handles are also .splitter elements but live
+     deep inside .main, and must stay usable at every width. */
+  .grid > :global(.splitter) { display: none; }
   @media (min-width: 900px) {
     .grid { grid-template-columns: 220px minmax(0, 1fr); }
   }
@@ -111,7 +113,7 @@
         var(--ws-left, 220px) auto minmax(0, 1fr) auto var(--ws-right, 360px);
       gap: var(--space-2);
     }
-    .grid :global(.splitter) { display: block; }
+    .grid > :global(.splitter) { display: block; }
   }
 
   .side, .main, .right {

--- a/src/lib/stores/layout.svelte.js
+++ b/src/lib/stores/layout.svelte.js
@@ -157,9 +157,12 @@ class LayoutStore {
     if (local?.dirty) {
       // Local has an unsynced edit — it wins. Push it up rather than
       // overwriting it with whatever the server still holds.
+      const before = this.#mutationVersion;
       try {
         await api.putPreferences(this.#serialize());
-        this.#writeLocal(false);
+        // Only clear dirty if the user didn't drag again during the PUT;
+        // otherwise that newer edit is still unsaved and must stay dirty.
+        if (this.#mutationVersion === before) this.#writeLocal(false);
       } catch {
         // Still offline; leave dirty set so the next boot retries.
       }

--- a/src/lib/stores/layout.svelte.js
+++ b/src/lib/stores/layout.svelte.js
@@ -59,6 +59,10 @@ class LayoutStore {
   columns = $state({});
 
   #saveTimer = null;
+  // Bumped on every local edit. Captured before the boot server fetch so
+  // a late response can't clobber a width the user changed in the
+  // meantime.
+  #mutationVersion = 0;
 
   constructor() {
     const local = readLocal();
@@ -73,6 +77,11 @@ class LayoutStore {
   /** Column widths for a tool, defaults filled in for untouched columns. */
   columnsFor(toolId) {
     return { ...DEFAULT_COLUMNS, ...(this.columns[toolId] ?? {}) };
+  }
+
+  /** Min/max for a column, for the resize handle's aria-value range. */
+  columnLimit(col) {
+    return COLUMN_LIMITS[col] ?? { min: undefined, max: undefined };
   }
 
   // ── Mutations ────────────────────────────────────────────────────────
@@ -135,12 +144,36 @@ class LayoutStore {
     return { panels: { ...this.panels }, columns: { ...this.columns } };
   }
 
+  // `dirty` marks localStorage as holding an edit not yet confirmed saved
+  // to the server. If the tab closes before the debounced PUT fires, the
+  // next boot sees the flag and pushes local up instead of pulling stale
+  // server data down.
+  #writeLocal(dirty) {
+    writeString(STORAGE_KEYS.LAYOUT, JSON.stringify({ ...this.#serialize(), dirty }));
+  }
+
   async #syncFromServer() {
+    const local = readLocal();
+    if (local?.dirty) {
+      // Local has an unsynced edit — it wins. Push it up rather than
+      // overwriting it with whatever the server still holds.
+      try {
+        await api.putPreferences(this.#serialize());
+        this.#writeLocal(false);
+      } catch {
+        // Still offline; leave dirty set so the next boot retries.
+      }
+      return;
+    }
+    const before = this.#mutationVersion;
     try {
       const remote = await api.getPreferences();
+      // The user dragged something while the fetch was in flight — keep
+      // their in-progress layout instead of snapping back to the server's.
+      if (this.#mutationVersion !== before) return;
       if (remote && (remote.panels || remote.columns)) {
         this.#apply(remote);
-        writeString(STORAGE_KEYS.LAYOUT, JSON.stringify(this.#serialize()));
+        this.#writeLocal(false);
       }
     } catch {
       // Offline or endpoint missing — keep local values.
@@ -148,15 +181,23 @@ class LayoutStore {
   }
 
   #persist() {
-    const snapshot = this.#serialize();
-    writeString(STORAGE_KEYS.LAYOUT, JSON.stringify(snapshot));
+    this.#mutationVersion += 1;
+    const version = this.#mutationVersion;
+    // Mark dirty immediately so an unflushed change survives a tab close.
+    this.#writeLocal(true);
     if (!isBrowser) return;
     if (this.#saveTimer) clearTimeout(this.#saveTimer);
     this.#saveTimer = setTimeout(() => {
       this.#saveTimer = null;
-      api.putPreferences(snapshot).catch(() => {
-        // Best-effort; localStorage already holds the change.
-      });
+      const snapshot = this.#serialize();
+      api.putPreferences(snapshot)
+        .then(() => {
+          // Only clear dirty if no newer edit landed while saving.
+          if (this.#mutationVersion === version) this.#writeLocal(false);
+        })
+        .catch(() => {
+          // Best-effort; localStorage keeps the dirty change.
+        });
     }, SAVE_DEBOUNCE_MS);
   }
 }

--- a/src/lib/stores/layout.svelte.js
+++ b/src/lib/stores/layout.svelte.js
@@ -1,0 +1,164 @@
+// Workspace layout widths: the panel split (file list vs the right
+// Convert/Jobs panel) and the file table's column widths.
+//
+// Persistence is local-first with server sync. localStorage is read
+// synchronously on construct so widths apply with no flash; the server
+// copy is then fetched and, if present, wins and is written back to
+// localStorage. Every change writes localStorage immediately and PUTs
+// to the server debounced, so the layout survives a browser/cache wipe
+// and follows the user across browsers.
+//
+// Panel widths are global. Column widths are per tool (chdman / dolphin
+// / z3ds) because each tool lists different file types.
+
+import { STORAGE_KEYS, readString, writeString } from '$lib/util/localStorage.js';
+import { api } from '$lib/api/endpoints.js';
+
+const SAVE_DEBOUNCE_MS = 500;
+
+// Defaults mirror the static CSS the resizable layout replaces.
+const DEFAULT_PANELS = Object.freeze({ left: 220, right: 360 });
+const DEFAULT_COLUMNS = Object.freeze({ name: 360, size: 80, ext: 60, status: 160 });
+
+// Clamp ranges keep a drag from collapsing a panel/column to nothing or
+// stretching it past anything useful.
+const PANEL_LIMITS = Object.freeze({
+  left: { min: 160, max: 360 },
+  right: { min: 280, max: 640 },
+});
+const COLUMN_LIMITS = Object.freeze({
+  name: { min: 120, max: 900 },
+  size: { min: 48, max: 240 },
+  ext: { min: 48, max: 240 },
+  status: { min: 80, max: 480 },
+});
+
+const isBrowser = typeof window !== 'undefined';
+
+function clamp(value, { min, max }) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return min;
+  return Math.min(max, Math.max(min, Math.round(n)));
+}
+
+function readLocal() {
+  const raw = readString(STORAGE_KEYS.LAYOUT, null);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+class LayoutStore {
+  panels = $state({ ...DEFAULT_PANELS });
+  // { [toolId]: { name, size, ext, status } } — only the keys a user has
+  // actually dragged are stored; columnsFor() merges over defaults.
+  columns = $state({});
+
+  #saveTimer = null;
+
+  constructor() {
+    const local = readLocal();
+    if (local) this.#apply(local);
+    // Reconcile with the server copy after first paint. Fire-and-forget:
+    // a failed fetch just leaves the local values in place.
+    if (isBrowser) this.#syncFromServer();
+  }
+
+  // ── Reads ────────────────────────────────────────────────────────────
+
+  /** Column widths for a tool, defaults filled in for untouched columns. */
+  columnsFor(toolId) {
+    return { ...DEFAULT_COLUMNS, ...(this.columns[toolId] ?? {}) };
+  }
+
+  // ── Mutations ────────────────────────────────────────────────────────
+
+  setPanelWidth(side, px) {
+    const limits = PANEL_LIMITS[side];
+    if (!limits) return;
+    this.panels = { ...this.panels, [side]: clamp(px, limits) };
+    this.#persist();
+  }
+
+  resetPanel(side) {
+    if (!(side in DEFAULT_PANELS)) return;
+    this.panels = { ...this.panels, [side]: DEFAULT_PANELS[side] };
+    this.#persist();
+  }
+
+  setColumnWidth(toolId, col, px) {
+    const limits = COLUMN_LIMITS[col];
+    if (!limits || !toolId) return;
+    const current = this.columns[toolId] ?? {};
+    this.columns = { ...this.columns, [toolId]: { ...current, [col]: clamp(px, limits) } };
+    this.#persist();
+  }
+
+  resetColumn(toolId, col) {
+    const current = this.columns[toolId];
+    if (!current || !(col in current)) return;
+    const next = { ...current };
+    delete next[col];
+    this.columns = { ...this.columns, [toolId]: next };
+    this.#persist();
+  }
+
+  // ── Persistence ──────────────────────────────────────────────────────
+
+  #apply(data) {
+    if (data.panels && typeof data.panels === 'object') {
+      const next = { ...this.panels };
+      for (const side of ['left', 'right']) {
+        if (data.panels[side] != null) next[side] = clamp(data.panels[side], PANEL_LIMITS[side]);
+      }
+      this.panels = next;
+    }
+    if (data.columns && typeof data.columns === 'object') {
+      const next = {};
+      for (const [toolId, cols] of Object.entries(data.columns)) {
+        if (!cols || typeof cols !== 'object') continue;
+        const clean = {};
+        for (const [col, px] of Object.entries(cols)) {
+          if (COLUMN_LIMITS[col] && px != null) clean[col] = clamp(px, COLUMN_LIMITS[col]);
+        }
+        if (Object.keys(clean).length) next[toolId] = clean;
+      }
+      this.columns = next;
+    }
+  }
+
+  #serialize() {
+    return { panels: { ...this.panels }, columns: { ...this.columns } };
+  }
+
+  async #syncFromServer() {
+    try {
+      const remote = await api.getPreferences();
+      if (remote && (remote.panels || remote.columns)) {
+        this.#apply(remote);
+        writeString(STORAGE_KEYS.LAYOUT, JSON.stringify(this.#serialize()));
+      }
+    } catch {
+      // Offline or endpoint missing — keep local values.
+    }
+  }
+
+  #persist() {
+    const snapshot = this.#serialize();
+    writeString(STORAGE_KEYS.LAYOUT, JSON.stringify(snapshot));
+    if (!isBrowser) return;
+    if (this.#saveTimer) clearTimeout(this.#saveTimer);
+    this.#saveTimer = setTimeout(() => {
+      this.#saveTimer = null;
+      api.putPreferences(snapshot).catch(() => {
+        // Best-effort; localStorage already holds the change.
+      });
+    }, SAVE_DEBOUNCE_MS);
+  }
+}
+
+export const layout = new LayoutStore();

--- a/src/lib/util/localStorage.js
+++ b/src/lib/util/localStorage.js
@@ -6,6 +6,7 @@ const STORAGE_KEYS = Object.freeze({
   SHOW_METADATA_JOBS: 'compressatorium_show_metadata_jobs',
   THEME: 'theme-preference',
   SIDEBAR_COLLAPSED: 'sidebar-collapsed',
+  LAYOUT: 'workspace-layout',
 });
 
 function safe() {

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -50,6 +50,17 @@ def _current_rev(engine) -> str | None:
         return MigrationContext.configure(conn).get_current_revision()
 
 
+def _head_rev() -> str:
+    """Latest migration revision, read from the script directory.
+
+    Derived rather than hardcoded so adding a migration doesn't require
+    touching every revision assertion here.
+    """
+    from alembic.script import ScriptDirectory
+    cfg = _db._alembic_config(_db.make_engine(":memory:"))
+    return ScriptDirectory.from_config(cfg).get_current_head()
+
+
 # ---------------------------------------------------------------------------
 # I1 — fresh DB
 # ---------------------------------------------------------------------------
@@ -65,7 +76,7 @@ def test_upgrade_head_on_fresh_db(fresh_db_path: str):
     tables = set(inspect(engine).get_table_names())
     assert _db._BASELINE_TABLES.issubset(tables)
     assert "alembic_version" in tables
-    assert _current_rev(engine) == "0001"
+    assert _current_rev(engine) == _head_rev()
 
 
 # ---------------------------------------------------------------------------
@@ -81,6 +92,15 @@ def test_stamp_head_on_preexisting_schema(fresh_db_path: str):
     assert _db._BASELINE_TABLES.issubset(tables_before)
     assert "alembic_version" not in tables_before
 
+    # A genuine pre-Alembic install only had the baseline tables; models
+    # added in later migrations (e.g. preferences) didn't exist yet.
+    # create_all above over-creates them from the current metadata, so
+    # drop the non-baseline ones to faithfully simulate that older state
+    # before stamping + upgrading.
+    with engine.begin() as conn:
+        for table in set(inspect(engine).get_table_names()) - _db._BASELINE_TABLES:
+            conn.execute(text(f'DROP TABLE IF EXISTS "{table}"'))
+
     # Seed a row so we can prove stamping doesn't touch data.
     with engine.begin() as conn:
         conn.execute(
@@ -95,7 +115,7 @@ def test_stamp_head_on_preexisting_schema(fresh_db_path: str):
 
     # alembic_version is now present at head; schema is otherwise
     # unchanged; the seeded row still exists.
-    assert _current_rev(engine) == "0001"
+    assert _current_rev(engine) == _head_rev()
     with engine.begin() as conn:
         got = conn.execute(
             text("SELECT name FROM dats WHERE id = 'pre00001'")
@@ -117,7 +137,7 @@ def test_apply_migrations_idempotent(fresh_db_path: str):
     _db.apply_migrations()
     second_rev = _current_rev(_db.engine)
 
-    assert first_rev == second_rev == "0001"
+    assert first_rev == second_rev == _head_rev()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -92,15 +92,6 @@ def test_stamp_head_on_preexisting_schema(fresh_db_path: str):
     assert _db._BASELINE_TABLES.issubset(tables_before)
     assert "alembic_version" not in tables_before
 
-    # A genuine pre-Alembic install only had the baseline tables; models
-    # added in later migrations (e.g. preferences) didn't exist yet.
-    # create_all above over-creates them from the current metadata, so
-    # drop the non-baseline ones to faithfully simulate that older state
-    # before stamping + upgrading.
-    with engine.begin() as conn:
-        for table in set(inspect(engine).get_table_names()) - _db._BASELINE_TABLES:
-            conn.execute(text(f'DROP TABLE IF EXISTS "{table}"'))
-
     # Seed a row so we can prove stamping doesn't touch data.
     with engine.begin() as conn:
         conn.execute(

--- a/tests/test_db_startup_integration.py
+++ b/tests/test_db_startup_integration.py
@@ -50,6 +50,18 @@ def _current_rev(engine) -> str | None:
         return MigrationContext.configure(conn).get_current_revision()
 
 
+def _head_rev() -> str:
+    """Latest migration revision, read from the script directory.
+
+    Derived rather than hardcoded so adding a migration doesn't require
+    touching every revision assertion here.
+    """
+    from alembic.script import ScriptDirectory
+
+    cfg = _db._alembic_config(_db.make_engine(":memory:"))
+    return ScriptDirectory.from_config(cfg).get_current_head()
+
+
 def _run_startup(
     db_path: str,
     data_dir: Path,
@@ -93,7 +105,7 @@ def test_fresh_disk_no_legacy_json(tmp_path: Path, db_path: str):
     _run_startup(db_path, tmp_path)
 
     # Alembic drove schema, not create_all.
-    assert _current_rev(_db.engine) == "0001"
+    assert _current_rev(_db.engine) == _head_rev()
 
     tables = set(inspect(_db.engine).get_table_names())
     assert _db._BASELINE_TABLES.issubset(tables)
@@ -124,7 +136,7 @@ def test_full_legacy_migration(tmp_path: Path, db_path: str):
         dat_sync=SAMPLE_DAT_SYNC,
     )
 
-    assert _current_rev(_db.engine) == "0001"
+    assert _current_rev(_db.engine) == _head_rev()
 
     with _db.get_session() as s:
         assert s.query(_db.DAT).count() == 2
@@ -157,6 +169,12 @@ def test_pre_alembic_plus_json_coexistence(tmp_path: Path, db_path: str, reset_d
                 "VALUES ('pre00001', 'Pre-Alembic', '', '', '', 0)"
             )
         )
+        # The v3.6 create_all only made the baseline tables; tables added
+        # in later migrations (e.g. preferences) didn't exist yet. Drop
+        # the non-baseline ones the current metadata over-created so the
+        # stamp-baseline-then-upgrade path matches a real pre-Alembic DB.
+        for table in set(inspect(eng).get_table_names()) - _db._BASELINE_TABLES:
+            conn.execute(text(f'DROP TABLE IF EXISTS "{table}"'))
     reset_db_engine()
 
     # Now run the real startup sequence with JSON files dropped into the
@@ -171,7 +189,7 @@ def test_pre_alembic_plus_json_coexistence(tmp_path: Path, db_path: str, reset_d
     )
 
     # Alembic stamped the baseline and upgraded to head.
-    assert _current_rev(_db.engine) == "0001"
+    assert _current_rev(_db.engine) == _head_rev()
 
     with _db.get_session() as s:
         # Pre-existing DAT survived; new dat_store JSON was NOT imported.

--- a/tests/test_db_startup_integration.py
+++ b/tests/test_db_startup_integration.py
@@ -169,12 +169,6 @@ def test_pre_alembic_plus_json_coexistence(tmp_path: Path, db_path: str, reset_d
                 "VALUES ('pre00001', 'Pre-Alembic', '', '', '', 0)"
             )
         )
-        # The v3.6 create_all only made the baseline tables; tables added
-        # in later migrations (e.g. preferences) didn't exist yet. Drop
-        # the non-baseline ones the current metadata over-created so the
-        # stamp-baseline-then-upgrade path matches a real pre-Alembic DB.
-        for table in set(inspect(eng).get_table_names()) - _db._BASELINE_TABLES:
-            conn.execute(text(f'DROP TABLE IF EXISTS "{table}"'))
     reset_db_engine()
 
     # Now run the real startup sequence with JSON files dropped into the

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -1,0 +1,47 @@
+"""Tests for the preferences store (server-persisted UI layout)."""
+
+# ruff: noqa: S101
+
+from pathlib import Path
+
+import pytest
+
+from app.services.preferences_store import PreferencesStore
+
+
+@pytest.fixture(name="store")
+def _store(tmp_path: Path) -> PreferencesStore:
+    """A preferences store bound to a temporary SQLite DB."""
+    return PreferencesStore(str(tmp_path / "preferences.db"))
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(store: PreferencesStore) -> None:
+    assert await store.get("layout") is None
+
+
+@pytest.mark.asyncio
+async def test_put_then_get_round_trips(store: PreferencesStore) -> None:
+    layout = {
+        "panels": {"left": 220, "right": 360},
+        "columns": {"chdman": {"name": 320, "size": 90, "ext": 70, "status": 160}},
+    }
+    returned = await store.put("layout", layout)
+    assert returned == layout
+    assert await store.get("layout") == layout
+
+
+@pytest.mark.asyncio
+async def test_put_overwrites(store: PreferencesStore) -> None:
+    await store.put("layout", {"panels": {"left": 220, "right": 360}})
+    await store.put("layout", {"panels": {"left": 200, "right": 420}})
+    stored = await store.get("layout")
+    assert stored == {"panels": {"left": 200, "right": 420}}
+
+
+@pytest.mark.asyncio
+async def test_keys_are_independent(store: PreferencesStore) -> None:
+    await store.put("layout", {"a": 1})
+    await store.put("other", {"b": 2})
+    assert await store.get("layout") == {"a": 1}
+    assert await store.get("other") == {"b": 2}


### PR DESCRIPTION
## What and why

The file table was cramped on wide screens. Rather than hardcode a wider ratio, this makes the workspace layout adjustable and remembers it.

Two things are now draggable:
- The divider between the file list and the right Convert/Jobs panel (drag it left and the table grows).
- Individual table column borders: Name, Size, Ext, Status.

Widths persist on the server, so they survive a browser or cache wipe. This is the first server-stored preference; everything else was localStorage only.

## Decisions

- **Both panels and columns** are resizable.
- **Panel split is global; column widths are per tool** (chdman / dolphin / z3ds), since each tool lists different file types.
- **Local-first with server sync:** localStorage is read synchronously on boot so widths apply with no flash, then the server copy is fetched and wins, and every change writes localStorage immediately and PUTs to the server debounced (~500ms).

## Backend

- Generic `preferences` key/value table (Alembic migration `0002`), reusable for future prefs. The workspace layout lives under the `layout` key.
- `PreferencesStore` service following the existing store pattern, plus `GET`/`PUT /api/preferences`. Single-user, no auth.

## Frontend

- New `layout.svelte.js` store: load/reconcile/debounced-save, per-tool columns, width clamps.
- Reusable `Splitter.svelte` (WAI-ARIA window-splitter: focusable separator, arrow-key nudge, double-click / Enter to reset) drives both the panel dividers and the column handles.
- The file table moves to `table-layout: fixed` with a `<colgroup>` driven by the store. The Name column absorbs slack; a `min-width` keeps the existing horizontal scroll when columns outgrow the panel.

The DB tests now derive the head migration revision from the script directory instead of hardcoding `0001`, so adding a migration doesn't break them.

## Testing

- `pytest`: 590 passed, including a new `tests/test_preferences.py` and the updated migration/startup tests.
- Booted the backend against a temp DB and confirmed `GET` (empty → `{}`) → `PUT` → `GET` round-trips and the migration applies cleanly at startup.
- `npx svelte-check`: 0 errors, 0 warnings. `npm run build` succeeds. `eslint` clean. `pylint` 10/10 on the new modules.

Still worth a manual pass in a browser (drag panels + columns, switch tools, reload, clear localStorage to prove the server copy restores, double-click to reset). The static CSS widening from the earlier ask folded into this branch as the default values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draggable panel and column resizers for workspace and file table
  * Layout preferences persist locally and sync to server for cross-session restore
  * New accessible splitter control enabling pointer/keyboard resizing
* **Chores**
  * Database migration and server-side preference storage added
* **Tests**
  * New/updated tests covering migrations and preferences persistence/round-trip
<!-- end of auto-generated comment: release notes by coderabbit.ai -->