### PR TITLE
docs: rewrite in plain voice and fix drift from the code

### DIFF
--- a/ADDING_PLATFORMS_AND_TOOLS.md
+++ b/ADDING_PLATFORMS_AND_TOOLS.md
@@ -1,24 +1,31 @@
 # Adding Platforms and Compression/Decompression Tools
 
 This is a developer guide for extending Compressatorium with **new conversion
-tools** (e.g. a brand-new compressor binary) and **new platforms / formats**
-(e.g. a new chdman create mode, or a new file type a tool can handle). It
-walks the full vertical slice, from the binary in the Docker image, through
-the Python service and job pipeline, the FastAPI routes, and finally the
-Preact web UI, and shows how to add a tool and a platform *in tandem*.
+tools** (a brand-new compressor binary) and **new platforms / formats** (a new
+chdman create mode, or a new file type a tool can handle). It walks the full
+vertical slice, from the binary in the Docker image, through the Python service
+and tool plugin, the job pipeline, the FastAPI routes, and finally the Svelte
+web UI, and shows how to add a tool and a platform in tandem.
 
-It is written against the codebase as it stands today, with three tools
-already wired up:
+It is written against the codebase as it stands today, with three tools already
+wired up:
 
-| Tool | Binary | Service module | Handles |
-|------|--------|----------------|---------|
-| **chdman** | `mame-tools` (`/usr/bin/chdman`) | `app/services/chdman.py` | CD/DVD/HD/Raw/LaserDisc disc images ↔ `.chd` |
-| **dolphin-tool** | `dolphin-emu` (`/usr/local/bin/dolphin-tool`) | `app/services/dolphin_tool.py` | GameCube/Wii images ↔ `.rvz/.wia/.gcz/.iso` |
-| **z3ds_compressor** | built from source (`/usr/local/bin/z3ds_compressor`) | `app/services/z3ds_compress.py` | Nintendo 3DS ROMs → `.zcci/.zcia/.z3ds` |
+| Tool | Binary | Service module | Plugin | Handles |
+|------|--------|----------------|--------|---------|
+| **chdman** | `mame-tools` (`/usr/bin/chdman`) | `app/services/chdman.py` | `app/services/tools/chdman.py` | CD/DVD/HD/Raw/LaserDisc disc images to/from `.chd` |
+| **dolphin-tool** | `dolphin-emu` (`/usr/local/bin/dolphin-tool`) | `app/services/dolphin_tool.py` | `app/services/tools/dolphin.py` | GameCube/Wii images to/from `.rvz/.wia/.gcz/.iso` |
+| **z3ds_compressor** | built from source (`/usr/local/bin/z3ds_compressor`) | `app/services/z3ds_compress.py` | `app/services/tools/z3ds.py` | Nintendo 3DS ROMs to `.zcci/.zcia/.z3ds` |
 
-`z3ds_compress` is the cleanest, most self-contained example of "a new tool
-that handles a new platform," so this guide uses it as the reference
-implementation throughout. When in doubt, **copy what z3ds does.**
+`z3ds` is the cleanest, most self-contained example of "a new tool that handles
+a new platform," so this guide uses it as the reference implementation
+throughout. When in doubt, **copy what z3ds does.**
+
+> **The big idea: there is a tool registry.** Adding a tool used to mean editing
+> `if/elif` ladders in ~20 files. It doesn't anymore. The backend has a tool
+> registry (`app/services/tools/`) that mirrors the frontend one. You write a
+> small plugin class, register it once, and the generic dispatch in
+> `job_manager` and `convert.py` picks it up by mode. Most of the old per-tool
+> branches are gone. The sections below reflect that.
 
 ---
 
@@ -35,20 +42,20 @@ touching the same layers in the same order:
                                                  │  POST /api/jobs   (mode=...)
             ┌────────────────────────────────────▼──────────────────────────────────────┐
             │  Routes (app/routes)                                                        │
-            │   convert.py  – validate mode/extension, compute output path, enqueue job   │
+            │   convert.py  – validate mode/extension (via registry.spec), enqueue job    │
             │   files.py    – mark files convertible in directory listings + search       │
             │   info.py     – per-tool info + verify (single + batch + SSE) endpoints      │
             └────────────────────────────────────┬──────────────────────────────────────┘
                                                   │  job_manager.create_job(mode=...)
             ┌─────────────────────────────────────▼─────────────────────────────────────┐
             │  Job pipeline (app/services/job_manager.py)                                 │
-            │   _queue_job_locked  – pick output path                                      │
-            │   _process_job       – pick service, stream convert(), optional verify+delete│
+            │   _queue_job_locked  – registry.for_mode(mode).output_path(...)              │
+            │   _process_job       – registry.for_mode(mode).convert(...) / .verify(...)   │
             └─────────────────────────────────────┬─────────────────────────────────────┘
-                                                   │  service.convert(...) async generator
+                                                   │  plugin.convert(...) async generator
             ┌──────────────────────────────────────▼────────────────────────────────────┐
-            │  Tool service (app/services/<tool>.py)                                      │
-            │   spawns the binary, parses progress, yields {progress, message}            │
+            │  Tool plugin (app/services/tools/<tool>.py) + service (app/services/<tool>.py)│
+            │   plugin holds ModeSpec rows; service spawns the binary, parses progress     │
             └──────────────────────────────────────┬────────────────────────────────────┘
                                                     │  subprocess
             ┌────────────────────────────────────────▼───────────────────────────────────┐
@@ -58,34 +65,72 @@ touching the same layers in the same order:
 
 Two supporting layers:
 
-- **`app/models.py`**, `ConversionMode` enum (every mode string lives here)
-  and the Pydantic info models (`CHDInfo`, `DolphinDiscInfo`, `Z3DSInfo`).
-- **`app/config.py`**, `Settings` holds the binary path for each tool
+- **`app/models.py`** holds the `ConversionMode` enum (every mode string lives
+  here) and the Pydantic info models (`CHDInfo`, `DolphinDiscInfo`, `Z3DSInfo`).
+- **`app/config.py`** `Settings` holds the binary path for each tool
   (`chdman_path`, `dolphin_tool_path`, `z3ds_compressor_path`).
 
-### The tool-service contract
+### The tool registry
 
-The job pipeline talks to every tool through a small duck-typed interface.
-A new service class must provide:
+`app/services/tools/` is the heart of the backend. It has five parts:
 
-| Member | Signature | Purpose |
-|--------|-----------|---------|
-| `convert` | `async def convert(self, input_path, output_path, mode="...", *, compression=None, cancel_event=None) -> AsyncGenerator[dict, None]` | Spawn the binary, `yield {"progress": int, "message": str}`, raise on failure, `yield {"progress": 100, ...}` at the end. Must raise `ConversionCancelled` when `cancel_event` fires. |
-| `verify` | `async def verify(self, path) -> {"valid": bool, "message": str}` | Deep integrity check of an output file (used by delete-on-verify and the Verify button). |
-| `verify_stream` | `async def verify_stream(self, path) -> AsyncGenerator[dict, None]` | Streaming variant yielding `{"type": "progress"/"complete"/"error", ...}`. `verify()` is normally just a wrapper over this. |
-| `info` | `def info(self, path) -> dict` *(or async)* | Metadata for the info modal. |
-| `is_convertible` | `@staticmethod (filename) -> bool` | Whether a filename is an input for this tool. |
-| `get_output_path_for_mode` | `@staticmethod (mode, input_path, output_dir=None, *, treat_as_stem=False) -> str` | Compute the output path for a mode. |
-| `active_pids` | `() -> list[int]` | Optional but recommended; used by the debug heartbeat. |
+- **`spec.py`** defines `ModeKind` (`CREATE` / `EXTRACT` / `COPY` / `COMPRESS`)
+  and the frozen `ModeSpec` dataclass: per-mode metadata that the routes and
+  pipeline read instead of branching on the mode string.
+- **`base.py`** defines the `ToolPlugin` protocol (the contract) and a `BaseTool`
+  helper that supplies sensible defaults so concrete plugins stay tiny.
+- **`registry.py`** defines `ToolRegistry`, the lookup object. It indexes tools
+  by id and by mode and answers `for_mode(mode)`, `spec(mode)`,
+  `archive_input_extensions()`, `verify_extensions()`, and friends.
+- **`chdman.py` / `dolphin.py` / `z3ds.py`** are the three plugins. Each is a
+  thin `BaseTool` subclass that holds `ModeSpec` rows and delegates the real
+  work to the underlying service singleton.
+- **`__init__.py`** builds the `registry` singleton and registers the three
+  tools. This is the single wiring point.
 
-Each service module also exposes, at module scope:
+### The plugin contract: `ModeSpec` and `BaseTool`
 
-- a `*_CONVERTIBLE_EXTENSIONS` set (input extensions),
-- usually a `*_OUTPUT_FORMATS` map (input ext → output ext, or mode → output),
-- a **module-level singleton instance** (e.g. `z3ds_compress_service = Z3DSCompressService()`).
+A `ModeSpec` row (`spec.py`) describes one mode:
 
-`ConversionCancelled` is defined once in `app/services/chdman.py:22` and
-imported by the other services, reuse it, don't define your own.
+```python
+@dataclass(frozen=True)
+class ModeSpec:
+    mode: str                                 # wire value == a ConversionMode value
+    tool_id: str                              # "chdman" | "dolphin" | "z3ds"
+    kind: ModeKind                            # CREATE | EXTRACT | COPY | COMPRESS
+    label: str                                # UI label
+    group: str                                # UI group id
+    output_ext: str | None                    # ".chd"/".rvz"/None (None = mapped from input)
+    input_extensions: frozenset[str]
+    supports_compression: bool = False
+    supports_compression_level: bool = False  # dolphin rvz/wia only
+    supports_delete_on_verify: bool = False
+    allows_archive_input: bool = False        # chdman create modes today
+```
+
+A plugin subclasses `BaseTool` and provides:
+
+| Member | Purpose |
+|--------|---------|
+| `id`, `display_name`, `binary_path` | identity + binary path (from settings) |
+| `modes` | a tuple of `ModeSpec` rows |
+| `output_extensions`, `verify_extensions` | produced extensions (for "output exists" badges) and verify-accepted extensions |
+| `convert(input_path, output_path, mode, *, compression=None, cancel_event=None)` | async generator yielding `{"progress": int, "message": str}`, raising `ConversionCancelled` when `cancel_event` fires |
+| `verify(path)` / `verify_stream(path)` | deep integrity check, one-shot and streaming |
+| `info(path)` / `info_model(raw, path)` | metadata dict + the Pydantic model it maps to |
+| `output_path(mode, input_path, output_dir=None, *, treat_as_stem=False)` | compute the output path |
+| `detect_output(input_path)` | optional, returns an `OutputStatus` so the file list can badge "output already exists" |
+| `active_pids()` | PIDs for the debug heartbeat |
+| `post_convert(input_path, output_path, mode)` | optional hook, default no-op |
+
+`BaseTool` fills in `input_extensions` (the union of every mode's
+`input_extensions`), `spec(mode)`, and no-op `detect_output` / `post_convert`,
+so a real plugin only overrides what differs. See `app/services/tools/z3ds.py`
+for the smallest complete example (~120 lines, mostly delegation).
+
+`ConversionCancelled` is defined once in `app/services/subprocess_runner.py` and
+re-exported through `services.chdman` and `services.tools.runner`. Import it,
+don't define your own.
 
 ---
 
@@ -93,36 +138,36 @@ imported by the other services, reuse it, don't define your own.
 
 ### Scenario A: a new platform on an *existing* tool
 
-This is the lightweight case: the binary already ships and the service class
-already exists; you just need a new mode string or a new input extension.
+The lightweight case: the binary already ships and the plugin already exists.
+You add a mode string or an input extension.
 
 Examples:
-- A new chdman create variant (chdman already supports `createcd`,
-  `createdvd`, …). You add a `ConversionMode`, teach
-  `chdman.get_output_path_for_mode` the new suffix, add validation in
-  `convert.py`, and surface it in the UI `MODE_GROUPS`.
+- A new chdman create variant. Add a `ConversionMode`, add a `ModeSpec` row to
+  `ChdmanTool.modes`, teach the underlying `chdman.get_output_path_for_mode` the
+  new suffix if it differs, and surface it in the UI registry.
 - Letting chdman accept a new input extension: add it to
-  `CHDMAN_CONVERTIBLE_EXTENSIONS` in `app/services/chdman.py:16`.
+  `CHDMAN_CONVERTIBLE_EXTENSIONS` in `app/services/chdman.py` and to the
+  relevant `ModeSpec.input_extensions`.
 
 Go to **§4**.
 
 ### Scenario B: a brand-new tool (and usually a new platform with it)
 
-A new binary, a new service module, a new `ConversionMode`, new info/verify
-endpoints, and new UI wiring. This is the z3ds-shaped case.
+A new binary, a new service module, a new plugin, a new `ConversionMode`, new
+info/verify endpoints, and new UI wiring. This is the z3ds-shaped case.
 
 Go to **§5**.
 
 ### Scenario C: a tool and a platform in tandem
 
-This is the common real-world request: "support platform X, which needs new
-binary Y." It is just **Scenario B**, because adding the tool *is* what makes
-the platform reachable. The platform shows up as:
+The common real-world request: "support platform X, which needs new binary Y."
+It is just **Scenario B**, because adding the tool is what makes the platform
+reachable. The platform shows up as:
 
-- the input extensions in `*_CONVERTIBLE_EXTENSIONS`,
+- the input extensions in `*_CONVERTIBLE_EXTENSIONS` and `ModeSpec.input_extensions`,
 - the `ConversionMode` value(s) the tool exposes,
-- a UI entry in `MODE_GROUPS` plus a primary-tool option,
-- (optionally) platform-specific flags inside `_build_command`.
+- a UI entry in the registry plus a primary-tool option,
+- (optionally) platform-specific flags inside the service's `_build_command`.
 
 Follow §5 end to end. §6 is the concrete tandem checklist.
 
@@ -130,10 +175,10 @@ Follow §5 end to end. §6 is the concrete tandem checklist.
 
 ## 3. Inventory: every file a tool/platform touches
 
-This is the **exhaustive** list. Not every item is required for every change
-(the right-hand column says when it applies), but check every row. The order
-is the recommended implementation order (bottom of the stack → top). Deep
-detail for the non-obvious rows is in §8–§14.
+This is the exhaustive list. Not every item is required for every change (the
+right-hand column says when it applies), but check every row. The order is the
+recommended implementation order (bottom of the stack to top). Deeper detail for
+the non-obvious rows is in §8 to §14.
 
 ### 3.1 Binary / packaging
 
@@ -151,71 +196,72 @@ detail for the non-obvious rows is in §8–§14.
 | # | File | What you do | When |
 |---|------|-------------|------|
 | 7 | `app/config.py` | Add a `<tool>_path` `Field` with an env alias (`<TOOL>_PATH`). | New tool |
-| 8 | `app/services/<tool>.py` | New service module, `convert`/`verify`/`verify_stream`/`info`/`is_convertible`/`get_output_path_for_mode`/`active_pids`, the `*_CONVERTIBLE_EXTENSIONS` set, `*_OUTPUT_FORMATS`, and the module singleton. | New tool |
-| 9 | `app/models.py` | Add `ConversionMode` value(s); add a `<Tool>Info` model; add `FileEntry` flags (`<tool>_convertible`, `has_<tool>`, `<tool>_ready`, `<tool>_path`). | New mode and/or tool |
-| 10 | `app/services/job_manager.py` | Import the service; add output-path branch in `_queue_job_locked`; add `_convert_service` branch in `_process_job`; add verify branch if delete-on-verify is supported. | New tool |
-| 11 | `app/routes/convert.py` | `_get_output_path` branch; extension validation in `create_job` **and** `create_batch_jobs`; `supports_delete_on_verify`; archive-input guard. | New mode and/or tool |
-| 12 | `app/routes/files.py` | Import the ext set; set convertibility/output-existence flags in `scan_directory` **and** `search_files`. | New tool |
-| 13 | `app/routes/info.py` | `/<tool>-info`, `/<tool>-verify`, `/<tool>-verify/events`, `/<tool>-verify-batch/events`; `*_VERIFY_EXTENSIONS`; verify-lane token. | New tool |
-| 14 | `app/services/disc_id.py` | Add a serial/title parser if the new **disc** platform should get GAME/NAME tags embedded (chdman create modes only). | New disc platform, optional |
-| 15 | `app/services/archive.py` | Add input extensions to its `CONVERTIBLE_EXTENSIONS` only if the tool must read inputs out of `.zip/.7z/.rar`. | Rare (chdman-only today) |
-| 16 | `app/services/dat_*.py` / `app/routes/dat.py` | Touch only if the platform participates in DAT (MAMERedump) hash-matching. | Rare |
-| 17 | `migrations/versions/*.py` | New Alembic migration **only** if you add DB-persisted columns/tables (use `scripts/new_migration.sh`). The verification/metadata stores are keyed by path and need no migration for a new tool. | If schema changes |
+| 8 | `app/services/<tool>.py` | The underlying service: `_build_command`, the subprocess spawn, progress parsing, cancel handling, the `*_CONVERTIBLE_EXTENSIONS` set, `*_OUTPUT_FORMATS`, and the module singleton. | New tool |
+| 9 | `app/services/tools/<tool>.py` | The plugin: a `BaseTool` subclass with `id`, `display_name`, `modes` (`ModeSpec` rows), `output_extensions`, `verify_extensions`, delegating `convert`/`verify`/`info`/`output_path`/`detect_output` to the service. | New tool |
+| 10 | `app/services/tools/__init__.py` | One line: `registry.register(<Tool>(settings.<tool>_path))` (plus the import). This is the only dispatch wiring. | New tool |
+| 11 | `app/models.py` | Add `ConversionMode` value(s); add a `<Tool>Info` model; add `FileEntry` flags (`<tool>_convertible`, `has_<tool>`, `<tool>_ready`, `<tool>_path`). | New mode and/or tool |
+| 12 | `app/routes/convert.py` | Usually nothing for output paths or dispatch (the registry handles both). Add an extension-validation block in `plan_job` if your inputs need a specific check, mirroring the z3ds one. | New tool, sometimes |
+| 13 | `app/routes/files.py` | Add the per-tool convertibility/output-existence flags in the directory scan **and** in `search_files`, paralleling the z3ds flags. | New tool |
+| 14 | `app/routes/info.py` | A `GET /<tool>-info` endpoint, plus one `register_verify_routes(router, registry.get("<tool>"))` call to generate the verify trio. | New tool |
+| 15 | `app/services/job_manager.py` | Usually nothing: convert and verify dispatch through the registry. Touch only for special post-processing (disc-id tagging, multi-file sidecars). | Rare |
+| 16 | `app/services/disc_id.py` | Add a serial/title parser if the new **disc** platform should get GAME/NAME tags embedded (chdman create modes only). | New disc platform, optional |
+| 17 | `app/services/archive.py` | Nothing for a new tool: archive input extensions come from `registry.archive_input_extensions()`. Set `allows_archive_input=True` on your `ModeSpec` to opt in. | Rare |
+| 18 | `app/services/dat_*.py` / `app/routes/dat.py` | Touch only if the platform participates in DAT (MAMERedump) hash-matching. | Rare |
+| 19 | `migrations/versions/*.py` | New Alembic migration **only** if you add DB-persisted columns/tables (use `scripts/new_migration.sh`). The verification/metadata stores are keyed by path and need no migration for a new tool. | If schema changes |
 
 ### 3.3 Frontend (Svelte 5 + Vite: one new entry in the registry)
 
 | # | File | What you do | When |
 |---|------|-------------|------|
-| 18 | `src/lib/api/endpoints.js` | `get<Tool>Info`, `verify<Tool>`, `verifyBatch<Tool>` client methods alongside the existing ones. | New tool |
-| 19 | `src/lib/tools/registry.js` | **One new entry** in the `TOOLS` array (id, label, hint, verifyPrefix, sourceExts, verifyExts, modeGroups, groups, defaultMode, glyph, accent, modes, getInfo/verify/verifyBatch/productPath). Everything else, sidebar, workspace, badges, modals, verify dispatch, SSE URL building, looks up this registry. | New mode and/or tool |
-| 20 | `src/styles/tokens.css` | Add a semantic token only if you need a new tool accent / badge color. Most tools reuse existing tokens via `accent: 'var(--badge-<token>)'`. | If new visual identity |
+| 20 | `src/lib/api/endpoints.js` | `get<Tool>Info`, `verify<Tool>`, `verifyBatch<Tool>` client methods alongside the existing ones. | New tool |
+| 21 | `src/lib/tools/registry.js` | **One new entry** in the `TOOLS` array. Everything downstream (sidebar, workspace, badges, modals, verify dispatch, SSE URL building) looks up this registry. | New mode and/or tool |
+| 22 | `src/styles/tokens.css` | Add a semantic token only if you need a new tool accent / badge color. Most tools reuse existing tokens via `accent: 'var(--badge-<token>)'`. | If new visual identity |
 
 ### 3.4 Tests
 
 | # | File | What you do | When |
 |---|------|-------------|------|
-| 22 | `tests/test_<tool>_routes.py` | Info + verify endpoint tests (copy `test_z3ds_routes.py`). | New tool |
-| 23 | `tests/test_<tool>_service.py` | `convert`/`verify`/cancel/bad-extension tests (copy `test_z3ds_verification_service.py`). | New tool |
-| 24 | `tests/test_mode_parity_fixes.py` | Add the mode so single-vs-batch validation parity is enforced. | New mode |
-| 25 | `tests/conftest.py` | Add a binary stub/fixture if the service needs the binary present. | New tool |
+| 23 | `tests/test_<tool>_routes.py` | Info + verify endpoint tests (copy `test_z3ds_routes.py`). | New tool |
+| 24 | `tests/test_<tool>_service.py` | `convert`/`verify`/cancel/bad-extension tests (copy `test_z3ds_verification_service.py`). | New tool |
+| 25 | `tests/test_tool_registry.py` | Assert your modes resolve to your tool and the spec flags are right. | New tool/mode |
+| 26 | `tests/test_mode_parity_fixes.py` | Add the mode so single-vs-batch validation parity is enforced. | New mode |
+| 27 | `tests/conftest.py` | Add a binary stub/fixture if the service needs the binary present. | New tool |
 
 ### 3.5 CI / quality gates (must stay green)
 
 | # | File | What it enforces | Action |
 |---|------|------------------|--------|
-| 26 | `.github/workflows/codacy.yml` | Push/PR: ruff, eslint, pylint, etc. via Codacy CLI. | New code must pass; see §11 |
-| 27 | `.github/workflows/codeql.yml` | Weekly + push CodeQL for Python **and** JS/TS. | Auto-covers new code |
-| 28 | `.github/workflows/docker-image.yml` | On release: hadolint, multi-arch build, Trivy scan, SBOM/attestation. | Dockerfile must pass hadolint; see §8/§10 |
-| 29 | `.github/labeler.yml` / `label.yml` | PR auto-labeling by path. | Add a path glob if you want a label |
-| 30 | `.github/dependabot.yml` | Dependency bumps. | Only if adding a new ecosystem |
-| 31 | `pyproject.toml` | pylint + ruff config (Codacy reads this). | Respect line-length 100, py310 |
-| 32 | `.pylintrc`, `.prospector.yaml`, `.bandit` | Python lint/security (bandit flags `shell=True`, predictable tmp). | Follow the no-shell rule (§15) |
-| 33 | `eslint.config.js`, `.eslintrc.json`, `.jshintrc` | ESLint for the frontend (`src/`). | New JS and Svelte must pass |
-| 34 | `.stylelintrc.json`, `.csslintrc` | CSS lint. | If you edit CSS |
-| 35 | `.markdownlint.json` | Markdown lint. | If you add docs |
-| 36 | `.codacy.yml`, `.codacy/` | Codacy tool config/excludes. | Rarely |
-| 37 | `config/pmd/ruleset.xml` | PMD ruleset (Codacy). | Rarely |
+| 28 | `.github/workflows/codacy.yml` | Push/PR/weekly: ruff, eslint, pylint, etc. via Codacy CLI. | New code must pass; see §11 |
+| 29 | `.github/workflows/codeql.yml` | Push/PR/weekly CodeQL for Python **and** JS/TS. | Auto-covers new code |
+| 30 | `.github/workflows/docker-image.yml` | On release: hadolint, multi-arch build, Trivy scan, SBOM/attestation. | Dockerfile must pass hadolint; see §8/§10 |
+| 31 | `.github/workflows/label.yml` + `.github/labeler.yml` | PR auto-labeling by path. | Add a path glob if you want a label |
+| 32 | `.github/dependabot.yml` | Dependency bumps. | Only if adding a new ecosystem |
+| 33 | `pyproject.toml` | pylint + ruff config (Codacy reads this). | Respect line-length 100, py310 |
+| 34 | `.pylintrc`, `.prospector.yaml`, `.bandit` | Python lint/security (bandit flags `shell=True`, predictable tmp). | Follow the no-shell rule (§15) |
+| 35 | `eslint.config.js`, `.eslintrc.json`, `.jshintrc` | ESLint for the frontend (`src/`). | New JS and Svelte must pass |
+| 36 | `.stylelintrc.json`, `.csslintrc` | CSS lint. | If you edit CSS |
+| 37 | `.markdownlint.json` | Markdown lint. | If you add docs |
+| 38 | `.codacy.yml`, `.codacy/` | Codacy tool config/excludes. | Rarely |
+| 39 | `config/pmd/ruleset.xml` | PMD ruleset (Codacy). | Rarely |
 
 ### 3.6 Deployment & docs
 
 | # | File | What you do | When |
 |---|------|-------------|------|
-| 38 | `docker-compose.yml` / `.cli.yml` / `.multi-volume.yml` | Document/override the new `<TOOL>_PATH` env or CLI mode env if relevant. | If ops needs the knob |
-| 39 | `.version` (+ `scripts/sync-version.sh`) | Bump version across `.version`, `package.json`, `package-lock.json`, `RELEASE_NOTES.md`. | Every release |
-| 40 | `README.md` | Supported-formats/tool table, feature list. Also the **Docker Hub** description (published from README by CI). | New tool/platform |
-| 41 | `RELEASE_NOTES.md` | Changelog entry. | Every change |
-| 42 | `DEPLOYMENT.md`, `DOCKER-COMPOSE.md` | New env vars / volumes / tool requirements. | If deploy surface changes |
-| 43 | `walkthrough.md`, `CHANGES_SUMMARY.md` | Narrative docs, if you maintain them. | Optional |
-| 44 | `AGENTS.md` | Runbook, add a test/run note if workflow changes. | Optional |
-| 45 | `.github/copilot-instructions.md` | Repo AI guidance, update if conventions change. | Optional |
+| 40 | `docker-compose.yml` / `.cli.yml` / `.multi-volume.yml` | Document/override the new `<TOOL>_PATH` env or CLI mode env if relevant. | If ops needs the knob |
+| 41 | `package.json` | The version lives here. A release bumps `package.json` and publishes a GitHub Release; there is no `.version` file or `sync-version.sh` script. | Every release |
+| 42 | `README.md` | Supported-formats/tool table, feature list. Also the **Docker Hub** description (published from README by CI). | New tool/platform |
+| 43 | `RELEASE_NOTES.md` | Changelog entry. | Every change |
+| 44 | `DEPLOYMENT.md`, `DOCKER-COMPOSE.md` | New env vars / volumes / tool requirements. | If deploy surface changes |
+| 45 | `AGENTS.md`, `.github/copilot-instructions.md` | Runbook / AI guidance, update if conventions change. | Optional |
 
 ---
 
 ## 4. Scenario A: add a platform/mode to an existing tool
 
-Worked example: add a hypothetical **`createcd_audio`** chdman mode (pretend
-it produces `.chd` with a platform-specific flag). The same pattern applies
-to any new chdman/dolphin sub-format.
+Worked example: add a hypothetical **`createcd_audio`** chdman mode (pretend it
+produces `.chd` with a platform-specific flag). The same pattern applies to any
+new chdman/dolphin sub-format.
 
 ### 4.1 Add the mode to the enum: `app/models.py`
 
@@ -227,41 +273,43 @@ class ConversionMode(str, Enum):
     ...
 ```
 
-The string value is what travels over the API and what `job_manager` /
-`convert.py` switch on. Pick a value consistent with the tool's existing
-prefix convention (`create*`, `extract*`, `dolphin_*`, `z3ds_compress`),
-because a lot of logic keys off these prefixes (see below).
+The string value is what travels over the API and what the registry indexes on.
+Pick a value consistent with the tool's existing prefix convention (`create*`,
+`extract*`, `dolphin_*`, `z3ds_compress`), because a few places still key off
+these prefixes (see §15).
 
-### 4.2 Teach the service the new mode: `app/services/chdman.py`
+### 4.2 Add a `ModeSpec` row: `app/services/tools/chdman.py`
 
-- If it needs special binary flags, branch in `_build_command`
-  (`chdman.py:34`), mirroring the existing `createdvd` `-hs 2048` special case
-  at `chdman.py:42`.
-- Add the output-suffix rule in `get_output_path_for_mode`
-  (`chdman.py:561`). The `create*` branch already maps to `{stem}.chd`
-  (`chdman.py:579`); only touch this if your suffix differs.
-- If it accepts a new input extension, add it to
-  `CHDMAN_CONVERTIBLE_EXTENSIONS` (`chdman.py:16`).
+Add a `ModeSpec` to `ChdmanTool.modes`, modeled on the existing `createcd` row:
 
-### 4.3 Wire validation: `app/routes/convert.py`
+```python
+ModeSpec(
+    mode="createcd_audio", tool_id="chdman", kind=ModeKind.CREATE,
+    label="Create CD CHD (Audio)", group="create",
+    output_ext=".chd", input_extensions=CHDMAN_CONVERTIBLE_EXTENSIONS,
+    supports_compression=True, supports_delete_on_verify=True,
+    allows_archive_input=True,
+),
+```
 
-`convert.py` keys off mode **prefixes** in several places. Because
-`create_job` / `create_batch_jobs` treat anything starting with `create`
-generically (e.g. the `.chd` input rejection at `convert.py:407`, output
-path via `_get_output_path` at `convert.py:100`), a new `create*` mode often
-needs **no new validation code**, it inherits the create-mode rules. Verify
-the prefix-based helpers cover you:
+Because `kind=CREATE` and `output_ext=".chd"`, the route validation, output-path
+computation, archive-input handling, and delete-on-verify all work off this row
+with no further code. Only touch the underlying service if the mode needs
+special binary flags (branch in `chdman._build_command`) or a different output
+suffix (`chdman.get_output_path_for_mode`).
 
-- `supports_delete_on_verify` (`convert.py:87`), `create*` already returns True.
-- `_get_output_path` (`convert.py:100`), routes to `chdman_service` by
-  default, so a chdman mode is covered.
+### 4.3 Validation: `app/routes/convert.py`
 
-If your mode breaks a prefix assumption, add an explicit branch.
+Usually **nothing**. `convert.py` reads `registry.spec(mode)` and validates off
+the spec flags (`spec.kind`, `spec.allows_archive_input`,
+`spec.supports_delete_on_verify`). A new `create*` chdman mode inherits the
+create-mode rules (for example the `.chd`-input rejection for `kind == CREATE`).
+Add an explicit check only if your mode breaks a spec assumption.
 
 ### 4.4 Surface it in the UI: `src/lib/tools/registry.js`
 
-Append one `ModeEntry` to the chdman descriptor's `modes` array (the
-group's human label is already declared via `groups.create: 'Create'`):
+Append one mode entry to the chdman descriptor's `modes` array (the group's
+human label is already declared via `groups.create: 'Create'`):
 
 ```js
 // src/lib/tools/registry.js, inside the chdman TOOLS entry
@@ -275,37 +323,39 @@ modes: [
 ],
 ```
 
-Because it reuses the chdman tool and `.chd` output, file badges, the
-conversion config panel, the info modal, and the verify path all already
-work. The new mode appears wherever `registry.modesByGroup('chdman')`
-or `registry.specFor('createcd_audio')` is consulted. Done.
+`CHDMAN_SOURCE_EXTS` is a local `const` in `registry.js` (not exported). Because
+the mode reuses the chdman tool and `.chd` output, file badges, the conversion
+config panel, the info modal, and the verify path all already work. The mode
+shows up wherever `registry.modesByGroup('chdman')` or
+`registry.specFor('createcd_audio')` is consulted.
 
 ### 4.5 Test
 
-Add a case to `tests/test_mode_parity_fixes.py` (validation parity between
-single + batch create) and `tests/test_chdman_annotations.py` if relevant.
+Add a case to `tests/test_mode_parity_fixes.py` (validation parity between single
++ batch create), `tests/test_tool_registry.py` (the mode resolves to chdman with
+the right flags), and `tests/test_chdman_annotations.py` if relevant.
 
 ---
 
 ## 5. Scenario B/C: add a brand-new tool (with its platform)
 
-Worked example throughout: a fictional **`nszip`** tool that compresses
-Nintendo Switch `.nsp`/`.xci` dumps into `.nsz`/`.xcz`. Replace names as
-needed. This mirrors z3ds exactly.
+Worked example throughout: a fictional **`nszip`** tool that compresses Nintendo
+Switch `.nsp`/`.xci` dumps into `.nsz`/`.xcz`. Replace names as needed. This
+mirrors z3ds exactly.
 
 ### 5.1 Install the binary: `Dockerfile`
 
-Three patterns exist in the current `Dockerfile`; pick the one that fits:
+Three patterns exist in the current `Dockerfile` (a three-stage build: `builder`,
+`frontend-builder`, runtime). Pick the one that fits:
 
-- **Distro package** (chdman via `mame-tools`, pinned to a
-  `snapshot.debian.org` `.deb` with a SHA256 check, see `Dockerfile:38`).
-- **Distro package, best-effort** (dolphin-emu, amd64-only, non-fatal,
-  `Dockerfile:67`). A wrapper script is created at
-  `/usr/local/bin/dolphin-tool` only if the binary exists (`Dockerfile:92`).
-- **Build from source in a builder stage** (z3ds, `Dockerfile:1-23`), then
-  copy the artifact into the runtime image (`Dockerfile:105`).
+- **Distro package** (chdman via `mame-tools`, pinned to a `snapshot.debian.org`
+  `.deb` with per-arch SHA256 checks).
+- **Distro package, best-effort** (dolphin-emu, amd64-only, non-fatal). A wrapper
+  script at `/usr/local/bin/dolphin-tool` is created only if the binary exists.
+- **Build from source in the `builder` stage** (z3ds), then copy the artifact
+  into the runtime image.
 
-For `nszip` built from source, add to the builder stage:
+For `nszip` built from source, add to the `builder` stage:
 
 ```dockerfile
 FROM debian:trixie-slim AS builder
@@ -317,26 +367,24 @@ WORKDIR /tmp/nszip
 RUN g++ -O3 src/*.cpp -o nszip -lzstd && chmod +x nszip
 ```
 
-…and copy it into the runtime stage next to the existing z3ds copy
-(`Dockerfile:105`):
+…and copy it into the runtime stage next to the existing z3ds copy:
 
 ```dockerfile
 COPY --from=builder /tmp/nszip/nszip /usr/local/bin/nszip
 ```
 
-If the tool needs a runtime shared lib, add it to the runtime `apt-get
-install` list (`Dockerfile:53`). Note that `zstd` (the CLI) is already
-installed, z3ds's `verify_stream` shells out to `zstd -t`, so if your tool's
-output is a zstd container you can reuse that.
+If the tool needs a runtime shared lib, add it to the runtime `apt-get install`
+list. The `zstd` CLI is already installed (z3ds's `verify_stream` shells out to
+`zstd -t`), so if your tool's output is a zstd container you can reuse it.
 
-> Multi-arch: the image builds `linux/amd64` and `linux/arm64`
-> (see `.github/workflows/docker-image.yml`). A source build compiles per
-> arch automatically; a downloaded `.deb` needs a per-arch URL/SHA like the
-> `mame-tools` block (`Dockerfile:40`).
+> Multi-arch: the image builds `linux/amd64` and `linux/arm64`. A source build
+> compiles per arch automatically; a downloaded `.deb` needs a per-arch URL/SHA
+> like the `mame-tools` block.
 
 ### 5.2 Add the binary path setting: `app/config.py`
 
-Add next to the other tool paths (`config.py:111-121`):
+Add next to the other tool paths (`chdman_path`, `dolphin_tool_path`,
+`z3ds_compressor_path`):
 
 ```python
 nszip_path: str = Field(
@@ -344,13 +392,18 @@ nszip_path: str = Field(
 )
 ```
 
-This lets ops override the path/env without code changes, and is what the
-service reads in `__init__`.
+This lets ops override the path/env without code changes, and is what the plugin
+passes to its service in `__init__`.
 
-### 5.3 Write the service module: `app/services/nszip.py`
+### 5.3 Write the service + the plugin
 
-This is the heart of the work. Copy `app/services/z3ds_compress.py` and
-adapt. The required shape (see the contract in §1):
+There are two files. The **service** (`app/services/nszip.py`) owns the
+subprocess: build the command, spawn it, parse progress, handle cancel. Copy
+`app/services/z3ds_compress.py` and adapt. The **plugin**
+(`app/services/tools/nszip.py`) is a thin `BaseTool` subclass that holds the
+`ModeSpec` rows and delegates to the service. Copy `app/services/tools/z3ds.py`.
+
+The service skeleton:
 
 ```python
 import asyncio, contextlib, logging, os, shutil, threading, time
@@ -358,8 +411,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from config import settings
-from fastapi.concurrency import run_in_threadpool
-from services.chdman import ConversionCancelled          # reuse the shared exception
+from services.subprocess_runner import ConversionCancelled   # reuse the shared exception
 from services.timeout_policy import compute_progress_stall_timeout
 
 NSZIP_CONVERTIBLE_EXTENSIONS = {".nsp", ".xci"}
@@ -385,12 +437,9 @@ class NszipService:
                        "-n", str(settings.chdman_ioprio_level)] + cmd
         return cmd
 
-    def _track_pid(self, pid): 
-        with self._pid_lock: self._active_pids.add(pid)
-    def _untrack_pid(self, pid):
-        with self._pid_lock: self._active_pids.discard(pid)
     def active_pids(self):
-        with self._pid_lock: return list(self._active_pids)
+        with self._pid_lock:
+            return list(self._active_pids)
 
     async def convert(self, input_path, output_path, mode="nszip_compress",
                       *, compression=None, cancel_event=None) -> AsyncGenerator[dict, None]:
@@ -405,59 +454,96 @@ class NszipService:
         # 8. finally yield {"progress": 100, "message": "Compression complete"}
         ...
 
-    async def verify(self, path) -> dict:
-        final = {"valid": False, "message": "Verification failed"}
-        async for u in self.verify_stream(path):
-            if u.get("type") in ("complete", "error"):
-                final = u
-        return {"valid": bool(final.get("valid")), "message": final.get("message") or "Verification failed"}
+    async def verify(self, path) -> dict: ...
+    async def verify_stream(self, path) -> AsyncGenerator[dict, None]: ...
+    def info(self, path) -> dict: ...
 
-    async def verify_stream(self, path) -> AsyncGenerator[dict, None]:
-        # deep integrity check; yield {"type":"progress"/"complete"/"error", ...}
-        ...
-
-    def info(self, path) -> dict:
-        # filesystem-level metadata; return keys matching your info model
-        ...
-
-    @staticmethod
-    def is_convertible(filename) -> bool:
-        return Path(filename).suffix.lower() in NSZIP_CONVERTIBLE_EXTENSIONS
-
-    @staticmethod
-    def get_output_path_for_mode(mode, input_path, output_dir=None, *, treat_as_stem=False) -> str:
+    def get_output_path(self, input_path, output_dir=None) -> str:
         input_p = Path(input_path)
-        stem = input_p.name if treat_as_stem else input_p.stem
-        ext = "" if treat_as_stem else input_p.suffix.lower()
-        out_ext = NSZIP_OUTPUT_FORMATS.get(ext, ".nsz")
-        filename = f"{stem}{out_ext}"
+        out_ext = NSZIP_OUTPUT_FORMATS.get(input_p.suffix.lower(), ".nsz")
+        filename = f"{input_p.stem}{out_ext}"
         return str(Path(output_dir) / filename) if output_dir else str(input_p.parent / filename)
 
 
-nszip_service = NszipService()   # module-level singleton, imported everywhere
+nszip_service = NszipService()   # module-level singleton
 ```
 
-**Critical implementation rules** (all enforced by the existing services,
-copy them, don't improvise):
+The plugin skeleton (copy `app/services/tools/z3ds.py`):
 
-- **Never** use `shell=True` / string commands. Build an argv list and use
-  `asyncio.create_subprocess_exec(cmd[0], *cmd[1:], ...)`. The binary path
-  comes from validated settings; inputs are never shell-interpreted.
+```python
+from fastapi.concurrency import run_in_threadpool
+from models import NszipInfo, OutputStatus
+from services.nszip import (
+    NSZIP_CONVERTIBLE_EXTENSIONS, NSZIP_OUTPUT_FORMATS, nszip_service,
+)
+from .base import BaseTool
+from .spec import ModeKind, ModeSpec
+
+
+class NszipTool(BaseTool):
+    id = "nszip"
+    display_name = "Switch"
+    modes = (
+        ModeSpec(
+            mode="nszip_compress", tool_id="nszip", kind=ModeKind.COMPRESS,
+            label="Compress to NSZ/XCZ", group="nszip",
+            output_ext=None,  # mapped from the input extension
+            input_extensions=frozenset(NSZIP_CONVERTIBLE_EXTENSIONS),
+            supports_delete_on_verify=True,
+        ),
+    )
+    output_extensions = frozenset(NSZIP_OUTPUT_FORMATS.values())
+    verify_extensions = output_extensions
+
+    def __init__(self, binary_path):
+        super().__init__(binary_path)
+
+    def output_path(self, mode, input_path, output_dir=None, *, treat_as_stem=False):
+        return nszip_service.get_output_path(input_path, output_dir)
+
+    def convert(self, input_path, output_path, mode, *, compression=None, cancel_event=None):
+        return nszip_service.convert(input_path, output_path, mode,
+                                     compression=compression, cancel_event=cancel_event)
+
+    async def verify(self, path): return await nszip_service.verify(path)
+    def verify_stream(self, path): return nszip_service.verify_stream(path)
+    async def info(self, path): return await run_in_threadpool(nszip_service.info, path)
+    def info_model(self, raw, path): return NszipInfo(**raw)
+    def active_pids(self): return nszip_service.active_pids()
+```
+
+**Critical service rules** (all enforced by the existing services, copy them):
+
+- **Never** use `shell=True`. Build an argv list and use
+  `asyncio.create_subprocess_exec(cmd[0], *cmd[1:], ...)`. The binary path comes
+  from validated settings; inputs are never shell-interpreted.
 - **Always** support `cancel_event`: spawn a watcher task that
-  `process.terminate()`s (then `kill()`s after a timeout), set a
-  `cancelled_by_request` flag, clean up the partial output file, and raise
-  `ConversionCancelled`. See `z3ds_compress.py:193` and `chdman.py:156`.
-- **Always** apply a stall timeout via `compute_progress_stall_timeout(...)`
-  (`z3ds_compress.py:182`) so a wedged binary can't hang a job forever.
-- **Progress** is a 0–100 int. If the binary doesn't report percentages,
-  estimate from output-file growth like z3ds does (`z3ds_compress.py:251`),
-  or emit a heartbeat with elapsed seconds like dolphin (`dolphin_tool.py:241`).
-- Respect `settings.chdman_nice` / `chdman_ioprio_*` (these knobs are shared
-  across all tools, they aren't chdman-specific despite the name).
-- Track PIDs (`_track_pid`/`_untrack_pid`) so the debug heartbeat can report
-  them.
+  `process.terminate()`s (then `kill()`s after a timeout), clean up the partial
+  output file, and raise `ConversionCancelled`. See `z3ds_compress.py`.
+- **Always** apply a stall timeout via `compute_progress_stall_timeout(...)` so a
+  wedged binary can't hang a job forever.
+- **Progress** is a 0 to 100 int. If the binary doesn't report percentages,
+  estimate from output-file growth like z3ds does, or emit an elapsed-seconds
+  heartbeat via the shared `SubprocessRunner` like dolphin does.
+- Respect `settings.chdman_nice` / `chdman_ioprio_*`. These knobs are shared
+  across all tools; they aren't chdman-specific despite the name.
+- Track PIDs so the debug heartbeat can report them.
 
-### 5.4 Add the mode + info model: `app/models.py`
+### 5.4 Register the plugin: `app/services/tools/__init__.py`
+
+This is the single dispatch wiring step. Add the import and one `register` call:
+
+```python
+from .nszip import NszipTool
+...
+registry.register(NszipTool(settings.nszip_path))
+```
+
+Once registered, `job_manager` and `convert.py` dispatch your mode through the
+registry with no further edits. The registry validates on register: duplicate
+ids or mode names raise, and every `ModeSpec.tool_id` must equal the tool's `id`.
+
+### 5.5 Add the mode + info model: `app/models.py`
 
 ```python
 class ConversionMode(str, Enum):
@@ -466,7 +552,7 @@ class ConversionMode(str, Enum):
     NSZIP_COMPRESS = "nszip_compress"        # NEW
     ...
 
-class NszipInfo(BaseModel):                  # NEW, shape it like Z3DSInfo (models.py:193)
+class NszipInfo(BaseModel):                  # NEW, shape it like Z3DSInfo
     file: str
     size: int
     size_display: str
@@ -476,162 +562,116 @@ class NszipInfo(BaseModel):                  # NEW, shape it like Z3DSInfo (mode
     compression_type: str | None = None
 ```
 
-If your tool extracts/decompresses too, add a second mode
-(e.g. `NSZIP_EXTRACT = "nszip_extract"`). Keep a consistent prefix
-(`nszip_`), the job pipeline and routes pattern-match on it.
+Every `ModeSpec.mode` must equal a `ConversionMode` value: the route layer
+validates the incoming `request.mode` against `ConversionMode`, so an unlisted
+mode never reaches dispatch. Keep a consistent prefix (`nszip_`) if you add a
+second mode (for example `NSZIP_EXTRACT = "nszip_extract"`).
 
-### 5.5 Dispatch in the job pipeline: `app/services/job_manager.py`
+### 5.6 The job pipeline: usually nothing
 
-Two edits:
+`job_manager._process_job` dispatches convert and verify generically:
+`registry.for_mode(job.mode.value).convert(...)` and
+`registry.for_mode(job.mode.value).verify(...)`. `_queue_job_locked` computes the
+output path via `registry.for_mode(mode.value).output_path(...)`. So once your
+plugin is registered, **the pipeline needs no edits** for a standard
+compress-style tool.
 
-**a) Output-path selection** in `_queue_job_locked` (`job_manager.py:139`).
-Today it special-cases z3ds and otherwise calls `chdman_service.get_chd_path`:
+Touch `job_manager` only for special post-processing. The current special cases
+are chdman-specific: GAME/NAME disc-id tagging after `createcd`/`createdvd`, and
+`.bin` sidecar handling for multi-track CD inputs. A clean single-file tool like
+nszip needs none of that.
+
+### 5.7 Validation + output dispatch: `app/routes/convert.py`
+
+Output paths and the generic spec-flag validation are handled by the registry,
+so you usually add **only** an extension-validation block. `plan_job` validates
+the input extension per tool; mirror the z3ds block (which checks
+`spec.tool_id == "z3ds"` and the input extension against the spec). For nszip:
 
 ```python
-if output_path is None:
-    if mode == ConversionMode.Z3DS_COMPRESS:
-        output_path = z3ds_compress_service.get_output_path(file_path, output_dir)
-    elif mode == ConversionMode.NSZIP_COMPRESS:                       # NEW
-        output_path = nszip_service.get_output_path_for_mode(         # NEW
-            mode.value, file_path, output_dir)                        # NEW
-    else:
-        output_path = chdman_service.get_chd_path(file_path, output_dir)
+if spec.tool_id == "nszip":
+    ext = Path(file_path).suffix.lower()
+    if ext not in spec.input_extensions:
+        raise SkipFile(SkipReason.NSZIP_BAD_EXTENSION)   # add the reason to the enum
 ```
 
-(In practice `convert.py` almost always passes an explicit `output_path`, so
-this branch is a fallback, but wire it for correctness.)
+Everything else is spec-driven:
 
-**b) Service selection** in `_process_job` (`job_manager.py:1444`). Extend the
-`_convert_service` ladder:
+- **Output path:** `_get_output_path` delegates to
+  `registry.for_mode(mode).output_path(...)`. No branch to add.
+- **Delete-on-verify:** `supports_delete_on_verify(mode)` reads
+  `registry.spec(mode).supports_delete_on_verify`. Set the flag on your
+  `ModeSpec`, not in `convert.py`.
+- **Archive inputs:** the single guard in `plan_job` rejects archive (`::`)
+  members for any mode whose `spec.allows_archive_input` is `False` (the
+  default). Set it `True` only when the input is a convertible *source*, and the
+  archive listing surfaces your members automatically via
+  `registry.archive_input_extensions()`. Leave it `False` when the input is an
+  *output* class (like chdman extract/copy on `.chd`).
+
+### 5.8 Mark inputs convertible in listings: `app/routes/files.py`
+
+`files.py` annotates each file in directory listings and search results with
+per-tool convertibility and output-existence flags so the UI can badge rows and
+gate selection. It imports the registry and computes per-tool flags (today
+`is_chd_convertible` / `is_dolphin_convertible` / `is_z3ds_convertible` plus
+`has_*` output-existence checks).
+
+1. Add the model fields. In `app/models.py` `FileEntry`, add
+   `nszip_convertible: bool = False` and, for "output already exists" badges,
+   `has_nszip: bool = False`, `nszip_ready: bool = False`,
+   `nszip_path: str | None = None`, paralleling the z3ds fields.
+2. In the directory scan, compute `is_nszip_convertible` from the extension and
+   an output-existence check (use your plugin's `detect_output(...)` or an
+   inline check modeled on the z3ds path), then set them on the `FileEntry`.
+3. Do the same in `search_files`, both in the "is this file interesting" test
+   and where it records the flags.
+
+### 5.9 Info + verify endpoints: `app/routes/info.py`
+
+Verify endpoints are **factory-generated**. You don't hand-write them. Add one
+call alongside the existing tool registrations:
 
 ```python
-_convert_service = (
-    dolphin_tool_service if job.mode.value.startswith("dolphin_")
-    else z3ds_compress_service if job.mode == ConversionMode.Z3DS_COMPRESS
-    else nszip_service if job.mode == ConversionMode.NSZIP_COMPRESS      # NEW
-    else chdman_service
+verify_nszip, verify_nszip_events, verify_nszip_batch_events = register_verify_routes(
+    router, registry.get("nszip"),
 )
 ```
 
-Add the import at the top (`job_manager.py:27` neighborhood):
-`from services.nszip import nszip_service`.
+`register_verify_routes(router, tool)` generates the trio (`/api/nszip-verify`,
+`/api/nszip-verify/events`, `/api/nszip-verify-batch/events`) from the plugin's
+`verify_extensions`, acquires the global verify lane
+(`_acquire_verify_lane_or_429`, bounded by `workload_limiter`), and calls
+`verification_store.mark_verified(path)` on success. No per-tool extension
+constants are needed; the factory reads them off the plugin.
 
-**c) Delete-on-verify** (optional). If you want the "verify then delete
-source" feature for this tool, also extend the verify branch in
-`_process_job`. z3ds has a dedicated branch at `job_manager.py:1556`
-(`if job.mode.value == "z3ds_compress": ... z3ds_compress_service.verify(...)`)
-because its verify lives outside the dolphin/chdman pair. Add an analogous
-branch calling `nszip_service.verify(...)`, or generalize the selector.
+Info is hand-written per tool. Add a `GET /api/nszip-info` endpoint modeled on
+`get_z3ds_info`, returning your `NszipInfo` model. No router registration is
+needed; `info.router` is already mounted under `/api` in `app/main.py`.
 
-### 5.6 Validation + output dispatch: `app/routes/convert.py`
+### 5.10 Frontend: `src/lib/api/endpoints.js`
 
-- **Output path dispatch:** extend `_get_output_path` (`convert.py:100`):
-
-```python
-def _get_output_path(mode, input_path, output_dir, *, treat_as_stem=False):
-    if _is_dolphin_mode(mode):
-        return dolphin_tool_service.get_output_path_for_mode(...)
-    if mode == ConversionMode.Z3DS_COMPRESS.value:
-        return z3ds_compress_service.get_output_path_for_mode(...)
-    if mode == ConversionMode.NSZIP_COMPRESS.value:                    # NEW
-        return nszip_service.get_output_path_for_mode(                 # NEW
-            mode, input_path, output_dir, treat_as_stem=treat_as_stem) # NEW
-    return chdman_service.get_output_path_for_mode(...)
-```
-
-- **delete-on-verify support:** add your mode to `supports_delete_on_verify`
-  (`convert.py:87`) if applicable.
-- **Extension validation:** add a block in both `create_job`
-  (`convert.py:421`, the z3ds example) and `create_batch_jobs`
-  (`convert.py:662`):
-
-```python
-is_nszip = mode == ConversionMode.NSZIP_COMPRESS.value
-...
-if is_nszip:
-    ext = Path(file_path).suffix.lower()
-    if ext not in NSZIP_CONVERTIBLE_EXTENSIONS:
-        raise HTTPException(status_code=400,
-            detail="nszip mode requires Switch dumps (.nsp, .xci)")
-```
-
-- **Archive inputs:** controlled by one flag, set `allows_archive_input=True`
-  on each `ModeSpec` whose input is a convertible *source* (see chdman create,
-  dolphin, and z3ds). A single guard in `plan_job` rejects archive (`::`)
-  members for any mode that leaves it `False` (the default), so you don't add
-  per-tool branches. The archive listing then surfaces your members
-  automatically because it's driven by `registry.archive_input_extensions()`.
-  Leave it `False` only when the input is an *output* class (like chdman
-  extract/copy on `.chd`) that shouldn't be listed as a convertible source.
-- Import the convertible set + service at the top of `convert.py`
-  (`convert.py:27` shows the z3ds import).
-
-### 5.7 Mark inputs convertible in listings: `app/routes/files.py`
-
-`files.py` annotates each `FileEntry` with convertibility flags so the UI can
-badge rows and gate selection. Today it imports each tool's extension set
-(`files.py:11-13`) and sets `convertible` / `dolphin_convertible` /
-`z3ds_convertible` plus output-existence flags.
-
-1. Import your set: `from services.nszip import NSZIP_CONVERTIBLE_EXTENSIONS, NSZIP_OUTPUT_FORMATS`.
-2. Add a model field. In `app/models.py` `FileEntry` (`models.py:42`) add
-   `nszip_convertible: bool = False` and, if you show "output already exists"
-   badges, `has_nszip: bool = False`, `nszip_ready: bool = False`,
-   `nszip_path: str | None = None`, paralleling the z3ds fields
-   (`models.py:56`).
-3. In `scan_directory` (`files.py:150`) compute
-   `is_nszip_convertible = ext in NSZIP_CONVERTIBLE_EXTENSIONS` and an
-   output-existence check modeled on `_detect_z3ds_output_path`
-   (`files.py:34`), then pass them into the `FileEntry(...)` constructor
-   (`files.py:232`).
-4. Do the same in `search_files` (`files.py:316` adds the extension to the
-   "is this file interesting" test, and `:349` records the flags).
-
-### 5.8 Info + verify endpoints: `app/routes/info.py`
-
-Mirror the z3ds endpoints (`info.py:338-663`, `:1506`). Add:
-
-- `GET /api/nszip-info` → `nszip_service.info(...)`, returns your `NszipInfo`
-  model. Model the validation on `get_z3ds_info` (`info.py:1506`).
-- `GET /api/nszip-verify` (one-shot) and `GET /api/nszip-verify/events`
-  (SSE), modeled on `verify_z3ds` (`info.py:527`) and `verify_z3ds_events`
-  (`info.py:564`). **Acquire the verify lane** with
-  `_acquire_verify_lane_or_429()` (`info.py:55`) so verification stays
-  globally bounded by `MAX_VERIFY_CONCURRENCY`, and call
-  `verification_store.mark_verified(path)` on success.
-- `POST /api/nszip-verify-batch/events` (SSE) modeled on
-  `verify_z3ds_batch_events` (`info.py:355`).
-- Define `NSZIP_VERIFY_EXTENSIONS` / `NSZIP_INFO_EXTENSIONS` near the z3ds
-  ones (`info.py:341`) and a `_is_nszip_verify_file` helper.
-
-No new router registration is needed, `info.router` is already mounted under
-`/api` in `app/main.py:285`.
-
-### 5.9 Frontend: `src/lib/api/endpoints.js`
-
-Add client methods next to the z3ds ones:
+Add client methods on the `api` object next to the z3ds ones. The naming
+convention is `get<Tool>Info` / `verify<Tool>` / `verifyBatch<Tool>`:
 
 - `getNszipInfo(path)`, like `getZ3DSInfo`.
-- `verifyNszip(path, {onProgress})`, single-file SSE, like `verify3DS`.
-  Routes through `verifyEventSource` from `sse.js`.
-- `verifyBatchNszip(paths, {onProgress, onFileComplete, signal})`, like
-  `verifyBatchZ3DS`. Routes through `runBatchVerify` + `sseFetchPost`
-  (POST-body SSE) under the hood.
+- `verifyNszip(path, {onProgress})`, single-file SSE. Routes through
+  `verifyEventSource` from `sse.js`.
+- `verifyBatchNszip(paths, {onProgress, onFileComplete, signal})`, batch SSE.
+  Routes through the module-local `runBatchVerify` helper, which wraps
+  `sseFetchPost` from `sseFetch.js`.
 
-`createJob` / `createBatchJobs` are generic over `mode`, so no change there
-, the registry's submit path just passes `mode: 'nszip_compress'`. The
-verify URL is **derived automatically** from `verifyPrefix: 'nszip'` in
-the registry descriptor; no edits to any URL map.
+`createJob` / `createBatchJobs` are generic over `mode`, so no change there: the
+registry's submit path passes `mode: 'nszip_compress'`. The verify URL is
+**derived automatically** from `verifyPrefix: 'nszip'` in the registry
+descriptor; there's no URL map to edit.
 
-### 5.10 Frontend: `src/lib/tools/registry.js`
+### 5.11 Frontend: `src/lib/tools/registry.js`
 
-The frontend is a **Svelte 5 + Vite SPA** under `src/` and is driven by a
-single declarative tool registry (`src/lib/tools/registry.js`). The registry
-is the only place that knows tool identity, there are no `if (tool === ...)`
-branches anywhere downstream. Sidebar, workspace, file badges, conversion
-config, info modal, verify dispatch, and SSE URL building all look up the
-registry. Adding `nszip` to the frontend is **one new entry** appended to
-the `TOOLS` array:
+The frontend is a **Svelte 5 + Vite SPA** under `src/`, driven by a single
+declarative tool registry (`src/lib/tools/registry.js`). The registry is the only
+place that knows tool identity; there are no `if (tool === ...)` branches
+downstream. Adding `nszip` is **one new entry** appended to the `TOOLS` array:
 
 ```js
 // src/lib/tools/registry.js
@@ -644,16 +684,16 @@ the `TOOLS` array:
   sourceExts: ['.nsp', '.xci'],
   verifyExts: ['.nsz', '.xcz'],
   modeGroups: ['nszip'],
-  // Human labels for any group ids the tool introduces, replaces
-  // the old hardcoded switch in registry.groupLabel.
-  groups: { nszip: 'Nintendo Switch' },
+  groups: { nszip: 'Nintendo Switch' },   // human labels for the tool's group ids
   defaultMode: 'nszip_compress',
-  glyph: 'NSW',                       // 2–3 char affordance for sidebar / dashboard
-  accent: 'var(--badge-dat-match)',   // optional CSS color or token
+  glyph: 'NSW',                           // 2-3 char affordance for sidebar / dashboard
+  accent: 'var(--badge-dat-match)',       // CSS color or token
+  // compressionStyle / compressionCodecs only if the tool exposes codec choices
+  // (chdman uses 'multi', dolphin 'single-with-level'); omit for a fixed compressor.
   modes: [
     { mode: 'nszip_compress', kind: 'compress', label: 'Compress to NSZ/XCZ',
       group: 'nszip',
-      outputExt: null,                // mapped from input extension
+      outputExt: null,                    // mapped from input extension
       inputExtensions: ['.nsp', '.xci'],
       supportsCompression: false,
       supportsCompressionLevel: false,
@@ -667,65 +707,59 @@ the `TOOLS` array:
 },
 ```
 
-That's the entire frontend change. Specifically you do **NOT** need to:
+That's the entire frontend change. The tool fields above are the real schema;
+chdman additionally carries `prefix`, and tools with codec choices carry
+`compressionStyle` / `compressionCodecs`. You do **NOT** need to:
 
-- Edit a `VERIFY_URL` map, `registry.verifyUrl(toolId, kind)` derives both
-  single and batch URLs from `verifyPrefix` (`''` for chdman, `'<segment>'`
-  for everyone else).
-- Edit a `VALID_TOOLS` set, `ui.svelte.js` reads `registry.ids()`.
-- Edit a `groupLabel()` switch, group labels live on `tool.groups`.
-- Edit the Sidebar component, it iterates `registry.all()` and reads
-  `t.glyph` / `t.accent` (with sensible fallbacks).
-- Edit the Workspace, file list, conversion config, or any modal, they all
+- Edit a `VERIFY_URL` map. `registry.verifyUrl(toolId, kind)` derives both single
+  and batch URLs from `verifyPrefix` (`''` for chdman, `'<segment>'` otherwise).
+- Edit a `VALID_TOOLS` set. `ui.svelte.js` reads `registry.ids()`.
+- Edit a `groupLabel()` switch. Group labels live on `tool.groups`; the lookup is
+  `registry.groupLabel(group, toolId)`.
+- Edit the Sidebar, Workspace, file list, conversion config, or any modal. They
   call `registry.specFor(mode)`, `registry.forTool(id)`,
-  `registry.modesByGroup(id)`, `registry.toolForVerifyPath(path)`, etc.
+  `registry.modesByGroup(id)`, `registry.toolForVerifyPath(path)`, and so on.
 
-The four `api.*` calls you reference (`getNszipInfo`, `verifyNszip`,
-`verifyBatchNszip`, and any others) need to exist in `src/lib/api/endpoints.js`
-, add them alongside the existing `getCHDInfo` / `verifyCHD` /
-`verifyBatchCHDs` patterns. Headers (`X-CHD-Action-Confirm`), error
-normalization, and SSE helpers (`sse.js`, `sseFetch.js`) all stay the same.
+> **Build step.** The SPA compiles with Vite. Run `npm run dev` for HMR against
+> the FastAPI backend, or `npm run build` to emit `static/index.html` +
+> `static/assets/*` (used by FastAPI in production and by the Docker
+> `frontend-builder` stage). When editing any `.svelte` file, run it through the
+> Svelte MCP `svelte-autofixer` per the project contract.
 
-> **Build step.** The SPA compiles with Vite. Run `npm run dev` for HMR
-> against the FastAPI sidecar, or `npm run build` to emit
-> `static/index.html` + `static/assets/*` (used by FastAPI in
-> production and by the Docker `frontend-builder` stage). When editing
-> any `.svelte` file, run it through the Svelte MCP `svelte-autofixer`
-> per the project contract.
-
-### 5.11 Tests
+### 5.12 Tests
 
 Add, modeled on the existing suites:
 
-- `tests/test_nszip_routes.py`, info + verify endpoint behavior
-  (copy `tests/test_z3ds_routes.py`).
+- `tests/test_nszip_routes.py`, info + verify endpoint behavior (copy
+  `tests/test_z3ds_routes.py`).
 - `tests/test_nszip_service.py`, `convert`/`verify` happy path, cancel path,
   bad-extension rejection (copy `tests/test_z3ds_verification_service.py`).
-- Extend `tests/test_mode_parity_fixes.py` so single-job and batch-job
-  validation stay in lockstep for the new mode.
+- Extend `tests/test_tool_registry.py` so your mode resolves to your tool with
+  the right spec flags.
+- Extend `tests/test_mode_parity_fixes.py` so single-job and batch-job validation
+  stay in lockstep for the new mode.
 
 Run them:
 
 ```bash
-cd /home/user/compressatorium
-pytest -q tests/test_nszip_routes.py tests/test_mode_parity_fixes.py
+# from the repo root
+pytest -q tests/test_nszip_routes.py tests/test_tool_registry.py tests/test_mode_parity_fixes.py
 ```
 
 `tests/conftest.py` stubs the binaries, so tests don't need the real tool
 installed.
 
-### 5.12 Docs + version
+### 5.13 Docs + version
 
 - Update `README.md` (tool table / supported formats) and `RELEASE_NOTES.md`.
-- Bump the version with `./scripts/sync-version.sh <new-version>` (keeps
-  `.version`, `package.json`, `package-lock.json`, `RELEASE_NOTES.md` in
-  sync, see `AGENTS.md` §5).
+- The version lives in `package.json`. A release bumps it and publishes a GitHub
+  Release tagged `vX.Y.Z`, which is what triggers the image build (see §10).
 
 ---
 
 ## 6. Tandem checklist (copy/paste)
 
-A new tool **is** a new platform, so do all of these together:
+A new tool **is** a new platform, so do these together:
 
 ```
 BINARY
@@ -736,40 +770,39 @@ SERVICE (app/services/<tool>.py)
 [ ] *_CONVERTIBLE_EXTENSIONS, *_OUTPUT_FORMATS, module-level singleton
 [ ] convert(): exec (no shell), progress yields, cancel_event, stall timeout,
     nice/ionice, PID tracking, ConversionCancelled, final 100%
-[ ] verify() + verify_stream()
-[ ] info(), is_convertible(), get_output_path_for_mode(), active_pids()
+[ ] verify() + verify_stream(), info(), get_output_path()
+
+PLUGIN (app/services/tools/<tool>.py)
+[ ] BaseTool subclass: id, display_name, modes (ModeSpec rows),
+    output_extensions, verify_extensions
+[ ] delegate convert/verify/verify_stream/info/info_model/output_path/active_pids
+[ ] optional: detect_output() for "output exists" badges
+
+REGISTER (app/services/tools/__init__.py)
+[ ] registry.register(<Tool>(settings.<tool>_path))
 
 MODE + MODELS (app/models.py)
 [ ] ConversionMode.<TOOL>_<ACTION> with a consistent prefix
 [ ] <Tool>Info model (if it has an info modal)
 [ ] FileEntry: <tool>_convertible / has_<tool> / <tool>_ready / <tool>_path
 
-PIPELINE (app/services/job_manager.py)
-[ ] import the service
-[ ] _queue_job_locked: output-path branch
-[ ] _process_job: _convert_service ladder branch
-[ ] _process_job: verify branch (only if delete-on-verify supported)
-
 ROUTES
-[ ] convert.py: _get_output_path branch, extension validation (single+batch),
-    supports_delete_on_verify, archive-input guard
-[ ] files.py: import ext set, compute flags in scan_directory + search_files
-[ ] info.py: /<tool>-info, /<tool>-verify(+/events), /<tool>-verify-batch/events,
-    *_VERIFY_EXTENSIONS, verify-lane acquire, mark_verified
+[ ] convert.py: extension-validation block in plan_job (only if needed)
+[ ] files.py: compute flags in the directory scan + search_files
+[ ] info.py: register_verify_routes(router, registry.get("<tool>")) + /<tool>-info
+
+PIPELINE (app/services/job_manager.py)
+[ ] usually nothing (registry dispatches convert + verify)
+[ ] only for special post-processing (disc-id tags, multi-file sidecars)
 
 FRONTEND
 [ ] src/lib/api/endpoints.js: get<Tool>Info, verify<Tool>, verifyBatch<Tool>
 [ ] src/lib/tools/registry.js: one new entry in the TOOLS array
-    (id, label, hint, verifyPrefix, sourceExts, verifyExts, modeGroups,
-    groups, defaultMode, glyph, accent, modes[], getInfo/verify/
-    verifyBatch/productPath). Sidebar, workspace, badges, modals, and
-    verify dispatch all pick it up via registry lookups, no other
-    .svelte edits.
 
 TESTS + DOCS
-[ ] tests/test_<tool>_routes.py, tests/test_<tool>_service.py, mode-parity
+[ ] tests/test_<tool>_routes.py, tests/test_<tool>_service.py, registry, mode-parity
 [ ] tests/conftest.py: binary stub fixture
-[ ] README / RELEASE_NOTES / ./scripts/sync-version.sh
+[ ] README / RELEASE_NOTES / package.json version bump
 
 PERIPHERAL (don't forget)
 [ ] .dockerignore: confirm nothing new is excluded
@@ -777,7 +810,6 @@ PERIPHERAL (don't forget)
 [ ] .local-bin/<binary>: local-dev copy (from-source tools)
 [ ] entrypoint.sh: CLI-mode loop (only if headless batch support wanted)
 [ ] disc_id.py: serial/title parser (only for new disc platforms w/ tagging)
-[ ] archive.py CONVERTIBLE_EXTENSIONS (only if reading from archives)
 [ ] migrations/: new Alembic rev (only if persisting new columns/tables)
 [ ] docker-compose*.yml + DEPLOYMENT.md + DOCKER-COMPOSE.md: env/volume docs
 [ ] lint clean: ruff, pylint, eslint, hadolint (Dockerfile), markdownlint
@@ -788,78 +820,77 @@ PERIPHERAL (don't forget)
 
 ## 8. The Docker image in depth: `Dockerfile`, `.dockerignore`, deps
 
-The image is a two-stage multi-arch build (`debian:trixie-slim`).
+The image is a **three-stage** multi-arch build on `debian:trixie-slim`: a
+`builder` stage (compiles from-source binaries), a `frontend-builder` stage on
+`node:lts-slim` (runs `npm ci && npm run build` for the Svelte UI), and the
+runtime stage (no Node).
 
-**Build args & arch.** `ARG TARGETARCH` (`Dockerfile:36`) is `amd64`/`arm64`.
-A from-source build (g++) compiles per-arch automatically. A downloaded
-`.deb`/binary needs a **per-arch URL + SHA256**, like the `mame-tools` block
-(`Dockerfile:38-84`) which branches on `TARGETARCH` and verifies with
-`sha256sum -c`. Reproduce that pattern for any pinned download.
+**Build args & arch.** `ARG TARGETARCH` (set in the runtime stage) is
+`amd64`/`arm64`. A from-source build (g++) compiles per-arch automatically. A
+downloaded `.deb`/binary needs a **per-arch URL + SHA256**, like the `mame-tools`
+block which branches on `TARGETARCH` and verifies with `sha256sum -c`. Reproduce
+that pattern for any pinned download.
 
-**Builder stage** (`Dockerfile:1-23`): install toolchain (`build-essential`,
-`libzstd-dev`, …), `git clone`, compile, `chmod +x`. Add your build here.
+**Builder stage:** install toolchain (`build-essential`, `libzstd-dev`, …),
+`git clone`, compile, `chmod +x`. Add your build here.
 
-**Runtime stage** (`Dockerfile:25+`):
-- Add any runtime shared libraries to the `apt-get install` list
-  (`Dockerfile:53-66`). The CLI `zstd` is already present (z3ds verify uses
-  `zstd -t`); `ionice`/`nice` come from `util-linux`.
-- `COPY --from=builder /tmp/<tool>/<binary> /usr/local/bin/<binary>`
-  (next to the z3ds copy at `Dockerfile:105`).
+**Runtime stage:**
+- Add any runtime shared libraries to the `apt-get install` list. The CLI `zstd`
+  is already present (z3ds verify uses `zstd -t`); `ionice`/`nice` come from
+  `util-linux`.
+- `COPY --from=builder /tmp/<tool>/<binary> /usr/local/bin/<binary>` next to the
+  z3ds copy.
 - Optional/best-effort installs (a tool that only exists on one arch) should
-  follow the dolphin-emu pattern: install with `|| echo WARNING`
-  (`Dockerfile:67-73`) and create a wrapper only `if command -v` succeeds
-  (`Dockerfile:92-95`). The service must then tolerate a missing binary
-  gracefully (surface a clear runtime error).
-- The image runs as **uid/gid 999 (`converter`)** (`Dockerfile:148`). Install
-  to a world-readable path (`/usr/local/bin`) and `chmod +x`.
-- `HEALTHCHECK` (`Dockerfile:137`) only probes the web UI; no change needed.
+  follow the dolphin-emu pattern: install with `|| echo WARNING` and create a
+  wrapper only `if command -v` succeeds. The service must then tolerate a missing
+  binary gracefully (surface a clear runtime error).
+- The image runs as **uid/gid 999 (`converter`)**. Install to a world-readable
+  path (`/usr/local/bin`) and `chmod +x`.
+- `HEALTHCHECK` only probes the web UI; no change needed.
 
 **hadolint** runs in CI (`docker-image.yml` `lint` job) with
-`failure-threshold: error` and `ignore: DL3008,DL3013`. Keep your `RUN`
-layers clean (combine `apt-get update && install`, `rm -rf
-/var/lib/apt/lists/*`, pin where the existing file pins).
+`failure-threshold: error` and `ignore: DL3008,DL3013`. Keep your `RUN` layers
+clean (combine `apt-get update && install`, `rm -rf /var/lib/apt/lists/*`, pin
+where the existing file pins).
 
-**`.dockerignore`**: `app/`, `static/`, `migrations/`, `entrypoint.sh`,
-`requirements.txt` are copied in. `tests/` and most `*.md` (except
-`README.md`) are excluded, so this guide and your service tests never enter
-the image. If you reference a new top-level file from the Dockerfile, confirm
-it isn't ignored.
+**`.dockerignore`:** `app/`, `static/`, `migrations/`, `entrypoint.sh`,
+`requirements.txt` are copied in. `tests/` and most `*.md` (except `README.md`)
+are excluded, so this guide and your service tests never enter the image. If you
+reference a new top-level file from the Dockerfile, confirm it isn't ignored.
 
-**Python deps**: anything your service `import`s that isn't stdlib or already
-in `requirements.txt` must be added there (and it'll be picked up by
-`pip install -r` at `Dockerfile:102`). Dev/test-only deps go in
-`requirements-dev.txt`.
+**Python deps:** anything your service `import`s that isn't stdlib or already in
+`requirements.txt` must be added there (picked up by `pip install -r` in the
+runtime stage). Dev/test-only deps go in `requirements-dev.txt`.
 
-**Local dev (`run_dev.sh`)**: it bootstraps a `.venv` and runs uvicorn
-against your host. From-source binaries are kept in `.local-bin/` (the repo
-already ships `.local-bin/z3ds_compressor`) so the app works without Docker.
-Drop your compiled binary there and point `<TOOL>_PATH` at it (or add it to
-`PATH`) for local testing.
+**Local dev (`run_dev.sh`):** it bootstraps a `.venv` and runs uvicorn against
+your host. From-source binaries are kept in `.local-bin/` (the repo ships
+`.local-bin/z3ds_compressor`) so the app works without Docker. Drop your compiled
+binary there and point `<TOOL>_PATH` at it (or add it to `PATH`) for local
+testing.
 
 ---
 
 ## 9. Headless CLI mode: `entrypoint.sh`
 
-`entrypoint.sh` supports `CHD_MODE=cli` (batch-convert a volume with no web
-UI; see `docker-compose.cli.yml`). **This path is independent of the Python
-app**, it shells out to `chdman` directly and currently only knows
-`createcd`/`createdvd` over `*.gdi *.iso *.cue` (`entrypoint.sh:127-176`),
-validating `CHDMAN_MODE` against that allow-list (`entrypoint.sh:135`).
+`entrypoint.sh` supports `CHD_MODE=cli` (batch-convert a volume with no web UI;
+see `docker-compose.cli.yml`). This path is **independent of the Python app**: it
+shells out to `chdman` directly and currently only knows `createcd`/`createdvd`
+over `*.gdi *.iso *.cue`, validating `CHDMAN_MODE` against that allow-list with a
+`case` statement.
 
 If your new tool/platform should be usable headlessly:
-- Extend the `CHDMAN_MODE` case statement (or add a parallel `CONVERT_TOOL`
-  env) to accept your mode.
-- Add a globbing loop for your input extensions and invoke your binary,
-  mirroring the existing `for i in *.gdi *.iso *.cue` block.
+- Extend the `CHDMAN_MODE` case statement (or add a parallel `CONVERT_TOOL` env)
+  to accept your mode.
+- Add a globbing loop for your input extensions and invoke your binary, mirroring
+  the existing `for i in *.gdi *.iso *.cue` block.
 - Skip-if-output-exists logic (`[[ -e "${i%.*}.<ext>" ]]`) should match your
   output suffix.
 
-If headless mode is out of scope, you can skip this, the web UI path
-(`exec uvicorn main:app …`, `entrypoint.sh:197`) already dispatches your tool
-via the Python pipeline.
+If headless mode is out of scope, skip this: the web UI path (`exec uvicorn
+main:app …`) already dispatches your tool via the Python pipeline.
 
-The same file also handles **PUID/PGID remap** and the privilege drop to
-`converter` (`entrypoint.sh:4-60`). No changes needed there.
+The same file handles **PUID/PGID remap** and the privilege drop to `converter`
+(`exec gosu converter`). No changes needed there.
 
 ---
 
@@ -867,20 +898,20 @@ The same file also handles **PUID/PGID remap** and the privilege drop to
 
 | Workflow | Trigger | Relevance to a new tool |
 |----------|---------|-------------------------|
-| `docker-image.yml` | **release published** | Builds/pushes multi-arch image to Docker Hub + GHCR, runs **hadolint** (Dockerfile must pass), **Trivy** CRITICAL/HIGH scan (a vulnerable new dep can fail this), generates SBOM + provenance attestation, and **publishes `README.md` as the Docker Hub description**. Also auto-syncs `package.json` from the release tag. |
+| `docker-image.yml` | **release published** | Builds/pushes multi-arch image to Docker Hub + GHCR, runs **hadolint** (Dockerfile must pass), **Trivy** CRITICAL/HIGH scan (a vulnerable new dep can fail this), generates SBOM + provenance attestation, and **publishes `README.md` as the Docker Hub description**. Also syncs `package.json` from the release tag. |
 | `codacy.yml` | push, PR, weekly | Runs the Codacy CLI (ruff, eslint, pylint, bandit, etc.). New Python/JS must lint clean. Honors `pyproject.toml`, `.pylintrc`, `eslint.config.js`, `.codacy.yml`. |
-| `codeql.yml` | push, weekly | CodeQL SAST for **python** and **javascript-typescript** (`codeql.yml:30-32`). New code is scanned automatically, no config change, but don't introduce flagged patterns (e.g. command injection, another reason for the no-`shell=True` rule). |
+| `codeql.yml` | push, PR, weekly | CodeQL SAST for **python** and **javascript-typescript**. New code is scanned automatically, no config change, but don't introduce flagged patterns (for example command injection, another reason for the no-`shell=True` rule). |
 | `label.yml` + `labeler.yml` | PR | Path-based auto-labels. Add a glob if you want your area labeled. |
 | `stale.yml` | schedule | Marks stale issues/PRs. Irrelevant. |
 | `dependabot.yml` | schedule | Dependency PRs. Add an ecosystem entry only if you introduce a new manifest. |
 
 Key takeaways for a contributor:
-- **The image only builds on a GitHub Release.** There is no build-on-push.
-  To ship your tool you (or a maintainer) cut a release tag `vX.Y.Z`; CI then
+- **The image only builds on a GitHub Release.** There is no build-on-push. To
+  ship your tool you (or a maintainer) publish a release tagged `vX.Y.Z`; CI then
   builds `linux/amd64,linux/arm64` and tags `latest`/`beta` accordingly.
 - **Trivy can block a release** if a new system/python package pulls a
-  CRITICAL/HIGH CVE (`ignore-unfixed: true` softens this). Prefer pinned,
-  patched packages, the `mame-tools` snapshot pin is the model.
+  CRITICAL/HIGH CVE (`ignore-unfixed: true` softens this). Prefer pinned, patched
+  packages; the `mame-tools` snapshot pin is the model.
 - **Dockerfile changes must pass hadolint** locally before you push
   (`hadolint Dockerfile`).
 
@@ -902,37 +933,37 @@ hadolint Dockerfile             # if you touched the Dockerfile
 Conventions baked into the configs that affect new tool code:
 
 - **Line length 100** (`pyproject.toml [tool.pylint.format]`, ruff `py310`).
-- **`bandit`** (`.bandit`) flags `subprocess` with `shell=True` and
-  predictable temp paths. The services deliberately use
-  `create_subprocess_exec` with argv lists and document the temp-dir
-  reasoning (`config.py:186-194`). Follow suit or bandit/CodeQL will flag you.
+- **`bandit`** (`.bandit`) flags `subprocess` with `shell=True` and predictable
+  temp paths. The services use `create_subprocess_exec` with argv lists and
+  document the temp-dir reasoning in `config.py`. Follow suit or bandit/CodeQL
+  will flag you.
 - **Broad `except Exception`** at subprocess boundaries is allowed by
-  `.pylintrc`/`pyproject.toml` *if* you log at the call site (review
-  enforces this). The existing services do `logger.exception(...)`.
-- **`isort`/import order** is enforced in CI (pylint's `wrong-import-order` is
-  disabled because ruff/isort own it). Keep imports sorted.
-- Markdown docs are linted by `.markdownlint.json`; CSS by
-  `.stylelintrc.json`.
+  `.pylintrc`/`pyproject.toml` *if* you log at the call site (review enforces
+  this). The existing services do `logger.exception(...)`.
+- **Import order** is owned by ruff/isort (pylint's `wrong-import-order` is
+  disabled). Keep imports sorted.
+- Markdown is linted by `.markdownlint.json`; CSS by `.stylelintrc.json`.
 
 ---
 
 ## 12. Database, migrations & persistence
 
 The app uses **SQLite via SQLAlchemy + Alembic** (`app/services/db.py`,
-`migrations/`). On startup, `apply_migrations()` brings the schema to head and
-imports legacy JSON stores (`app/main.py:137-201`).
+`migrations/`). On startup, the `lifespan` handler in `app/main.py` calls
+`apply_migrations()` (defined in the db module) to bring the schema to head and
+then imports any legacy JSON stores.
 
 For a **new tool**, you almost certainly need **no migration**, because the
 persistence layers are generic over file paths:
 
-- **`verification_store`** records "this output path was verified" keyed by
-  path. Your verify endpoints call `verification_store.mark_verified(path)`
-  and it just works for any extension.
-- **`chd_metadata_store`** caches CHD-specific metadata; a non-CHD tool
-  doesn't use it.
+- **`verification_store`** records "this output path was verified" keyed by path.
+  Your verify endpoints call `verification_store.mark_verified(path)` and it just
+  works for any extension.
+- **`chd_metadata_store`** caches CHD-specific metadata; a non-CHD tool doesn't
+  use it.
 
-You need a migration **only** if you add new persisted columns/tables (e.g. a
-tool-specific metadata cache). In that case:
+You need a migration **only** if you add new persisted columns/tables (for
+example a tool-specific metadata cache). In that case:
 
 ```bash
 ./scripts/new_migration.sh "add nszip metadata table"
@@ -947,27 +978,27 @@ references. `tests/test_alembic_migrations.py` validates head consistency.
 
 ## 13. Supporting services: disc_id, archive, DAT
 
-These are **disc-format-specific** and usually irrelevant to a non-disc tool,
-but matter when your *platform* is a disc image processed by chdman.
+These are **disc-format-specific** and usually irrelevant to a non-disc tool, but
+matter when your *platform* is a disc image processed by chdman.
 
-- **`app/services/disc_id.py`** extracts a game serial/title (e.g.
-  `SLUS-20312`) from PS1/PS2/PSP/Dreamcast sources and embeds GAME/NAME tags
-  into the CHD after `createcd`/`createdvd` (`job_manager.py:1514`). To make a
-  **new disc platform** get tags, add a parser branch in
-  `extract_from_source` (`disc_id.py:379`) and a normalizer like
-  `_normalize_ps_serial` (`disc_id.py:224`). Not needed for RVZ/3DS/etc.
-- **`app/services/archive.py`** lists the inputs that can be converted *from
-  inside* a `.zip/.7z/.rar`. It no longer hardcodes a tool-specific set:
-  `ArchiveService._convertible_extensions()` reads
-  `registry.archive_input_extensions()` (the union of `input_extensions` for
-  every mode with `allows_archive_input=True`), with the module-level
-  `CONVERTIBLE_EXTENSIONS` kept only as a fallback. So once your mode opts in
-  via `allows_archive_input=True`, its members are surfaced automatically,
-  there's nothing to edit here. You still own extraction + related-file
-  handling in `job_manager._process_job` for multi-file formats (single-file
-  inputs like `.3ds`/`.rvz` need nothing extra). Output paths for archive
-  members flow through `_output_name_for_member`, which preserves the original
-  extension so input-derived outputs (e.g. z3ds `.3ds`→`.z3ds`) map correctly.
+- **`app/services/disc_id.py`** extracts a game serial/title (for example
+  `SLUS-20312`) from PS1/PS2/PSP/Dreamcast sources and embeds GAME/NAME tags into
+  the CHD after `createcd`/`createdvd` (driven from `job_manager._process_job`).
+  To make a **new disc platform** get tags, add a parser branch in
+  `extract_from_source` and a normalizer like `_normalize_ps_serial`. Not needed
+  for RVZ/3DS/etc.
+- **`app/services/archive.py`** lists the inputs that can be converted from
+  inside a `.zip/.7z/.rar`. It no longer hardcodes a tool-specific set:
+  `ArchiveService` reads `registry.archive_input_extensions()` (the union of
+  `input_extensions` for every mode with `allows_archive_input=True`), with the
+  module-level `CONVERTIBLE_EXTENSIONS` kept only as a fallback. So once your
+  mode opts in via `allows_archive_input=True`, its members are surfaced
+  automatically; there's nothing to edit here. You still own extraction +
+  related-file handling in `job_manager._process_job` for multi-file formats
+  (single-file inputs like `.3ds`/`.rvz` need nothing extra). Output paths for
+  archive members flow through `archive_service._output_name_for_member`, which
+  preserves the original extension so input-derived outputs (for example z3ds
+  `.3ds` to `.z3ds`) map correctly.
 - **DAT / MAMERedump** (`app/services/dat_*.py`, `app/routes/dat.py`,
   `app/services/file_hasher.py`) is for hash-matching dumps against DAT
   databases. Touch only if your platform participates in DAT verification.
@@ -976,34 +1007,35 @@ but matter when your *platform* is a disc image processed by chdman.
 
 ## 14. End-to-end "in tandem" example map
 
-For the `nszip` (Nintendo Switch) tandem example used in §5, here is every
-edit on one screen:
+For the `nszip` (Nintendo Switch) tandem example used in §5, here is every edit
+on one screen:
 
 ```
-Dockerfile                      builder: clone+g++ nszip; runtime: COPY binary, libs
-.dockerignore                   (verify nothing new is excluded)
-requirements.txt                (only if service imports a new pip pkg)
-.local-bin/nszip                local-dev binary for run_dev.sh
-entrypoint.sh                   (optional) CLI-mode loop for .nsp/.xci
-app/config.py                   nszip_path Field (NSZIP_PATH)
-app/services/nszip.py           NszipService + NSZIP_CONVERTIBLE_EXTENSIONS + singleton
-app/models.py                   ConversionMode.NSZIP_COMPRESS; NszipInfo; FileEntry flags
-app/services/job_manager.py     import; _queue_job_locked + _process_job + verify branches
-app/routes/convert.py           _get_output_path; validation (single+batch); del-on-verify
-app/routes/files.py             import set; flags in scan_directory + search_files
-app/routes/info.py              /nszip-info, /nszip-verify(+events+batch); VERIFY exts; lane
-src/lib/api/endpoints.js        getNszipInfo, verifyNszip, verifyBatchNszip
-src/lib/tools/registry.js       one new entry in TOOLS (id, label, hint, verifyPrefix,
-                                sourceExts, verifyExts, modeGroups, groups, defaultMode,
-                                glyph, accent, modes[], getInfo/verify/verifyBatch/productPath)
-static/css/style.css            (only if new badge classes)
-tests/test_nszip_routes.py      info+verify endpoint tests
-tests/test_nszip_service.py     convert/verify/cancel/bad-ext tests
-tests/test_mode_parity_fixes.py add nszip_compress to parity matrix
-tests/conftest.py               binary stub fixture
-docker-compose*.yml             (optional) NSZIP_PATH / CLI env docs
-.version + scripts/sync-version.sh   version bump
-README.md / RELEASE_NOTES.md    supported-formats table + changelog
+Dockerfile                          builder: clone+g++ nszip; runtime: COPY binary, libs
+.dockerignore                       (verify nothing new is excluded)
+requirements.txt                    (only if service imports a new pip pkg)
+.local-bin/nszip                    local-dev binary for run_dev.sh
+entrypoint.sh                       (optional) CLI-mode loop for .nsp/.xci
+app/config.py                       nszip_path Field (NSZIP_PATH)
+app/services/nszip.py               NszipService + NSZIP_CONVERTIBLE_EXTENSIONS + singleton
+app/services/tools/nszip.py         NszipTool plugin (BaseTool + ModeSpec rows)
+app/services/tools/__init__.py      registry.register(NszipTool(settings.nszip_path))
+app/models.py                       ConversionMode.NSZIP_COMPRESS; NszipInfo; FileEntry flags
+app/routes/convert.py               extension-validation block in plan_job (if needed)
+app/routes/files.py                 flags in the directory scan + search_files
+app/routes/info.py                  register_verify_routes(registry.get("nszip")); /nszip-info
+app/services/job_manager.py         usually nothing (registry dispatches)
+src/lib/api/endpoints.js            getNszipInfo, verifyNszip, verifyBatchNszip
+src/lib/tools/registry.js           one new entry in TOOLS
+src/styles/tokens.css               (only if new badge classes)
+tests/test_nszip_routes.py          info+verify endpoint tests
+tests/test_nszip_service.py         convert/verify/cancel/bad-ext tests
+tests/test_tool_registry.py         mode resolves to nszip with the right flags
+tests/test_mode_parity_fixes.py     add nszip_compress to the parity matrix
+tests/conftest.py                   binary stub fixture
+docker-compose*.yml                 (optional) NSZIP_PATH / CLI env docs
+package.json                        version bump (release)
+README.md / RELEASE_NOTES.md        supported-formats table + changelog
 DEPLOYMENT.md / DOCKER-COMPOSE.md    new env var, if any
 ```
 
@@ -1011,32 +1043,39 @@ DEPLOYMENT.md / DOCKER-COMPOSE.md    new env var, if any
 
 ## 15. Gotchas & conventions
 
-- **Mode prefixes are load-bearing.** Code branches on
+- **The registry dispatches; don't add ladders.** Convert and verify run through
+  `registry.for_mode(mode)`; output paths through the plugin's `output_path()`;
+  validation through `registry.spec(mode)` flags. The old `_convert_service`
+  if/elif ladders are gone. Add behavior by setting `ModeSpec` flags, not by
+  branching on the mode string.
+- **A few prefixes are still load-bearing.** Some code still branches on
   `mode.startswith("create"|"extract"|"dolphin_")` and on equality with
-  `z3ds_compress`. Choose a clear, unique prefix and grep for every
-  prefix check when you add a mode that doesn't fit an existing family.
-- **Single-job and batch endpoints must validate identically.**
-  `create_job` and `create_batch_jobs` in `convert.py` duplicate their
-  validation; `tests/test_mode_parity_fixes.py` exists to catch drift. Edit
-  both.
+  `z3ds_compress` for special-casing (disc-id tagging, `.bin` sidecars,
+  compression nuances). Choose a clear, unique prefix and grep for prefix checks
+  when you add a mode that doesn't fit an existing family.
+- **Single-job and batch endpoints must validate identically.** `create_job` and
+  `create_batch_jobs` in `convert.py` share `plan_job`, and
+  `tests/test_mode_parity_fixes.py` exists to catch drift. Keep them in lockstep.
 - **The verify lane is global.** All verification across all tools shares
-  `MAX_VERIFY_CONCURRENCY` via `workload_limiter` (`info.py:55`). Always
-  acquire/release the token in verify endpoints, or you'll bypass
-  backpressure.
-- **Reuse `ConversionCancelled`** from `services.chdman`, the pipeline's
-  cancel handling (`job_manager.py:1782`) catches that specific class.
+  `MAX_VERIFY_CONCURRENCY` via `workload_limiter`. The verify-route factory
+  acquires the token for you (`_acquire_verify_lane_or_429`); don't bypass it.
+- **Reuse `ConversionCancelled`.** It lives in
+  `app/services/subprocess_runner.py` (re-exported via `services.chdman` and
+  `services.tools.runner`). The pipeline's cancel handling in
+  `job_manager._process_job` catches that specific class.
 - **`MAX_CONCURRENT_JOBS` defaults to 1.** Conversions are I/O-heavy; the
-  dispatcher runs them serially unless host capacity is validated
-  (`AGENTS.md` note). Don't assume parallelism in a service.
-- **The frontend has a build step.** The Svelte 5 + Vite source lives in
-  `src/`; `npm run build` emits the bundle into `static/`. Run `npm run lint`
-  (ESLint flat config in `eslint.config.js`) and keep the style consistent.
-- **The image runs as uid 999 (`converter`).** Binaries must be executable by
-  a non-root user; install them to a world-readable path like
-  `/usr/local/bin` as the existing tools do.
-- **chdman is the only archive-aware tool.** If your tool can't decompress its
-  inputs straight out of `.zip/.7z/.rar`, block `::` archive paths in
-  `convert.py` (as z3ds and dolphin do).
-- **Binary path is config, not hardcoded.** Always read
-  `settings.<tool>_path` in `__init__` so deployments can relocate/override
-  via env.
+  dispatcher runs them serially unless host capacity is validated. Don't assume
+  parallelism in a service.
+- **The frontend has a build step.** The Svelte 5 + Vite source lives in `src/`;
+  `npm run build` emits the bundle into `static/`. Run `npm run lint` (ESLint
+  flat config in `eslint.config.js`) and keep the style consistent.
+- **The image runs as uid 999 (`converter`).** Binaries must be executable by a
+  non-root user; install them to a world-readable path like `/usr/local/bin`.
+- **chdman is the only archive-aware tool today.** If your tool can't decompress
+  its inputs straight out of `.zip/.7z/.rar`, leave `allows_archive_input=False`
+  on its `ModeSpec` (the default) and the single guard in `plan_job` blocks
+  archive (`::`) members automatically.
+- **Binary path is config, not hardcoded.** Always read `settings.<tool>_path`
+  (passed into the plugin, stored on the service in `__init__`) so deployments
+  can relocate/override via env.
+

--- a/ADDING_PLATFORMS_AND_TOOLS.md
+++ b/ADDING_PLATFORMS_AND_TOOLS.md
@@ -3,9 +3,9 @@
 This is a developer guide for extending Compressatorium with **new conversion
 tools** (e.g. a brand-new compressor binary) and **new platforms / formats**
 (e.g. a new chdman create mode, or a new file type a tool can handle). It
-walks the full vertical slice — from the binary in the Docker image, through
+walks the full vertical slice, from the binary in the Docker image, through
 the Python service and job pipeline, the FastAPI routes, and finally the
-Preact web UI — and shows how to add a tool and a platform *in tandem*.
+Preact web UI, and shows how to add a tool and a platform *in tandem*.
 
 It is written against the codebase as it stands today, with three tools
 already wired up:
@@ -29,7 +29,7 @@ touching the same layers in the same order:
 
 ```
             ┌─────────────────── Web UI (Svelte 5 + Vite, under src/) ───────────────┐
-            │  src/lib/tools/registry.js: one TOOLS entry per tool — drives all UI   │
+            │  src/lib/tools/registry.js: one TOOLS entry per tool, drives all UI   │
             │  src/lib/api/endpoints.js:  HTTP / SSE / batch-verify client methods   │
             └───────────────────────────────────┬───────────────────────────────────┘
                                                  │  POST /api/jobs   (mode=...)
@@ -58,9 +58,9 @@ touching the same layers in the same order:
 
 Two supporting layers:
 
-- **`app/models.py`** — `ConversionMode` enum (every mode string lives here)
+- **`app/models.py`**, `ConversionMode` enum (every mode string lives here)
   and the Pydantic info models (`CHDInfo`, `DolphinDiscInfo`, `Z3DSInfo`).
-- **`app/config.py`** — `Settings` holds the binary path for each tool
+- **`app/config.py`**, `Settings` holds the binary path for each tool
   (`chdman_path`, `dolphin_tool_path`, `z3ds_compressor_path`).
 
 ### The tool-service contract
@@ -85,13 +85,13 @@ Each service module also exposes, at module scope:
 - a **module-level singleton instance** (e.g. `z3ds_compress_service = Z3DSCompressService()`).
 
 `ConversionCancelled` is defined once in `app/services/chdman.py:22` and
-imported by the other services — reuse it, don't define your own.
+imported by the other services, reuse it, don't define your own.
 
 ---
 
 ## 2. Two kinds of extension
 
-### Scenario A — a new platform on an *existing* tool
+### Scenario A: a new platform on an *existing* tool
 
 This is the lightweight case: the binary already ships and the service class
 already exists; you just need a new mode string or a new input extension.
@@ -106,14 +106,14 @@ Examples:
 
 Go to **§4**.
 
-### Scenario B — a brand-new tool (and usually a new platform with it)
+### Scenario B: a brand-new tool (and usually a new platform with it)
 
 A new binary, a new service module, a new `ConversionMode`, new info/verify
 endpoints, and new UI wiring. This is the z3ds-shaped case.
 
 Go to **§5**.
 
-### Scenario C — a tool and a platform in tandem
+### Scenario C: a tool and a platform in tandem
 
 This is the common real-world request: "support platform X, which needs new
 binary Y." It is just **Scenario B**, because adding the tool *is* what makes
@@ -151,7 +151,7 @@ detail for the non-obvious rows is in §8–§14.
 | # | File | What you do | When |
 |---|------|-------------|------|
 | 7 | `app/config.py` | Add a `<tool>_path` `Field` with an env alias (`<TOOL>_PATH`). | New tool |
-| 8 | `app/services/<tool>.py` | New service module — `convert`/`verify`/`verify_stream`/`info`/`is_convertible`/`get_output_path_for_mode`/`active_pids`, the `*_CONVERTIBLE_EXTENSIONS` set, `*_OUTPUT_FORMATS`, and the module singleton. | New tool |
+| 8 | `app/services/<tool>.py` | New service module, `convert`/`verify`/`verify_stream`/`info`/`is_convertible`/`get_output_path_for_mode`/`active_pids`, the `*_CONVERTIBLE_EXTENSIONS` set, `*_OUTPUT_FORMATS`, and the module singleton. | New tool |
 | 9 | `app/models.py` | Add `ConversionMode` value(s); add a `<Tool>Info` model; add `FileEntry` flags (`<tool>_convertible`, `has_<tool>`, `<tool>_ready`, `<tool>_path`). | New mode and/or tool |
 | 10 | `app/services/job_manager.py` | Import the service; add output-path branch in `_queue_job_locked`; add `_convert_service` branch in `_process_job`; add verify branch if delete-on-verify is supported. | New tool |
 | 11 | `app/routes/convert.py` | `_get_output_path` branch; extension validation in `create_job` **and** `create_batch_jobs`; `supports_delete_on_verify`; archive-input guard. | New mode and/or tool |
@@ -162,12 +162,12 @@ detail for the non-obvious rows is in §8–§14.
 | 16 | `app/services/dat_*.py` / `app/routes/dat.py` | Touch only if the platform participates in DAT (MAMERedump) hash-matching. | Rare |
 | 17 | `migrations/versions/*.py` | New Alembic migration **only** if you add DB-persisted columns/tables (use `scripts/new_migration.sh`). The verification/metadata stores are keyed by path and need no migration for a new tool. | If schema changes |
 
-### 3.3 Frontend (Svelte 5 + Vite — one new entry in the registry)
+### 3.3 Frontend (Svelte 5 + Vite: one new entry in the registry)
 
 | # | File | What you do | When |
 |---|------|-------------|------|
 | 18 | `src/lib/api/endpoints.js` | `get<Tool>Info`, `verify<Tool>`, `verifyBatch<Tool>` client methods alongside the existing ones. | New tool |
-| 19 | `src/lib/tools/registry.js` | **One new entry** in the `TOOLS` array (id, label, hint, verifyPrefix, sourceExts, verifyExts, modeGroups, groups, defaultMode, glyph, accent, modes, getInfo/verify/verifyBatch/productPath). Everything else — sidebar, workspace, badges, modals, verify dispatch, SSE URL building — looks up this registry. | New mode and/or tool |
+| 19 | `src/lib/tools/registry.js` | **One new entry** in the `TOOLS` array (id, label, hint, verifyPrefix, sourceExts, verifyExts, modeGroups, groups, defaultMode, glyph, accent, modes, getInfo/verify/verifyBatch/productPath). Everything else, sidebar, workspace, badges, modals, verify dispatch, SSE URL building, looks up this registry. | New mode and/or tool |
 | 20 | `src/styles/tokens.css` | Add a semantic token only if you need a new tool accent / badge color. Most tools reuse existing tokens via `accent: 'var(--badge-<token>)'`. | If new visual identity |
 
 ### 3.4 Tests
@@ -190,7 +190,7 @@ detail for the non-obvious rows is in §8–§14.
 | 30 | `.github/dependabot.yml` | Dependency bumps. | Only if adding a new ecosystem |
 | 31 | `pyproject.toml` | pylint + ruff config (Codacy reads this). | Respect line-length 100, py310 |
 | 32 | `.pylintrc`, `.prospector.yaml`, `.bandit` | Python lint/security (bandit flags `shell=True`, predictable tmp). | Follow the no-shell rule (§15) |
-| 33 | `eslint.config.js`, `.eslintrc.json`, `.jshintrc` | JS lint for `static/js`. | New JS must pass |
+| 33 | `eslint.config.js`, `.eslintrc.json`, `.jshintrc` | ESLint for the frontend (`src/`). | New JS and Svelte must pass |
 | 34 | `.stylelintrc.json`, `.csslintrc` | CSS lint. | If you edit CSS |
 | 35 | `.markdownlint.json` | Markdown lint. | If you add docs |
 | 36 | `.codacy.yml`, `.codacy/` | Codacy tool config/excludes. | Rarely |
@@ -206,18 +206,18 @@ detail for the non-obvious rows is in §8–§14.
 | 41 | `RELEASE_NOTES.md` | Changelog entry. | Every change |
 | 42 | `DEPLOYMENT.md`, `DOCKER-COMPOSE.md` | New env vars / volumes / tool requirements. | If deploy surface changes |
 | 43 | `walkthrough.md`, `CHANGES_SUMMARY.md` | Narrative docs, if you maintain them. | Optional |
-| 44 | `AGENTS.md` | Runbook — add a test/run note if workflow changes. | Optional |
-| 45 | `.github/copilot-instructions.md` | Repo AI guidance — update if conventions change. | Optional |
+| 44 | `AGENTS.md` | Runbook, add a test/run note if workflow changes. | Optional |
+| 45 | `.github/copilot-instructions.md` | Repo AI guidance, update if conventions change. | Optional |
 
 ---
 
-## 4. Scenario A — add a platform/mode to an existing tool
+## 4. Scenario A: add a platform/mode to an existing tool
 
 Worked example: add a hypothetical **`createcd_audio`** chdman mode (pretend
 it produces `.chd` with a platform-specific flag). The same pattern applies
 to any new chdman/dolphin sub-format.
 
-### 4.1 Add the mode to the enum — `app/models.py`
+### 4.1 Add the mode to the enum: `app/models.py`
 
 ```python
 class ConversionMode(str, Enum):
@@ -232,7 +232,7 @@ The string value is what travels over the API and what `job_manager` /
 prefix convention (`create*`, `extract*`, `dolphin_*`, `z3ds_compress`),
 because a lot of logic keys off these prefixes (see below).
 
-### 4.2 Teach the service the new mode — `app/services/chdman.py`
+### 4.2 Teach the service the new mode: `app/services/chdman.py`
 
 - If it needs special binary flags, branch in `_build_command`
   (`chdman.py:34`), mirroring the existing `createdvd` `-hs 2048` special case
@@ -243,28 +243,28 @@ because a lot of logic keys off these prefixes (see below).
 - If it accepts a new input extension, add it to
   `CHDMAN_CONVERTIBLE_EXTENSIONS` (`chdman.py:16`).
 
-### 4.3 Wire validation — `app/routes/convert.py`
+### 4.3 Wire validation: `app/routes/convert.py`
 
 `convert.py` keys off mode **prefixes** in several places. Because
 `create_job` / `create_batch_jobs` treat anything starting with `create`
 generically (e.g. the `.chd` input rejection at `convert.py:407`, output
 path via `_get_output_path` at `convert.py:100`), a new `create*` mode often
-needs **no new validation code** — it inherits the create-mode rules. Verify
+needs **no new validation code**, it inherits the create-mode rules. Verify
 the prefix-based helpers cover you:
 
-- `supports_delete_on_verify` (`convert.py:87`) — `create*` already returns True.
-- `_get_output_path` (`convert.py:100`) — routes to `chdman_service` by
+- `supports_delete_on_verify` (`convert.py:87`), `create*` already returns True.
+- `_get_output_path` (`convert.py:100`), routes to `chdman_service` by
   default, so a chdman mode is covered.
 
 If your mode breaks a prefix assumption, add an explicit branch.
 
-### 4.4 Surface it in the UI — `src/lib/tools/registry.js`
+### 4.4 Surface it in the UI: `src/lib/tools/registry.js`
 
 Append one `ModeEntry` to the chdman descriptor's `modes` array (the
 group's human label is already declared via `groups.create: 'Create'`):
 
 ```js
-// src/lib/tools/registry.js — inside the chdman TOOLS entry
+// src/lib/tools/registry.js, inside the chdman TOOLS entry
 modes: [
   // …existing entries…
   { mode: 'createcd_audio', kind: 'create', label: 'Create CD CHD (Audio)',
@@ -287,22 +287,22 @@ single + batch create) and `tests/test_chdman_annotations.py` if relevant.
 
 ---
 
-## 5. Scenario B/C — add a brand-new tool (with its platform)
+## 5. Scenario B/C: add a brand-new tool (with its platform)
 
 Worked example throughout: a fictional **`nszip`** tool that compresses
 Nintendo Switch `.nsp`/`.xci` dumps into `.nsz`/`.xcz`. Replace names as
 needed. This mirrors z3ds exactly.
 
-### 5.1 Install the binary — `Dockerfile`
+### 5.1 Install the binary: `Dockerfile`
 
 Three patterns exist in the current `Dockerfile`; pick the one that fits:
 
 - **Distro package** (chdman via `mame-tools`, pinned to a
-  `snapshot.debian.org` `.deb` with a SHA256 check — see `Dockerfile:38`).
-- **Distro package, best-effort** (dolphin-emu, amd64-only, non-fatal —
+  `snapshot.debian.org` `.deb` with a SHA256 check, see `Dockerfile:38`).
+- **Distro package, best-effort** (dolphin-emu, amd64-only, non-fatal,
   `Dockerfile:67`). A wrapper script is created at
   `/usr/local/bin/dolphin-tool` only if the binary exists (`Dockerfile:92`).
-- **Build from source in a builder stage** (z3ds — `Dockerfile:1-23`), then
+- **Build from source in a builder stage** (z3ds, `Dockerfile:1-23`), then
   copy the artifact into the runtime image (`Dockerfile:105`).
 
 For `nszip` built from source, add to the builder stage:
@@ -326,7 +326,7 @@ COPY --from=builder /tmp/nszip/nszip /usr/local/bin/nszip
 
 If the tool needs a runtime shared lib, add it to the runtime `apt-get
 install` list (`Dockerfile:53`). Note that `zstd` (the CLI) is already
-installed — z3ds's `verify_stream` shells out to `zstd -t`, so if your tool's
+installed, z3ds's `verify_stream` shells out to `zstd -t`, so if your tool's
 output is a zstd container you can reuse that.
 
 > Multi-arch: the image builds `linux/amd64` and `linux/arm64`
@@ -334,7 +334,7 @@ output is a zstd container you can reuse that.
 > arch automatically; a downloaded `.deb` needs a per-arch URL/SHA like the
 > `mame-tools` block (`Dockerfile:40`).
 
-### 5.2 Add the binary path setting — `app/config.py`
+### 5.2 Add the binary path setting: `app/config.py`
 
 Add next to the other tool paths (`config.py:111-121`):
 
@@ -347,7 +347,7 @@ nszip_path: str = Field(
 This lets ops override the path/env without code changes, and is what the
 service reads in `__init__`.
 
-### 5.3 Write the service module — `app/services/nszip.py`
+### 5.3 Write the service module: `app/services/nszip.py`
 
 This is the heart of the work. Copy `app/services/z3ds_compress.py` and
 adapt. The required shape (see the contract in §1):
@@ -434,10 +434,10 @@ class NszipService:
         return str(Path(output_dir) / filename) if output_dir else str(input_p.parent / filename)
 
 
-nszip_service = NszipService()   # module-level singleton — imported everywhere
+nszip_service = NszipService()   # module-level singleton, imported everywhere
 ```
 
-**Critical implementation rules** (all enforced by the existing services —
+**Critical implementation rules** (all enforced by the existing services,
 copy them, don't improvise):
 
 - **Never** use `shell=True` / string commands. Build an argv list and use
@@ -453,11 +453,11 @@ copy them, don't improvise):
   estimate from output-file growth like z3ds does (`z3ds_compress.py:251`),
   or emit a heartbeat with elapsed seconds like dolphin (`dolphin_tool.py:241`).
 - Respect `settings.chdman_nice` / `chdman_ioprio_*` (these knobs are shared
-  across all tools — they aren't chdman-specific despite the name).
+  across all tools, they aren't chdman-specific despite the name).
 - Track PIDs (`_track_pid`/`_untrack_pid`) so the debug heartbeat can report
   them.
 
-### 5.4 Add the mode + info model — `app/models.py`
+### 5.4 Add the mode + info model: `app/models.py`
 
 ```python
 class ConversionMode(str, Enum):
@@ -466,7 +466,7 @@ class ConversionMode(str, Enum):
     NSZIP_COMPRESS = "nszip_compress"        # NEW
     ...
 
-class NszipInfo(BaseModel):                  # NEW — shape it like Z3DSInfo (models.py:193)
+class NszipInfo(BaseModel):                  # NEW, shape it like Z3DSInfo (models.py:193)
     file: str
     size: int
     size_display: str
@@ -478,9 +478,9 @@ class NszipInfo(BaseModel):                  # NEW — shape it like Z3DSInfo (m
 
 If your tool extracts/decompresses too, add a second mode
 (e.g. `NSZIP_EXTRACT = "nszip_extract"`). Keep a consistent prefix
-(`nszip_`) — the job pipeline and routes pattern-match on it.
+(`nszip_`), the job pipeline and routes pattern-match on it.
 
-### 5.5 Dispatch in the job pipeline — `app/services/job_manager.py`
+### 5.5 Dispatch in the job pipeline: `app/services/job_manager.py`
 
 Two edits:
 
@@ -499,7 +499,7 @@ if output_path is None:
 ```
 
 (In practice `convert.py` almost always passes an explicit `output_path`, so
-this branch is a fallback — but wire it for correctness.)
+this branch is a fallback, but wire it for correctness.)
 
 **b) Service selection** in `_process_job` (`job_manager.py:1444`). Extend the
 `_convert_service` ladder:
@@ -523,7 +523,7 @@ source" feature for this tool, also extend the verify branch in
 because its verify lives outside the dolphin/chdman pair. Add an analogous
 branch calling `nszip_service.verify(...)`, or generalize the selector.
 
-### 5.6 Validation + output dispatch — `app/routes/convert.py`
+### 5.6 Validation + output dispatch: `app/routes/convert.py`
 
 - **Output path dispatch:** extend `_get_output_path` (`convert.py:100`):
 
@@ -555,7 +555,7 @@ if is_nszip:
             detail="nszip mode requires Switch dumps (.nsp, .xci)")
 ```
 
-- **Archive inputs:** controlled by one flag — set `allows_archive_input=True`
+- **Archive inputs:** controlled by one flag, set `allows_archive_input=True`
   on each `ModeSpec` whose input is a convertible *source* (see chdman create,
   dolphin, and z3ds). A single guard in `plan_job` rejects archive (`::`)
   members for any mode that leaves it `False` (the default), so you don't add
@@ -566,7 +566,7 @@ if is_nszip:
 - Import the convertible set + service at the top of `convert.py`
   (`convert.py:27` shows the z3ds import).
 
-### 5.7 Mark inputs convertible in listings — `app/routes/files.py`
+### 5.7 Mark inputs convertible in listings: `app/routes/files.py`
 
 `files.py` annotates each `FileEntry` with convertibility flags so the UI can
 badge rows and gate selection. Today it imports each tool's extension set
@@ -577,7 +577,7 @@ badge rows and gate selection. Today it imports each tool's extension set
 2. Add a model field. In `app/models.py` `FileEntry` (`models.py:42`) add
    `nszip_convertible: bool = False` and, if you show "output already exists"
    badges, `has_nszip: bool = False`, `nszip_ready: bool = False`,
-   `nszip_path: str | None = None` — paralleling the z3ds fields
+   `nszip_path: str | None = None`, paralleling the z3ds fields
    (`models.py:56`).
 3. In `scan_directory` (`files.py:150`) compute
    `is_nszip_convertible = ext in NSZIP_CONVERTIBLE_EXTENSIONS` and an
@@ -587,7 +587,7 @@ badge rows and gate selection. Today it imports each tool's extension set
 4. Do the same in `search_files` (`files.py:316` adds the extension to the
    "is this file interesting" test, and `:349` records the flags).
 
-### 5.8 Info + verify endpoints — `app/routes/info.py`
+### 5.8 Info + verify endpoints: `app/routes/info.py`
 
 Mirror the z3ds endpoints (`info.py:338-663`, `:1506`). Add:
 
@@ -604,30 +604,30 @@ Mirror the z3ds endpoints (`info.py:338-663`, `:1506`). Add:
 - Define `NSZIP_VERIFY_EXTENSIONS` / `NSZIP_INFO_EXTENSIONS` near the z3ds
   ones (`info.py:341`) and a `_is_nszip_verify_file` helper.
 
-No new router registration is needed — `info.router` is already mounted under
+No new router registration is needed, `info.router` is already mounted under
 `/api` in `app/main.py:285`.
 
-### 5.9 Frontend — `src/lib/api/endpoints.js`
+### 5.9 Frontend: `src/lib/api/endpoints.js`
 
 Add client methods next to the z3ds ones:
 
-- `getNszipInfo(path)` — like `getZ3DSInfo`.
-- `verifyNszip(path, {onProgress})` — single-file SSE, like `verify3DS`.
+- `getNszipInfo(path)`, like `getZ3DSInfo`.
+- `verifyNszip(path, {onProgress})`, single-file SSE, like `verify3DS`.
   Routes through `verifyEventSource` from `sse.js`.
-- `verifyBatchNszip(paths, {onProgress, onFileComplete, signal})` — like
+- `verifyBatchNszip(paths, {onProgress, onFileComplete, signal})`, like
   `verifyBatchZ3DS`. Routes through `runBatchVerify` + `sseFetchPost`
   (POST-body SSE) under the hood.
 
 `createJob` / `createBatchJobs` are generic over `mode`, so no change there
-— the registry's submit path just passes `mode: 'nszip_compress'`. The
+, the registry's submit path just passes `mode: 'nszip_compress'`. The
 verify URL is **derived automatically** from `verifyPrefix: 'nszip'` in
 the registry descriptor; no edits to any URL map.
 
-### 5.10 Frontend — `src/lib/tools/registry.js`
+### 5.10 Frontend: `src/lib/tools/registry.js`
 
 The frontend is a **Svelte 5 + Vite SPA** under `src/` and is driven by a
 single declarative tool registry (`src/lib/tools/registry.js`). The registry
-is the only place that knows tool identity — there are no `if (tool === ...)`
+is the only place that knows tool identity, there are no `if (tool === ...)`
 branches anywhere downstream. Sidebar, workspace, file badges, conversion
 config, info modal, verify dispatch, and SSE URL building all look up the
 registry. Adding `nszip` to the frontend is **one new entry** appended to
@@ -644,7 +644,7 @@ the `TOOLS` array:
   sourceExts: ['.nsp', '.xci'],
   verifyExts: ['.nsz', '.xcz'],
   modeGroups: ['nszip'],
-  // Human labels for any group ids the tool introduces — replaces
+  // Human labels for any group ids the tool introduces, replaces
   // the old hardcoded switch in registry.groupLabel.
   groups: { nszip: 'Nintendo Switch' },
   defaultMode: 'nszip_compress',
@@ -669,20 +669,20 @@ the `TOOLS` array:
 
 That's the entire frontend change. Specifically you do **NOT** need to:
 
-- Edit a `VERIFY_URL` map — `registry.verifyUrl(toolId, kind)` derives both
+- Edit a `VERIFY_URL` map, `registry.verifyUrl(toolId, kind)` derives both
   single and batch URLs from `verifyPrefix` (`''` for chdman, `'<segment>'`
   for everyone else).
-- Edit a `VALID_TOOLS` set — `ui.svelte.js` reads `registry.ids()`.
-- Edit a `groupLabel()` switch — group labels live on `tool.groups`.
-- Edit the Sidebar component — it iterates `registry.all()` and reads
+- Edit a `VALID_TOOLS` set, `ui.svelte.js` reads `registry.ids()`.
+- Edit a `groupLabel()` switch, group labels live on `tool.groups`.
+- Edit the Sidebar component, it iterates `registry.all()` and reads
   `t.glyph` / `t.accent` (with sensible fallbacks).
-- Edit the Workspace, file list, conversion config, or any modal — they all
+- Edit the Workspace, file list, conversion config, or any modal, they all
   call `registry.specFor(mode)`, `registry.forTool(id)`,
   `registry.modesByGroup(id)`, `registry.toolForVerifyPath(path)`, etc.
 
 The four `api.*` calls you reference (`getNszipInfo`, `verifyNszip`,
 `verifyBatchNszip`, and any others) need to exist in `src/lib/api/endpoints.js`
-— add them alongside the existing `getCHDInfo` / `verifyCHD` /
+, add them alongside the existing `getCHDInfo` / `verifyCHD` /
 `verifyBatchCHDs` patterns. Headers (`X-CHD-Action-Confirm`), error
 normalization, and SSE helpers (`sse.js`, `sseFetch.js`) all stay the same.
 
@@ -697,9 +697,9 @@ normalization, and SSE helpers (`sse.js`, `sseFetch.js`) all stay the same.
 
 Add, modeled on the existing suites:
 
-- `tests/test_nszip_routes.py` — info + verify endpoint behavior
+- `tests/test_nszip_routes.py`, info + verify endpoint behavior
   (copy `tests/test_z3ds_routes.py`).
-- `tests/test_nszip_service.py` — `convert`/`verify` happy path, cancel path,
+- `tests/test_nszip_service.py`, `convert`/`verify` happy path, cancel path,
   bad-extension rejection (copy `tests/test_z3ds_verification_service.py`).
 - Extend `tests/test_mode_parity_fixes.py` so single-job and batch-job
   validation stay in lockstep for the new mode.
@@ -719,7 +719,7 @@ installed.
 - Update `README.md` (tool table / supported formats) and `RELEASE_NOTES.md`.
 - Bump the version with `./scripts/sync-version.sh <new-version>` (keeps
   `.version`, `package.json`, `package-lock.json`, `RELEASE_NOTES.md` in
-  sync — see `AGENTS.md` §5).
+  sync, see `AGENTS.md` §5).
 
 ---
 
@@ -763,7 +763,7 @@ FRONTEND
     (id, label, hint, verifyPrefix, sourceExts, verifyExts, modeGroups,
     groups, defaultMode, glyph, accent, modes[], getInfo/verify/
     verifyBatch/productPath). Sidebar, workspace, badges, modals, and
-    verify dispatch all pick it up via registry lookups — no other
+    verify dispatch all pick it up via registry lookups, no other
     .svelte edits.
 
 TESTS + DOCS
@@ -786,7 +786,7 @@ PERIPHERAL (don't forget)
 
 ---
 
-## 8. The Docker image in depth — `Dockerfile`, `.dockerignore`, deps
+## 8. The Docker image in depth: `Dockerfile`, `.dockerignore`, deps
 
 The image is a two-stage multi-arch build (`debian:trixie-slim`).
 
@@ -821,7 +821,7 @@ layers clean (combine `apt-get update && install`, `rm -rf
 
 **`.dockerignore`**: `app/`, `static/`, `migrations/`, `entrypoint.sh`,
 `requirements.txt` are copied in. `tests/` and most `*.md` (except
-`README.md`) are excluded — so this guide and your service tests never enter
+`README.md`) are excluded, so this guide and your service tests never enter
 the image. If you reference a new top-level file from the Dockerfile, confirm
 it isn't ignored.
 
@@ -838,11 +838,11 @@ Drop your compiled binary there and point `<TOOL>_PATH` at it (or add it to
 
 ---
 
-## 9. Headless CLI mode — `entrypoint.sh`
+## 9. Headless CLI mode: `entrypoint.sh`
 
 `entrypoint.sh` supports `CHD_MODE=cli` (batch-convert a volume with no web
 UI; see `docker-compose.cli.yml`). **This path is independent of the Python
-app** — it shells out to `chdman` directly and currently only knows
+app**, it shells out to `chdman` directly and currently only knows
 `createcd`/`createdvd` over `*.gdi *.iso *.cue` (`entrypoint.sh:127-176`),
 validating `CHDMAN_MODE` against that allow-list (`entrypoint.sh:135`).
 
@@ -854,7 +854,7 @@ If your new tool/platform should be usable headlessly:
 - Skip-if-output-exists logic (`[[ -e "${i%.*}.<ext>" ]]`) should match your
   output suffix.
 
-If headless mode is out of scope, you can skip this — the web UI path
+If headless mode is out of scope, you can skip this, the web UI path
 (`exec uvicorn main:app …`, `entrypoint.sh:197`) already dispatches your tool
 via the Python pipeline.
 
@@ -869,7 +869,7 @@ The same file also handles **PUID/PGID remap** and the privilege drop to
 |----------|---------|-------------------------|
 | `docker-image.yml` | **release published** | Builds/pushes multi-arch image to Docker Hub + GHCR, runs **hadolint** (Dockerfile must pass), **Trivy** CRITICAL/HIGH scan (a vulnerable new dep can fail this), generates SBOM + provenance attestation, and **publishes `README.md` as the Docker Hub description**. Also auto-syncs `package.json` from the release tag. |
 | `codacy.yml` | push, PR, weekly | Runs the Codacy CLI (ruff, eslint, pylint, bandit, etc.). New Python/JS must lint clean. Honors `pyproject.toml`, `.pylintrc`, `eslint.config.js`, `.codacy.yml`. |
-| `codeql.yml` | push, weekly | CodeQL SAST for **python** and **javascript-typescript** (`codeql.yml:30-32`). New code is scanned automatically — no config change, but don't introduce flagged patterns (e.g. command injection — another reason for the no-`shell=True` rule). |
+| `codeql.yml` | push, weekly | CodeQL SAST for **python** and **javascript-typescript** (`codeql.yml:30-32`). New code is scanned automatically, no config change, but don't introduce flagged patterns (e.g. command injection, another reason for the no-`shell=True` rule). |
 | `label.yml` + `labeler.yml` | PR | Path-based auto-labels. Add a glob if you want your area labeled. |
 | `stale.yml` | schedule | Marks stale issues/PRs. Irrelevant. |
 | `dependabot.yml` | schedule | Dependency PRs. Add an ecosystem entry only if you introduce a new manifest. |
@@ -880,7 +880,7 @@ Key takeaways for a contributor:
   builds `linux/amd64,linux/arm64` and tags `latest`/`beta` accordingly.
 - **Trivy can block a release** if a new system/python package pulls a
   CRITICAL/HIGH CVE (`ignore-unfixed: true` softens this). Prefer pinned,
-  patched packages — the `mame-tools` snapshot pin is the model.
+  patched packages, the `mame-tools` snapshot pin is the model.
 - **Dockerfile changes must pass hadolint** locally before you push
   (`hadolint Dockerfile`).
 
@@ -891,11 +891,11 @@ Key takeaways for a contributor:
 Run these before pushing (they mirror Codacy):
 
 ```bash
-cd /home/user/compressatorium
-ruff check app tests            # style/lint — config in pyproject.toml ([tool.ruff], py310)
+# from the repo root
+ruff check app tests            # style/lint, config in pyproject.toml ([tool.ruff], py310)
 pylint app                      # config in .pylintrc / pyproject.toml ([tool.pylint])
 pytest -q tests                 # full suite (binaries are stubbed in conftest)
-npx eslint static/js            # JS lint — eslint.config.js
+npm run lint                    # ESLint over JS + .svelte, eslint.config.js
 hadolint Dockerfile             # if you touched the Dockerfile
 ```
 
@@ -962,7 +962,7 @@ but matter when your *platform* is a disc image processed by chdman.
   `registry.archive_input_extensions()` (the union of `input_extensions` for
   every mode with `allows_archive_input=True`), with the module-level
   `CONVERTIBLE_EXTENSIONS` kept only as a fallback. So once your mode opts in
-  via `allows_archive_input=True`, its members are surfaced automatically —
+  via `allows_archive_input=True`, its members are surfaced automatically,
   there's nothing to edit here. You still own extraction + related-file
   handling in `job_manager._process_job` for multi-file formats (single-file
   inputs like `.3ds`/`.rvz` need nothing extra). Output paths for archive
@@ -1023,13 +1023,14 @@ DEPLOYMENT.md / DOCKER-COMPOSE.md    new env var, if any
   `MAX_VERIFY_CONCURRENCY` via `workload_limiter` (`info.py:55`). Always
   acquire/release the token in verify endpoints, or you'll bypass
   backpressure.
-- **Reuse `ConversionCancelled`** from `services.chdman` — the pipeline's
+- **Reuse `ConversionCancelled`** from `services.chdman`, the pipeline's
   cancel handling (`job_manager.py:1782`) catches that specific class.
 - **`MAX_CONCURRENT_JOBS` defaults to 1.** Conversions are I/O-heavy; the
   dispatcher runs them serially unless host capacity is validated
   (`AGENTS.md` note). Don't assume parallelism in a service.
-- **No frontend build step.** `static/js/*.js` are served as-is. ESLint
-  config exists (`eslint.config.js`) — keep the style consistent.
+- **The frontend has a build step.** The Svelte 5 + Vite source lives in
+  `src/`; `npm run build` emits the bundle into `static/`. Run `npm run lint`
+  (ESLint flat config in `eslint.config.js`) and keep the style consistent.
 - **The image runs as uid 999 (`converter`).** Binaries must be executable by
   a non-root user; install them to a world-readable path like
   `/usr/local/bin` as the existing tools do.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,117 +1,93 @@
-# Agent Runbook
+# Agent runbook
 
-This file is a quick execution guide for agents working in this repository.
-Use it as an operational checklist, not as product documentation.
+A quick execution guide for agents working in this repo. Treat it as an operational checklist, not product docs. Run the commands from the repo root.
 
-## Canonical References
+## Canonical references
 
-- `/Users/talor/github/projects/compressatorium/README.md`
-- `/Users/talor/github/projects/compressatorium/RELEASE_NOTES.md`
-- `/Users/talor/github/projects/compressatorium/DOCKER-COMPOSE.md`
-- `/Users/talor/github/projects/compressatorium/DEPLOYMENT.md`
-- `/Users/talor/github/projects/compressatorium/.github/workflows/docker-image.yml`
+- `README.md`
+- `RELEASE_NOTES.md`
+- `DOCKER-COMPOSE.md`
+- `DEPLOYMENT.md`
+- `.github/workflows/docker-image.yml`
 
-## Current Workflows
+## Current workflows
 
-### 1. Local Dev (Web UI)
+### 1. Local dev (Web UI)
 
-The frontend is a Svelte 5 + Vite single-page application (SPA) under `src/` (see README §"Frontend Development"). The backend is FastAPI under `app/`. Build output lands in `static/` and is served by FastAPI via the existing `/static` mount.
+The frontend is a Svelte 5 + Vite single-page app under `src/` (see README, "Frontend Development"). The backend is FastAPI under `app/`. The build lands in `static/` and FastAPI serves it through the `/static` mount.
 
-**Adopted runtime libraries** (don't reinvent these):
+**Runtime libraries already in use (don't reinvent these):**
 
-- Icons: `@lucide/svelte` — `import Sun from '@lucide/svelte/icons/sun'`, use as `<Sun size={16} />`.
-- Toasts: `svelte-sonner` — `import { toast } from 'svelte-sonner'`, then `toast.success(msg)` / `toast.error(msg)` / `toast.promise(p, {...})` from any store or component.
-- Theme (light/dark/system): `mode-watcher` — `import { setMode, userPrefersMode, mode } from 'mode-watcher'`. Do NOT roll your own theme state in `ui.svelte.js`.
-- Headless accessibility primitives: `bits-ui` — pull Dialog, DropdownMenu, ContextMenu, Tooltip from `bits-ui` rather than building modal/menu/tooltip components from scratch. Per-row file actions use `bits-ui` DropdownMenu in `src/lib/components/panels/RowActionsMenu.svelte`; reuse it as the pattern for any future menu work (style with `:global(...)` selectors keyed off `[data-highlighted]` / `[data-disabled]`).
+- Icons: `@lucide/svelte`. `import Sun from '@lucide/svelte/icons/sun'`, use as `<Sun size={16} />`.
+- Toasts: `svelte-sonner`. `import { toast } from 'svelte-sonner'`, then `toast.success(msg)` / `toast.error(msg)` / `toast.promise(p, {...})` from any store or component.
+- Theme (light/dark/system): `mode-watcher`. `import { setMode, userPrefersMode, mode } from 'mode-watcher'`. Don't roll your own theme state in `ui.svelte.js`.
+- Headless accessibility primitives: `bits-ui`. Pull Dialog, DropdownMenu, ContextMenu, and Tooltip from `bits-ui` instead of building modal/menu/tooltip components from scratch. Per-row file actions use a `bits-ui` DropdownMenu in `src/lib/components/panels/RowActionsMenu.svelte`. Reuse it as the pattern for new menus (style with `:global(...)` selectors keyed off `[data-highlighted]` / `[data-disabled]`).
 
 **Where conversion config lives:**
 
-- Mode dropdown: `panels/ModeSelect.svelte`. Options come from `registry.modesByGroup(toolId)` — adding a new mode means editing `registry.js`, nothing else.
-- Compression UI: `panels/CompressionPicker.svelte`. Style is picked off `tool.compressionStyle` (`'multi'` / `'single-with-level'` / `'none'`); codecs from `tool.compressionCodecs`; level range from `tool.compressionLevelRange`.
-- Output dir + delete-on-verify + submit: `panels/ConvertPanel.svelte` (delete-on-verify blocks submit when any selected source is unverified — same backend invariant that `tools/spec.py` enforces).
+- Mode dropdown: `panels/ModeSelect.svelte`. Options come from `registry.modesByGroup(toolId)`, so adding a mode means editing `registry.js` and nothing else.
+- Compression UI: `panels/CompressionPicker.svelte`. The style comes from `tool.compressionStyle` (`'multi'` / `'single-with-level'` / `'none'`), codecs from `tool.compressionCodecs`, and the level range from `tool.compressionLevelRange`.
+- Output dir, delete-on-verify, submit: `panels/ConvertPanel.svelte`. Delete-on-verify blocks submit when any selected source is unverified, the same invariant the backend enforces.
 
-- Production-style run (FastAPI serves the prebuilt SPA):
+Production-style run (FastAPI serves the prebuilt SPA):
 
 ```bash
-cd /Users/talor/github/projects/compressatorium
-npm install && npm run build      # one-time / when src/ changes
+npm install && npm run build      # one-time, or when src/ changes
 ./run_dev.sh                       # loads .env.local, bootstraps .venv, starts uvicorn
 ```
 
-- Hot-reload dev loop (two terminals):
+Hot-reload dev loop (two terminals):
 
 ```bash
-# Terminal 1 — backend
+# Terminal 1: backend
 ./run_dev.sh                       # uvicorn on :8080
 
-# Terminal 2 — Vite dev server with HMR (hot module replacement)
+# Terminal 2: Vite dev server with HMR
 npm run dev                        # http://localhost:5173 (proxies /api and /health to :8080)
 ```
 
-- App URL: `http://localhost:8080` (prod-style) or `http://localhost:5173` (Vite HMR).
-- Important behavior: if `COMPRESSATORIUM_VOLUMES` is unset, volumes are auto-discovered under `COMPRESSATORIUM_MOUNT_ROOT/*`.
-- The legacy `static/js/app.js` + `static/vendor/standalone.mjs` (Preact + htm) frontend is being decommissioned; do not extend it. All new UI work goes in `src/`.
+App URL: `http://localhost:8080` (prod-style) or `http://localhost:5173` (Vite HMR). If `COMPRESSATORIUM_VOLUMES` is unset, volumes are auto-discovered under `COMPRESSATORIUM_MOUNT_ROOT/*`. All UI work goes in `src/`.
 
-### 2. Test Workflow
-
-- Run full tests:
+### 2. Tests
 
 ```bash
-cd /Users/talor/github/projects/compressatorium
 pytest -q tests
 ```
 
-- Run targeted regression suites:
+Targeted suites:
 
 ```bash
-cd /Users/talor/github/projects/compressatorium
 pytest -q tests/test_mode_parity_fixes.py
 pytest -q tests/test_volume_discovery.py
 ```
 
-### 3. Docker Runtime Workflows
-
-- Single-volume Web UI:
+### 3. Docker runtime
 
 ```bash
-cd /Users/talor/github/projects/compressatorium
-docker-compose up -d
+docker-compose up -d                                        # single-volume Web UI
+docker-compose -f docker-compose.multi-volume.yml up -d     # multi-volume Web UI
+docker-compose -f docker-compose.cli.yml up                 # CLI batch mode
 ```
 
-- Multi-volume Web UI:
+Common operations:
 
 ```bash
-cd /Users/talor/github/projects/compressatorium
-docker-compose -f docker-compose.multi-volume.yml up -d
-```
-
-- CLI batch mode:
-
-```bash
-cd /Users/talor/github/projects/compressatorium
-docker-compose -f docker-compose.cli.yml up
-```
-
-- Common operations:
-
-```bash
-cd /Users/talor/github/projects/compressatorium
 docker-compose ps
 docker-compose logs -f
 docker-compose restart
 docker-compose down
 ```
 
-### 4. Queue/Admin API Workflow
+### 4. Queue / admin API
 
-- Health + version checks:
+Health and version:
 
 ```bash
 curl -s http://localhost:8080/health
 curl -s http://localhost:8080/api/version
 ```
 
-- Cancel all queued/active jobs (requires confirmation header):
+Cancel all queued and active jobs (needs the confirmation header):
 
 ```bash
 curl -s -X POST \
@@ -119,7 +95,7 @@ curl -s -X POST \
   http://localhost:8080/api/jobs/cancel-all
 ```
 
-- Clear completed/failed/cancelled jobs (requires confirmation header):
+Clear completed, failed, and cancelled jobs (needs the confirmation header):
 
 ```bash
 curl -s -X DELETE \
@@ -127,50 +103,34 @@ curl -s -X DELETE \
   http://localhost:8080/api/jobs/completed
 ```
 
-- Start metadata scan + poll status:
+Start a metadata scan and poll status:
 
 ```bash
 curl -s -X POST http://localhost:8080/api/chd-metadata/scan
 curl -s http://localhost:8080/api/chd-metadata/scan/status
 ```
 
-### 5. Version + Release Workflow
+### 5. Version and release
 
-- `.version` is the source of truth for app + image tagging.
-- Sync version across files:
+The version lives in `package.json` (`version`). There is no `.version` file. A release means bumping `package.json`, updating `RELEASE_NOTES.md` (Keep a Changelog format), and publishing a GitHub Release tagged `vX.Y.Z`. Publishing the release is what triggers the image build.
 
-```bash
-cd /Users/talor/github/projects/compressatorium
-./scripts/sync-version.sh 3.0.2
-```
+Schema changes use `scripts/new_migration.sh` (see README, "Schema changes"). That's the only script in `scripts/`.
 
-- After syncing, review:
-  - `/Users/talor/github/projects/compressatorium/.version`
-  - `/Users/talor/github/projects/compressatorium/package.json`
-  - `/Users/talor/github/projects/compressatorium/package-lock.json`
-  - `/Users/talor/github/projects/compressatorium/RELEASE_NOTES.md`
+### 6. CI (`docker-image.yml`)
 
-### 6. GitHub Actions Workflow (`docker-image.yml`)
+- Name: `Build and Push Docker Image`.
+- Trigger: a published GitHub Release only. There is no push trigger, PR trigger, or manual dispatch.
+- It lints the Dockerfile with Hadolint, builds `linux/amd64` and `linux/arm64`, and pushes to Docker Hub and GHCR. The image tags, including the semver tags, come from the release tag.
 
-- Workflow name: `Build and Push Docker Image`
-- Triggers: push to `main`/`latest`, tags `v*.*.*`, PRs to `main`/`latest`, manual dispatch.
-- Manual dispatch example:
+Watch the latest run:
 
 ```bash
-cd /Users/talor/github/projects/compressatorium
-gh workflow run docker-image.yml --ref main -f push=true -f platforms='linux/amd64,linux/arm64'
-```
-
-- Monitor the latest run:
-
-```bash
-cd /Users/talor/github/projects/compressatorium
 gh run list --workflow docker-image.yml --limit 5
 gh run watch "$(gh run list --workflow docker-image.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
 ```
 
-## Command Notes
+## Command notes
 
-- Preferred env names are `COMPRESSATORIUM_MOUNT_ROOT` and `COMPRESSATORIUM_VOLUMES`.
-- Legacy aliases `CHD_MOUNT_ROOT` and `CHD_VOLUMES` are still supported.
-- Keep default `MAX_CONCURRENT_JOBS=1` unless host capacity has been explicitly validated.
+- Preferred env names: `COMPRESSATORIUM_MOUNT_ROOT` and `COMPRESSATORIUM_VOLUMES`.
+- Legacy aliases `CHD_MOUNT_ROOT` and `CHD_VOLUMES` still work.
+- Keep `MAX_CONCURRENT_JOBS=1` unless you've checked the host can handle more.

--- a/CHANGES_SUMMARY.md
+++ b/CHANGES_SUMMARY.md
@@ -1,197 +1,26 @@
-# Changes Summary - Docker Compose & Deployment Audit
+# Changes summary: Docker Compose and deployment docs
 
-## Overview
-This PR adds Docker Compose configurations and performs a comprehensive deployment readiness audit for the CHD Converter Web UI.
+This records the change that added the Docker Compose configs and the deployment docs. It's a historical summary, not current reference. For the live docs, see [DEPLOYMENT.md](DEPLOYMENT.md) and [DOCKER-COMPOSE.md](DOCKER-COMPOSE.md).
 
----
+## What it added
 
-## 📦 New Files Created (7 files, 638+ lines)
+**Compose files**
+- `docker-compose.yml`: single-volume Web UI setup with a health check, a restart policy, and active resource limits.
+- `docker-compose.multi-volume.yml`: four game-library mounts as separate volumes.
+- `docker-compose.cli.yml`: CLI batch mode that exits after the run, with no restart policy.
 
-### Docker Compose Configurations (3 files)
+**Docs**
+- `DEPLOYMENT.md`: deployment guide covering security, the health check, tuning, and a checklist.
+- `DOCKER-COMPOSE.md`: quick reference for the compose files, common commands, and troubleshooting.
+- `README.md`: added the Docker Compose section and links to both guides.
 
-1. **docker-compose.yml** (38 lines)
-   - Single volume setup for basic usage
-   - Configured for Web UI mode
-   - Includes health checks and restart policy
-   - Commented resource limits ready to enable
+**Build**
+- `.dockerignore`: keeps the build context small.
 
-2. **docker-compose.multi-volume.yml** (40 lines)
-   - Multiple volume configuration example
-   - Pre-configured with 4 game library paths
-   - Ideal for organizing different console libraries
+## Security review at the time
 
-3. **docker-compose.cli.yml** (22 lines)
-   - CLI batch processing mode
-   - No restart policy (exits after conversion)
-   - Perfect for automated/scheduled conversions
+The code review found no hardcoded secrets, path-traversal protection in `files.py` and `convert.py`, command execution through `asyncio.create_subprocess_exec()` with no shell, file paths validated against the configured volumes, and archive extraction guarded by the same validation. Those still hold. See [DEPLOYMENT.md](DEPLOYMENT.md) for the current state.
 
-### Documentation (3 files)
+## Follow-ups since
 
-4. **DEPLOYMENT.md** (292 lines)
-   - Comprehensive deployment readiness audit
-   - Security assessment (path traversal, secrets, injection)
-   - Docker best practices review
-   - Production deployment checklist
-   - Recommendations for hardening
-
-5. **DOCKER-COMPOSE.md** (174 lines)
-   - Quick reference guide
-   - Common commands
-   - Troubleshooting tips
-   - Environment variables reference
-
-6. **README.md** (Updated)
-   - Added Docker Compose section
-   - Quick start instructions
-   - Links to deployment guides
-
-### Build Optimization
-
-7. **.dockerignore** (44 lines)
-   - Excludes unnecessary files from Docker builds
-   - Reduces build context size
-   - Improves build speed and caching
-
----
-
-## 🔒 Security Audit Results
-
-### ✅ Passed Security Checks
-
-- **No hardcoded secrets**: No passwords, API keys, or tokens in codebase
-- **Path traversal protection**: Implemented in both `files.py` and `convert.py`
-- **Command injection protection**: Uses `asyncio.create_subprocess_exec()` without shell
-- **Input validation**: All file paths validated against configured volumes
-- **Archive handling**: Secure extraction with proper path validation
-
-### ⚠️ Recommendations
-
-1. **Add non-root user** to Dockerfile (high priority)
-2. **Enable resource limits** in production deployments
-3. **Add security headers** for web UI
-4. **Configure HTTPS** if exposing externally
-5. **Consider rate limiting** for public deployments
-
----
-
-## ✅ Validation Results
-
-All Docker Compose files validated:
-- ✅ Valid YAML syntax
-- ✅ Service definitions correct
-- ✅ Required fields present (image, volumes, environment)
-- ✅ Health checks configured
-- ✅ Environment variables documented
-
----
-
-## 📊 Deployment Readiness Status
-
-**Overall Assessment: ✅ READY**
-
-### Development/Staging
-- **Status**: ✅ Ready to deploy immediately
-- **Action**: Run `docker-compose up -d`
-
-### Production
-- **Status**: ✅ Ready with recommendations
-- **Action**: Implement high-priority security recommendations first
-
----
-
-## 🚀 Quick Start
-
-### For Users
-
-**Basic setup:**
-```bash
-docker-compose up -d
-```
-Access at: http://localhost:8080
-
-**Multiple libraries:**
-```bash
-docker-compose -f docker-compose.multi-volume.yml up -d
-```
-
-**Batch conversion:**
-```bash
-docker-compose -f docker-compose.cli.yml up
-```
-
-### For Developers
-
-**Review deployment guide:**
-```bash
-cat DEPLOYMENT.md
-```
-
-**Quick reference:**
-```bash
-cat DOCKER-COMPOSE.md
-```
-
----
-
-## 📈 Impact
-
-- **Ease of deployment**: Significantly improved with ready-to-use compose files
-- **Documentation**: Comprehensive guides for all deployment scenarios
-- **Security**: Audited and documented with actionable recommendations
-- **Build optimization**: Faster builds with .dockerignore
-- **Production readiness**: Clear path to production deployment
-
----
-
-## 🔄 Next Steps (Optional)
-
-1. Set `PUID`/`PGID` in runtime configs where host ownership mapping is required
-2. Add security headers middleware
-3. Create production-specific compose file with TLS
-4. Add monitoring/metrics endpoint
-5. Set up automated security scanning
-
----
-
-## 📝 Files Modified
-
-- `README.md` - Added Docker Compose section with examples
-
-## 📦 Files Added
-
-- `.dockerignore` - Build optimization
-- `docker-compose.yml` - Single volume setup
-- `docker-compose.multi-volume.yml` - Multiple volumes
-- `docker-compose.cli.yml` - CLI mode
-- `DEPLOYMENT.md` - Comprehensive deployment guide
-- `DOCKER-COMPOSE.md` - Quick reference
-- `CHANGES_SUMMARY.md` - This file
-
----
-
-## ✅ Testing Performed
-
-- [x] YAML syntax validation (all files)
-- [x] Service definition validation
-- [x] Security audit (code review)
-- [x] Documentation review
-- [x] Path traversal testing (code review)
-- [x] Environment variables validation
-
----
-
-## 🎯 Problem Statement Addressed
-
-✅ **Created docker-compose.yml**
-- Three different configurations for various use cases
-- Well-documented and ready to use
-- Includes best practices and resource limits
-
-✅ **Audited repository for deployment readiness**
-- Comprehensive security audit completed
-- No critical issues found
-- Recommendations documented
-- Production deployment guide created
-- Deployment checklist provided
-
-**The repository is now deployment-ready!**
+Some items flagged here have since shipped. The runtime drops to a non-root `converter` user (`entrypoint.sh` plus `gosu`), and the compose files carry resource limits. What's still left to the operator: HTTPS and auth through a reverse proxy, security headers, rate limiting, and monitoring. DEPLOYMENT.md tracks the live list.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,341 +1,125 @@
-# Deployment Readiness Audit
+# Deployment guide
 
-This document contains the results of a comprehensive deployment readiness audit for the Docker CHD Converter Web UI.
+How to run Compressatorium in production, what the image already handles, and what you should add yourself.
 
-**Audit Date:** 2026-01-20  
-**Audit Scope:** Docker configuration, security, documentation, and deployment practices
+This file started as a one-time readiness audit (2026-01-20). Several of its old recommendations are now part of the image (`.dockerignore`, a multi-stage build, resource limits in the compose files), so what follows is the current picture, not the original audit.
 
----
+## Security
 
-## ✅ Security Assessment
+**Path traversal.** Every file operation goes through `is_within_configured_volumes()` and `ensure_path_within_volumes()` in `app/utils/path_utils.py`. Paths are resolved with `Path.resolve()` and checked against the configured volumes, and symlink loops (ELOOP) are rejected outright instead of slipping through. Used in `files.py` and `convert.py`.
 
-### Path Traversal Protection
-- **Status:** ✅ IMPLEMENTED
-- **Location:** `app/utils/path_utils.py`, used in `files.py` and `convert.py`
-- **Details:** `is_within_configured_volumes()` uses `Path.resolve()` and `is_relative_to()` to prevent directory traversal attacks
-- **Fallback:** Includes Python 3.8 fallback using `os.path.commonpath`
+**No hardcoded secrets.** No passwords, API keys, or tokens in the code. Sensitive config comes from environment variables.
 
-### Secrets and Credentials
-- **Status:** ✅ NO ISSUES FOUND
-- **Details:** No hardcoded passwords, API keys, tokens, or secrets found in codebase
-- **Environment Variables:** All sensitive configuration properly uses environment variables
+**Command injection.** The chdman and subprocess services call `asyncio.create_subprocess_exec()` with an argument list, never `shell=True`. See `app/services/chdman.py` and `app/services/subprocess_runner.py`.
 
-### Input Validation
-- **Status:** ✅ IMPLEMENTED
-- **File Path Validation:** All file operations validate paths against configured volumes
-- **Output Directory Validation:** Custom output directories are validated
-- **Archive Support:** Archive extraction paths are properly validated
+**Privilege drop.** `entrypoint.sh` starts as root, optionally remaps `PUID`/`PGID`, then drops to the `converter` user with `gosu` before the app runs.
 
-### Command Injection Protection
-- **Status:** ✅ SECURE
-- **Details:** `chdman` service uses `asyncio.create_subprocess_exec()` with argument list (not shell=True)
-- **Location:** `app/services/chdman.py`
+**Input validation.** File paths, custom output directories, and archive extraction paths are all validated against the configured volumes before use.
 
----
+## Health check
 
-## ✅ Docker Configuration
+The image ships a `HEALTHCHECK` (30s interval, 10s timeout, 10s start period, 3 retries) that hits `/health`. In CLI mode it exits 0 so a batch run isn't marked unhealthy. `/health` returns `{"status": "healthy", "version": "..."}`.
 
-### Dockerfile Best Practices
-- **Status:** ✅ GOOD with minor optimization opportunities
-- **Base Image:** Using `debian:trixie-slim` (minimal base)
-- **Package Cleanup:** Properly cleans apt cache (`apt-get clean && rm -rf /var/lib/apt/lists/*`)
-- **Virtual Environment:** Uses Python venv for isolation
-- **Runtime Privilege Drop:** ✅ IMPLEMENTED (`entrypoint.sh` starts as root, optionally remaps `PUID`/`PGID`, then drops to `converter` with `gosu`)
+## Environment and volumes
 
-### Health Check
-- **Status:** ✅ IMPLEMENTED
-- **Endpoint:** `/health` (returns `{"status": "healthy"}`)
-- **Configuration:** 30s interval, 10s timeout, 3 retries
-- **Note:** Gracefully handles CLI mode (exits with 0)
+The full environment variable reference lives in [README.md](README.md#environment-variables). The ones that matter most for a deployment:
 
-### Environment Variables
-| Variable | Default | Status | Purpose |
-|----------|---------|--------|---------|
-| `CHD_MODE` | `webui` | ✅ | Web UI or CLI mode |
-| `COMPRESSATORIUM_MOUNT_ROOT` | `/data` | ✅ | Startup scan root for auto-discovered volumes (`/data/*`) |
-| `COMPRESSATORIUM_VOLUMES` | (unset) | ✅ | Explicit comma-separated volume paths (skips startup scan) |
-| `CHD_MOUNT_ROOT` | `/data` | ✅ | Legacy alias for `COMPRESSATORIUM_MOUNT_ROOT` |
-| `CHD_VOLUMES` | (unset) | ✅ | Legacy alias for `COMPRESSATORIUM_VOLUMES` |
-| `PUID` | `999` | ✅ | Optional runtime UID remap for `converter` (common on Unraid/home servers) |
-| `PGID` | `999` | ✅ | Optional runtime GID remap for `converter`; uses existing group when that GID already exists |
-| `CHD_DATA_DIR` | `/config` | ✅ | Persistent data directory |
-| `COMPRESSATORIUM_SEARCH_AUTO_RETURN_TO_FILE_LIST` | `true` | ✅ | Web UI: when true, `Search All` conversions return to the previous file-list view after queueing |
-| `CHD_SEARCH_AUTO_RETURN_TO_FILE_LIST` | `true` | ✅ | Legacy alias for `COMPRESSATORIUM_SEARCH_AUTO_RETURN_TO_FILE_LIST` |
-| `CHD_TEMP_DIR` | `/config/temp` | ✅ | Temporary working directory for archive extraction (auto-created) |
-| `CHD_CONCURRENCY_LOCK_DIR` | `/tmp/chd-locks` | ✅ | Directory for job lock files (ephemeral, auto-cleaned on restart) |
-| `COMPRESSATORIUM_DB_PATH` | `/config/compressatorium.db` | ✅ | Unified SQLite database; replaces the legacy JSON stores and persists DAT-sync state |
-| `CHD_METADATA_STORE` | *(deprecated)* | ✅ | Legacy JSON path; auto-migrated to SQLite on first startup (custom path honored if set), renamed to `.migrated.bak` |
-| `CHD_VERIFICATION_STORE` | *(deprecated)* | ✅ | Legacy JSON path; auto-migrated to SQLite on first startup (custom path honored if set), renamed to `.migrated.bak` |
-| `CHDMAN_MODE` | `createcd` | ✅ | CD/DVD conversion mode (CLI mode) |
-| `CHDMAN_PATH` | `/usr/bin/chdman` | ✅ | Binary path override |
-| `DOLPHIN_TOOL_PATH` | `/usr/local/bin/dolphin-tool` | ✅ | Dolphin tool binary path |
-| `MAX_CONCURRENT_JOBS` | `1` | ✅ | Parallel job limit |
-| `MAX_JOB_HISTORY` | `500` | ✅ | Completed jobs to retain |
-| `CHD_CHDMAN_NICE` | `10` | ✅ | Nice level for chdman |
-| `CHD_CHDMAN_IOPRIO_CLASS` | `2` | ✅ | I/O priority class for chdman |
-| `CHD_CHDMAN_IOPRIO_LEVEL` | `6` | ✅ | I/O priority level for chdman |
-| `CHD_ARCHIVE_MAX_ENTRIES` | `5000` | ✅ | Max archive members to list (0 disables limit) |
-| `CHD_ARCHIVE_MAX_MEMBER_SIZE` | `0` | ✅ | Max size per archive member (0 disables limit) |
-| `CHD_ARCHIVE_MAX_TOTAL_SIZE` | `0` | ✅ | Max total size for archive listings/extractions (0 disables limit) |
-| `CHD_INFO_TIMEOUT` | `60` | ✅ | Timeout for `chdman info` (0 disables) |
-| `CHD_VERIFY_TIMEOUT` | `0` | ✅ | Timeout for `chdman verify` (0 disables) |
-| `CHD_VERIFY_PROGRESS_TIMEOUT` | `0` | ✅ | Timeout without verify output (0 disables) |
-| `LOGLEVEL` | `INFO` | ✅ | Log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) |
-| `LOG_PATH` | (none) | ✅ | Log file path (stdout only if unset) |
-| `CHD_DEBUG_HEARTBEAT` | `30` | ✅ | Maintenance loop interval (seconds) |
-| `CHD_DEBUG_PROGRESS_INTERVAL` | `30` | ✅ | Debug progress log interval |
-| `CHD_DEBUG_PROGRESS_TIMEOUT` | `300` | ✅ | Debug progress timeout |
-| `CHD_PROGRESS_TIMEOUT` | `600` | ✅ | Fail conversion if progress + output size stall for this many seconds (0 disables) |
-| `STATIC_DIR` | `/static` | ✅ | Path to static web assets |
-| `PYTHONUNBUFFERED` | `1` | ✅ | Logging optimization |
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CHD_MODE` | `webui` | Web UI or CLI batch mode |
+| `COMPRESSATORIUM_MOUNT_ROOT` | `/data` | Startup scan root; `/data/*` is auto-registered |
+| `COMPRESSATORIUM_VOLUMES` | (unset) | Explicit comma-separated volume paths; skips the scan |
+| `PUID` / `PGID` | `999` | Remap the `converter` user/group to match host ownership |
+| `CHD_DATA_DIR` | `/config` | Persistent data; the SQLite DB lives here |
+| `MAX_CONCURRENT_JOBS` | `1` | Parallel conversion jobs |
+| `CHD_CHDMAN_NICE` / `CHD_CHDMAN_IOPRIO_CLASS` / `CHD_CHDMAN_IOPRIO_LEVEL` | `10` / `2` / `6` | CPU and I/O priority for chdman |
+| `STATIC_DIR` | `/static` | Static web assets |
 
 Volume precedence:
-- If `COMPRESSATORIUM_VOLUMES` is set, that explicit list is used.
-- If `COMPRESSATORIUM_VOLUMES` is unset, the app scans `COMPRESSATORIUM_MOUNT_ROOT/*` once at startup.
-- Restart the container after adding/removing mounts so discovered volumes refresh.
+- If `COMPRESSATORIUM_VOLUMES` is set, that explicit list wins.
+- Otherwise the app scans `COMPRESSATORIUM_MOUNT_ROOT/*` once at startup.
+- Restart the container after adding or removing mounts so the discovered volumes refresh.
 
----
+## Tuning
 
-## ✅ Application Architecture
+**Where to change it.** Set environment variables in your runtime (Compose, Unraid, or `docker run`) and apply CPU/memory limits at the container level.
 
-### FastAPI Implementation
-- **Status:** ✅ WELL STRUCTURED
-- **API Documentation:** Automatic via FastAPI `/docs` endpoint
-- **Health Check:** Implemented at `/health`
-- **Static Files:** Properly served from `/static`
-- **SSE Support:** Real-time progress updates via Server-Sent Events
+**Starting points**
+- **Low to medium hosts (≤16 GB RAM, HDD or parity-backed arrays):** keep `MAX_CONCURRENT_JOBS=1`, `CHD_CHDMAN_NICE=10`, `CHD_CHDMAN_IOPRIO_CLASS=2`, `CHD_CHDMAN_IOPRIO_LEVEL=6`. Set a memory limit of 8 to 12 GB.
+- **Faster hosts (32+ GB RAM, SSD cache):** try `MAX_CONCURRENT_JOBS=2` and 16 to 24 GB. Raise I/O priority only if the host stays responsive.
+- **If the host gets sluggish:** lower `MAX_CONCURRENT_JOBS`, raise `CHD_CHDMAN_NICE`, or set `CHD_CHDMAN_IOPRIO_CLASS=3` (idle) with `CHD_CHDMAN_IOPRIO_LEVEL=7`.
 
-### Job Management
-- **Status:** ✅ IMPLEMENTED
-- **Queue System:** Async job queue with configurable concurrency
-- **Progress Tracking:** Real-time progress via SSE
-- **Job Cancellation:** Supports job cancellation
-- **Lock Management:** File locking to prevent duplicate conversions
+**Host tips**
+- Put `CHD_TEMP_DIR` and CHD output on SSD or cache to cut array contention.
+- Don't run other heavy services during a conversion.
+- Always set container CPU/memory limits on a shared host.
 
-### Archive Support
-- **Status:** ✅ IMPLEMENTED
+## What's already in the image
 
-### Tuning and Host Recommendations
+- `.dockerignore` at the repo root.
+- Multi-stage `Dockerfile`: a Debian `builder`, a `node:lts-slim` `frontend-builder` for the Svelte UI, and a slim runtime with no Node.
+- Conservative CPU/memory limits in the default compose files.
+- Async job queue with configurable concurrency, SSE progress, job cancellation, and per-job file locks.
+- Archive support (ZIP, 7z, RAR) through `py7zr`, `rarfile`, and the `p7zip-full` / `unrar-free` system packages, with temp extraction and cleanup.
+- Auto-generated API docs at `/docs` (OpenAPI/Swagger).
+- CI/CD in `.github/workflows/docker-image.yml`: builds `linux/amd64` and `linux/arm64` and pushes to Docker Hub and GHCR on pushes to `latest` and on `v*` tags.
 
-**How to change settings**
-- Set environment variables in your container runtime (Compose, Unraid, or docker run).
-- Apply CPU/memory limits at the container level to protect the host.
+## What you should add yourself
 
-**Recommended starting points**
-- **Low/medium hosts (≤16 GB RAM, HDD or parity-backed arrays):** keep `MAX_CONCURRENT_JOBS=1`, `CHD_CHDMAN_NICE=10`, `CHD_CHDMAN_IOPRIO_CLASS=2`, `CHD_CHDMAN_IOPRIO_LEVEL=6`. Set a container memory limit (8–12 GB).
-- **Faster hosts (32+ GB RAM, SSD cache):** try `MAX_CONCURRENT_JOBS=2` and a higher memory limit (16–24 GB). Raise I/O priority only if the host remains responsive.
-- **If the host becomes sluggish:** lower `MAX_CONCURRENT_JOBS`, increase `CHD_CHDMAN_NICE`, or set `CHD_CHDMAN_IOPRIO_CLASS=3` (idle) with `CHD_CHDMAN_IOPRIO_LEVEL=7`.
+Compressatorium has no built-in auth and doesn't terminate TLS. For anything reachable beyond your LAN:
 
-**Docker host tips**
-- Prefer SSD/cache for `CHD_TEMP_DIR` and CHD output to reduce array contention.
-- Avoid running other heavy services during conversion.
-- Always set container CPU/memory limits on shared hosts.
-- **Formats:** ZIP, 7z, RAR
-- **Dependencies:** `unrar-free`, `p7zip-full`, `py7zr`, `rarfile`
-- **Extraction:** Temporary extraction with cleanup
+- Put it behind a reverse proxy (nginx or Traefik) with HTTPS.
+- Add authentication at the proxy. There is none in the app.
+- Add security headers (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`) and rate limiting at the proxy.
+- There are no CORS restrictions by default. Add them at the proxy if the API needs protecting.
+- Set up monitoring and log aggregation. Logs go to stdout, or to `LOG_PATH` if you set it.
 
----
+## Directory structure
 
-## ✅ Documentation
-
-### README.md
-- **Status:** ✅ COMPREHENSIVE
-- **Covers:**
-  - Web UI mode with examples
-  - CLI mode with examples
-  - Multiple volume configuration
-  - Environment variables table
-  - Docker Compose example (now multiple examples)
-  - Supported file types
-  - Health check usage
-
-### API Documentation
-- **Status:** ✅ AUTO-GENERATED
-- **Access:** Available at `/docs` when running
-- **Format:** OpenAPI/Swagger
-
----
-
-## ⚠️ Recommendations
-
-### High Priority
-
-1. **Set `PUID`/`PGID` in your runtime** (Ownership)
-   - Recommended for Unraid and shared-host setups so generated files are owned by the correct host user/group.
-   - Defaults remain `999:999` when unset.
-
-2. **Add .dockerignore File** (Build Optimization)
-   ```
-   .git
-   .github
-   __pycache__
-   *.pyc
-   *.pyo
-   *.pyd
-   .Python
-   *.so
-   .DS_Store
-   .vscode
-   .idea
-   test
-   images
-   ```
-
-3. **Resource Limits in Docker Compose** (Production Readiness)
-   Add memory and CPU limits to prevent resource exhaustion
-
-### Medium Priority
-
-4. **Security Headers** (Web Security)
-   Add security headers middleware in FastAPI:
-   - X-Content-Type-Options: nosniff
-   - X-Frame-Options: DENY
-   - X-XSS-Protection: 1; mode=block
-
-5. **CORS Configuration** (Web Security)
-   Currently no CORS restrictions. Consider adding if API needs protection.
-
-6. **Rate Limiting** (DoS Protection)
-   Consider adding rate limiting for public deployments
-
-7. **Logging Configuration** (Observability)
-   Add structured logging with log levels and rotation
-
-### Low Priority
-
-8. **Multi-Stage Build** (Image Size)
-   Consider multi-stage build to reduce final image size
-
-9. **BuildKit Cache Mounts** (Build Speed)
-   Use BuildKit cache mounts for pip and apt
-
-10. **Monitoring Integration** (Production)
-    Add Prometheus metrics endpoint for production monitoring
-
----
-
-## ✅ CI/CD Configuration
-
-### GitHub Actions
-- **Status:** ✅ CONFIGURED
-- **Workflow:** `.github/workflows/docker-image.yml`
-- **Triggers:** Push to `latest` branch, version tags (`v*`)
-- **Platforms:** linux/amd64, linux/arm64
-- **Registries:** Docker Hub, GitHub Container Registry
-- **Secrets Required:**
-  - `DOCKER_HUB_USERNAME` ✅
-  - `DOCKER_HUB_ACCESS_TOKEN` ✅
-  - `GITHUB_TOKEN` (auto-provided) ✅
-
----
-
-## ✅ File Organization
-
-### .gitignore
-- **Status:** ✅ ADEQUATE
-- **Covers:** Python artifacts, build files, images, macOS files
-- **Recommendation:** Add more entries (see .dockerignore recommendation)
-
-### Directory Structure
 ```
 .
-├── .github/
-│   └── workflows/          # CI/CD configuration
+├── .github/workflows/      # CI/CD
 ├── app/
-│   ├── routes/            # API endpoints
-│   ├── services/          # Business logic
-│   ├── config.py          # Configuration
-│   ├── main.py            # FastAPI app
-│   └── models.py          # Data models
-├── static/
-│   ├── css/
-│   ├── js/
-│   └── index.html
-├── Dockerfile             # Container definition
-├── docker-compose*.yml    # Compose configurations
-├── entrypoint.sh          # Container entrypoint
-└── requirements.txt       # Python dependencies
+│   ├── routes/             # API endpoints
+│   ├── services/           # conversion tools, stores, job manager
+│   ├── utils/              # path validation, delete plans
+│   ├── config.py
+│   ├── main.py             # FastAPI app
+│   └── models.py
+├── src/                    # Svelte 5 + Vite frontend source
+├── static/                 # built UI: index.html + assets/ + images/
+├── migrations/             # Alembic migrations
+├── tests/
+├── Dockerfile
+├── docker-compose*.yml
+├── entrypoint.sh
+└── requirements.txt
 ```
 
-**Status:** ✅ WELL ORGANIZED
+## Deployment checklist
 
----
+**Before**
+- [ ] Set the environment variables you need.
+- [ ] Create the game library directories on the host.
+- [ ] Make sure there's enough disk space for conversions.
+- [ ] Mount your `/data/*` directories, or set an explicit `COMPRESSATORIUM_VOLUMES`.
+- [ ] Pick a `MAX_CONCURRENT_JOBS` that fits the host.
 
-## 📋 Deployment Checklist
+**Deploy**
+- [ ] Pull or build the image.
+- [ ] `docker-compose up -d`.
+- [ ] `docker-compose ps` and confirm the container is healthy.
+- [ ] Open http://localhost:8080.
+- [ ] `curl http://localhost:8080/health`.
 
-### Pre-Deployment
-- [ ] Review and set all environment variables
-- [ ] Create game library directories on host
-- [ ] Ensure sufficient disk space for conversions
-- [ ] Configure `/data/*` mounts (or set explicit `COMPRESSATORIUM_VOLUMES`)
-- [ ] Set appropriate concurrent job limits based on CPU
-- [ ] Review and adjust health check parameters if needed
+**After**
+- [ ] Browse files in the Web UI.
+- [ ] Convert a small test file and confirm the output lands.
+- [ ] Check logs: `docker-compose logs -f`.
+- [ ] Watch resource use: `docker stats`.
+- [ ] Set up backups of converted files if you need them.
+- [ ] Put a reverse proxy with HTTPS in front if it's internet-facing.
 
-### Deployment
-- [ ] Pull or build the Docker image
-- [ ] Start services: `docker-compose up -d`
-- [ ] Verify container is running: `docker-compose ps`
-- [ ] Check health status: `docker-compose ps` (should show "healthy")
-- [ ] Access web UI: http://localhost:8080
-- [ ] Test API health endpoint: `curl http://localhost:8080/health`
+## Bottom line
 
-### Post-Deployment
-- [ ] Test file browsing in Web UI
-- [ ] Test conversion with a small test file
-- [ ] Verify CHD file is created successfully
-- [ ] Check container logs: `docker-compose logs -f`
-- [ ] Monitor resource usage: `docker stats`
-- [ ] Set up automated backups of converted files (if needed)
-- [ ] Configure reverse proxy if exposing to internet (recommended: nginx/Traefik with HTTPS)
-
-### Production Considerations
-- [ ] Enable HTTPS if accessible externally
-- [ ] Consider adding authentication (not built-in)
-- [ ] Set up monitoring and alerting
-- [ ] Configure log aggregation
-- [ ] Implement backup strategy
-- [ ] Set resource limits in docker-compose.yml
-- [ ] Review and harden security settings
-
----
-
-## 📊 Test Results
-
-### Build Test
-- **Status:** ⚠️ SKIPPED (SSL certificate issue in CI environment)
-- **Note:** Build tested successfully in regular environment
-- **Issue:** Self-signed certificate in CI chain (environment-specific)
-
-### Configuration Validation
-- **Status:** ✅ PASSED
-- **Docker Compose Files:** 3 configurations created
-  - `docker-compose.yml` - Single volume (default)
-  - `docker-compose.multi-volume.yml` - Multiple libraries
-  - `docker-compose.cli.yml` - Batch processing mode
-
----
-
-## 🎯 Overall Assessment
-
-**Deployment Readiness: ✅ READY with minor recommendations**
-
-The application is well-architected with good security practices:
-- ✅ No critical security vulnerabilities found
-- ✅ Path traversal protection implemented
-- ✅ No hardcoded secrets
-- ✅ Command injection protection
-- ✅ Health checks configured
-- ✅ Comprehensive documentation
-- ✅ CI/CD configured
-- ✅ Multi-platform support
-
-**Recommended before production deployment:**
-
-1. Set `PUID`/`PGID` in your runtime to match host ownership expectations
-2. Create .dockerignore file
-3. Add resource limits to docker-compose.yml
-4. Consider security headers for web UI
-5. Set up HTTPS if exposing externally
-
-**The application can be safely deployed to development/staging environments immediately.**
-**For production deployment, implement the high-priority recommendations above.**
+The app is safe to run on development and staging right away. For production, add a reverse proxy with HTTPS and authentication, set resource limits, and decide on monitoring and backups. Nothing in the codebase blocks a production deploy. The gaps are the usual operational ones it leaves to you on purpose.

--- a/DESIGN_tool_plugin_architecture.md
+++ b/DESIGN_tool_plugin_architecture.md
@@ -7,9 +7,9 @@
 
 Adding one conversion tool today touches ~20 files, and the standing advice
 is "copy what z3ds does" in each of them. The tool-service contract already
-exists *implicitly* — every service (`chdman`, `dolphin_tool`,
+exists *implicitly*, every service (`chdman`, `dolphin_tool`,
 `z3ds_compress`) exposes the same shape (`convert` / `verify` /
-`verify_stream` / `info` / `is_convertible` / `get_output_path_for_mode`) —
+`verify_stream` / `info` / `is_convertible` / `get_output_path_for_mode`),
 but it was never formalized, so tool-specific knowledge is hand-scattered into
 hardcoded `if/elif` ladders and string-prefix checks across the codebase.
 
@@ -34,7 +34,7 @@ hardcoded `if/elif` ladders and string-prefix checks across the codebase.
 | Frontend dispatch | `static/js/app.js` (~10 sites), `api.js` | tool branches for label, hint, filters, `MODE_GROUPS`, info modal, verify routing |
 
 The rule of three is satisfied (three tools exist), so abstracting this is no
-longer premature — it is overdue.
+longer premature, it is overdue.
 
 ### 1.2 Goals / non-goals
 
@@ -98,7 +98,7 @@ app/services/tools/
   z3ds.py            # Z3dsTool
 ```
 
-### 3.1 `spec.py` — modes carry metadata
+### 3.1 `spec.py`: modes carry metadata
 
 ```python
 from dataclasses import dataclass
@@ -136,11 +136,11 @@ Every prefix check in the codebase maps to a field:
 | `supports_delete_on_verify(mode)` (`convert.py:87`) | `spec.supports_delete_on_verify` |
 | GCZ/ISO compression special-cases (`convert.py:315`–`324`) | `spec.supports_compression` |
 
-`ConversionMode` (the Pydantic enum in `models.py`) **stays** — it remains the
+`ConversionMode` (the Pydantic enum in `models.py`) **stays**, it remains the
 validated wire type. `ModeSpec.mode` equals `ConversionMode(...).value`. The
 registry is the bridge between the two.
 
-### 3.2 `base.py` — the plugin contract
+### 3.2 `base.py`: the plugin contract
 
 ```python
 from collections.abc import AsyncGenerator, Sequence
@@ -174,7 +174,7 @@ class ToolPlugin(Protocol):
     def active_pids(self) -> list[int]: ...
 
     # Optional post-processing hook (chdman uses it to embed disc-ID GAME/NAME
-    # tags after createcd/createdvd — today hardcoded at job_manager.py:1514).
+    # tags after createcd/createdvd, today hardcoded at job_manager.py:1514).
     async def post_convert(self, input_path: str, output_path: str, mode: str) -> None: ...
 ```
 
@@ -201,7 +201,7 @@ class BaseTool:
                 return m
         raise KeyError(mode)
 
-    # default verify() wraps verify_stream() — identical in all 3 services today
+    # default verify() wraps verify_stream(), identical in all 3 services today
     async def verify(self, path: str) -> dict:
         final = {"valid": False, "message": "Verification failed"}
         async for u in self.verify_stream(path):
@@ -222,9 +222,9 @@ class BaseTool:
 > **Normalization note:** `info()` is async on the contract.
 > `chdman.info`/`dolphin.header` are already async; `z3ds.info` is sync, so
 > `Z3dsTool.info` wraps it in `run_in_threadpool`. `dolphin` exposes header
-> data via `header()` today — `DolphinTool.info` simply calls it.
+> data via `header()` today, `DolphinTool.info` simply calls it.
 
-### 3.3 `runner.py` — shared subprocess orchestration
+### 3.3 `runner.py`: shared subprocess orchestration
 
 This collapses ~150 near-identical lines now living in each of
 `chdman.py:96`–`334`, `dolphin_tool.py:109`–`356`, `z3ds_compress.py:137`–`347`.
@@ -357,10 +357,10 @@ and instead loop `for tool in registry.all()` calling a tool-provided
 > See `src/lib/tools/registry.js` for the source of truth.
 
 ```js
-// src/lib/tools/registry.js (abridged — see file for full schema)
+// src/lib/tools/registry.js (abridged, see file for full schema)
 export const TOOLS = [
   { id: 'chdman', label: 'CHDMAN', hint: '…',
-    verifyPrefix: '',                                    // URL segment — '' → /api/verify
+    verifyPrefix: '',                                    // URL segment, '' → /api/verify
     sourceExts: ['.gdi','.iso','.cue','.bin'], verifyExts: ['.chd'],
     modeGroups: ['create','extract','copy'],
     groups: { create: 'Create', extract: 'Extract', copy: 'Copy' },
@@ -384,15 +384,15 @@ into `TOOLS` instead of `if (tool === 'dolphin') …` chains.
 
 Before: ~20 files (see `ADDING_PLATFORMS_AND_TOOLS.md` §3). After:
 
-1. `app/services/tools/nszip.py` — one `BaseTool` subclass with `modes`,
+1. `app/services/tools/nszip.py`, one `BaseTool` subclass with `modes`,
    `_build_command`, `_parse_progress`, `verify_stream`, `info`, `info_model`.
-2. `app/services/tools/__init__.py` — one `registry.register(NszipTool(...))`.
-3. `app/config.py` — one `nszip_path` Field.
-4. `static/js/tools.js` — one entry in `TOOLS`.
-5. `Dockerfile` — install the binary (irreducible).
+2. `app/services/tools/__init__.py`, one `registry.register(NszipTool(...))`.
+3. `app/config.py`, one `nszip_path` Field.
+4. `static/js/tools.js`, one entry in `TOOLS`.
+5. `Dockerfile`, install the binary (irreducible).
 6. tests + docs.
 
-Dispatch in `job_manager`, `convert`, `files`, `info` — **no edits**, because
+Dispatch in `job_manager`, `convert`, `files`, `info`, **no edits**, because
 they iterate the registry. That is the whole point.
 
 ---
@@ -405,20 +405,20 @@ Each phase is independently shippable, preserves behavior, and ends green
 Phases are ordered so the **registry exists first** and consumers migrate one
 at a time. Nothing here changes the wire API until Phase 9 (optional).
 
-### Phase 0 — Scaffold the registry around existing services (no behavior change)
+### Phase 0: Scaffold the registry around existing services (no behavior change)
 - Add `app/services/tools/` with `spec.py`, `base.py`, `registry.py`.
 - Write `ModeSpec` rows for **every** current `ConversionMode` value.
 - Create thin `ChdmanTool`/`DolphinTool`/`Z3dsTool` that **delegate** to the
   existing `chdman_service`/`dolphin_tool_service`/`z3ds_compress_service`
   singletons (no logic moved yet).
 - Add `registry` singleton.
-- **Tests:** new `tests/test_tool_registry.py` — assert every
+- **Tests:** new `tests/test_tool_registry.py`, assert every
   `ConversionMode` resolves to exactly one tool; assert
   `registry.spec(m).supports_delete_on_verify` matches today's
   `supports_delete_on_verify(m)` for all modes (characterization).
 - Risk: ~none (additive).
 
-### Phase 1 — Replace prefix checks with `ModeSpec` in `convert.py`
+### Phase 1: Replace prefix checks with `ModeSpec` in `convert.py`
 - Swap `mode.startswith(...)` / `== "z3ds_compress"` and
   `supports_delete_on_verify` for `registry.spec(mode)` field reads.
 - Keep the duplicated single/batch structure for now.
@@ -426,7 +426,7 @@ at a time. Nothing here changes the wire API until Phase 9 (optional).
   pass unchanged.
 - Risk: low; pure substitution guarded by characterization tests from Phase 0.
 
-### Phase 2 — Route output-path resolution through the registry
+### Phase 2: Route output-path resolution through the registry
 - `convert._get_output_path` (`:100`) → `registry.for_mode(mode).output_path(...)`.
 - `job_manager._queue_job_locked` (`:139`) → same.
 - Implement `output_path()` on each tool by calling the existing
@@ -436,7 +436,7 @@ at a time. Nothing here changes the wire API until Phase 9 (optional).
 - Risk: low-medium (path edge cases: `extractcd` `.cue`, archive stems). The
   equivalence test is the safety net.
 
-### Phase 3 — Route conversion + verify dispatch through the registry
+### Phase 3: Route conversion + verify dispatch through the registry
 - `job_manager._process_job` `_convert_service` ladder (`:1444`) →
   `registry.for_mode(job.mode.value)`.
 - Verify branch (`:1556`, `:1591`) → `plugin.verify(output_path)` uniformly
@@ -448,14 +448,14 @@ at a time. Nothing here changes the wire API until Phase 9 (optional).
 - Risk: medium (hot path). Ship behind close review; the behavior is a 1:1
   re-route.
 
-### Phase 4 — Deduplicate single vs batch in `convert.py`
+### Phase 4: Deduplicate single vs batch in `convert.py`
 - Extract `plan_job(file_path, mode, output_dir, duplicate_action, …) -> JobPlan|Skip`.
 - `create_job` and `create_batch_jobs` both call it.
 - **Tests:** `test_mode_parity_fixes.py` becomes near-trivial (one code path);
   keep it as a regression guard.
 - Risk: medium; well-covered by the existing parity suite.
 
-### Phase 5 — Extract `SubprocessRunner`; slim the three services
+### Phase 5: Extract `SubprocessRunner`; slim the three services
 - Add `runner.py`; refactor `convert()` in each tool to use it.
 - Move the real `chdman`/`dolphin`/`z3ds` logic *into*
   `services/tools/{chdman,dolphin,z3ds}.py` (Phase 0 left them delegating).
@@ -468,17 +468,17 @@ at a time. Nothing here changes the wire API until Phase 9 (optional).
   at once; keep `ConversionCancelled` in its current import location to avoid
   breaking `job_manager`'s `except`.
 
-### Phase 6 — Generic info/verify routes from the registry
+### Phase 6: Generic info/verify routes from the registry
 - Replace the three endpoint trios in `info.py` with the factory (§3.5) +
   shared SSE adapters. Maintain the `tool_id → url_prefix` alias map so paths
-  (`/api/chd-verify`? no — keep `/api/verify`, `/api/dolphin-verify`,
+  (`/api/chd-verify`? no, keep `/api/verify`, `/api/dolphin-verify`,
   `/api/z3ds-verify`) are byte-for-byte identical.
 - **Tests:** `test_z3ds_routes.py`, `test_dolphin_routes.py`, and CHD verify
   route tests must pass without edits (same URLs, same events).
-- Risk: medium; the SSE event names/shapes are load-bearing for the frontend —
+- Risk: medium; the SSE event names/shapes are load-bearing for the frontend,
   assert them explicitly.
 
-### Phase 7 — Generic `FileEntry` outputs + registry loop in `files.py`
+### Phase 7: Generic `FileEntry` outputs + registry loop in `files.py`
 - Add `convertible_by` / `outputs`; populate from `registry.all()`.
 - Keep legacy booleans (`has_chd`, `dolphin_ready`, …) populated **in
   parallel** so the frontend keeps working.
@@ -486,16 +486,16 @@ at a time. Nothing here changes the wire API until Phase 9 (optional).
   flags and new `outputs` agree.
 - Risk: low (additive on the model).
 
-### Phase 8 — Frontend descriptor table
+### Phase 8: Frontend descriptor table
 - Add `static/js/tools.js`; migrate the ~10 `app.js` branch sites + `api.js`
   to consume it.
 - Switch `FileList` badges to read `entry.outputs`/`convertible_by`.
-- **Tests:** manual UI pass (no JS test harness in repo) — browse, convert,
+- **Tests:** manual UI pass (no JS test harness in repo), browse, convert,
   verify, info modal, for each tool; confirm SSE progress + badges.
 - Risk: medium (no automated FE tests). Verify in a browser per
-  `ADDING_PLATFORMS_AND_TOOLS.md` §15 (no build step — edit JS directly).
+  `ADDING_PLATFORMS_AND_TOOLS.md` §15 (no build step, edit JS directly).
 
-### Phase 9 — Cleanup (optional, behavior-preserving)
+### Phase 9: Cleanup (optional, behavior-preserving)
 - Remove the now-unused legacy `FileEntry` booleans once the frontend reads
   `outputs` exclusively.
 - Delete the old `services/{chdman,dolphin,z3ds_compress}.py` shims; update

--- a/DOCKER-COMPOSE.md
+++ b/DOCKER-COMPOSE.md
@@ -20,7 +20,7 @@ docker-compose up -d
 - Mode: Web UI
 - Concurrent jobs: 1
 
-**Use case:** Perfect for a top-level directory containing games organized in subdirectories. The Web UI will recursively browse all subdirectories, allowing you to navigate and convert files anywhere in the directory tree.
+**Use case:** A top-level directory with games in subfolders. The Web UI browses every subdirectory, so you can convert files anywhere in the tree.
 
 ---
 
@@ -39,7 +39,7 @@ docker-compose -f docker-compose.multi-volume.yml up -d
 - `./games/ps2` → `/data/ps2`
 - Temp: `/config/temp` (inside `./config`)
 
-**Use case:** Ideal when you have games stored in completely separate directories (e.g., different physical drives or network shares). Each mount point appears as a separate volume in the Web UI.
+**Use case:** Games kept in separate directories, like different drives or network shares. Each mount shows up as its own volume in the Web UI.
 
 **Customization:**
 Edit the file to add/remove volume mounts under `/data/*`.
@@ -225,7 +225,7 @@ docker-compose exec compressatorium bash
 
 ## Production Deployment
 
-For production deployment guidance, security recommendations, and comprehensive checklists, see **[DEPLOYMENT.md](DEPLOYMENT.md)**.
+For production guidance, security notes, and checklists, see **[DEPLOYMENT.md](DEPLOYMENT.md)**.
 
 Key recommendations:
 - Enable resource limits

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Compressatorium
 
-> **Fork Notice:** This project is a fork of MarcTV's original Docker CHD Converter project with an added Web UI and additional features. Thanks to [MarcTV](https://github.com/MarcTV) for the original CLI-based converter!
+> **Fork notice:** This is a fork of MarcTV's Docker CHD Converter. It adds a Web UI and two more conversion tools on top of the original CLI converter. Thanks to [MarcTV](https://github.com/MarcTV) for the original.
 
-Multi-tool game disc image converter supporting **CHDMAN** (MAME), **dolphin-tool** (Dolphin Emulator), and **z3ds_compressor** (Nintendo 3DS).
+A disc image converter that wraps three tools: **CHDMAN** (MAME), **dolphin-tool** (Dolphin Emulator), and **z3ds_compressor** (Nintendo 3DS). Pick the tool that matches your files and convert from a browser, or run it headless from the command line.
 
-## ✨ Features
+## Features
 
-* **🎮 Three Primary Tools:** Choose between CHDMAN, Dolphin, or 3DS compression
-* **🌐 Web UI** for easy file browsing and conversion with intuitive tool selection
-* **📁 Nested directories** and **compressed archives** (ZIP, 7z, RAR) support
-* **💾 Multiple volume mounts** for organizing different game libraries
-* **🔄 Smart file detection** - automatically identifies convertible files for each tool
-* **✅ Existing output detection** with skip/rename/overwrite options
-* **🗑️ Delete-on-verify** - optional automatic source removal after successful conversion
-* **📊 Progress tracking** with real-time job queue monitoring
-* **🔍 File information** - view metadata for CHD, Dolphin, and 3DS files
+* **Three tools in one.** CHDMAN, Dolphin, or 3DS compression, chosen per job.
+* **Web UI** for browsing files and converting them. The tool picker filters the whole interface down to the tool you chose.
+* **Nested directories and archives.** Browse subfolders and look inside ZIP, 7z, and RAR archives.
+* **Multiple volume mounts** so you can keep separate game libraries separate.
+* **File detection** that works out which files each tool can convert.
+* **Existing-output detection** with skip, rename, or overwrite.
+* **Delete-on-verify.** Optionally remove the source after a conversion verifies. Off by default.
+* **Progress tracking** through a live job queue.
+* **File info** for CHD, Dolphin, and 3DS files.
 
 ### Supported Conversions
 
@@ -24,11 +24,11 @@ Multi-tool game disc image converter supporting **CHDMAN** (MAME), **dolphin-too
 | **Dolphin** | .iso, .wbfs, .rvz, .wia, .gcz | .rvz, .wia, .gcz, .iso | GameCube/Wii disc images |
 | **3DS** | .cci, .cia, .3ds | .zcci, .zcia, .z3ds | Nintendo 3DS ROM compression |
 
-> **Archive inputs:** every input format above can be converted directly from inside a ZIP, 7z, or RAR archive — including 3DS ROMs and Dolphin disc images. Browse into the archive, pick a member, and convert. (CHDMAN extract/copy modes are the exception: they act on a finished `.chd`, which is an output, not a convertible source.)
+> **Archive inputs:** every input format above can be converted straight from inside a ZIP, 7z, or RAR archive, including 3DS ROMs and Dolphin disc images. Browse into the archive, pick a member, and convert. The exception is CHDMAN extract and copy modes, which act on a finished `.chd`. That is an output, not a convertible source.
 
 ### MAME Redump DAT Integration
 
-Compressatorium supports one-click sync of [MAME Redump](https://github.com/MetalSlug/MAMERedump) DAT files (Logiqx XML format) to verify that your compressed files match known-good Redump hashes. This enables hash-based matching with tools like [Hasheous](https://github.com/gaseous-project/hasheous) and [RomM](https://github.com/rommapp/romm).
+Compressatorium can sync [MAME Redump](https://github.com/MetalSlug/MAMERedump) DAT files (Logiqx XML) in one click and check your compressed files against known-good Redump hashes. The same hashes let tools like [Hasheous](https://github.com/gaseous-project/hasheous) and [RomM](https://github.com/rommapp/romm) match your library.
 
 - **One-click sync**: Click "Sync from MAME Redump" in the DAT panel to download all ~69 DATs automatically from GitHub
 - **Auto-sync**: Set `MAMEREDUMP_AUTO_SYNC=true` to sync DATs on container startup when none are loaded
@@ -83,7 +83,7 @@ Or pin to a specific pre-release (recommended if you want to control when you up
 docker pull pacnpal/compressatorium:3.7.0-beta-3
 ```
 
-> **⚠️ Warning — beta builds can cause data loss.** Pre-releases may contain unfinished migrations, experimental conversion logic, or breaking changes to the job database. Running a beta against a database populated by a stable release can corrupt or irreversibly migrate it, and downgrading back to `:latest` afterwards is **not supported**. Before pulling `:beta`:
+> **Warning: beta builds can cause data loss.** Pre-releases may carry unfinished migrations, experimental conversion logic, or breaking changes to the job database. Running a beta against a database that a stable release created can corrupt it or migrate it past the point of return, and downgrading back to `:latest` afterwards is **not supported**. Before you pull `:beta`:
 >
 > - Back up your SQLite database (`compressatorium.db` in your data volume) and any in-flight output files.
 > - Prefer a separate data volume for beta testing rather than pointing a beta container at your production volume.
@@ -101,7 +101,7 @@ When you open the Web UI, you'll see three tool options at the top:
 * **Dolphin** - For GameCube/Wii disc image conversions
 * **3DS** - For compressing Nintendo 3DS ROMs
 
-**Choose the tool that matches your files.** The interface will automatically show only relevant modes and file types.
+**Choose the tool that matches your files.** The interface then shows only the modes and file types that tool can use.
 
 ### 2. Browse and Select Files
 
@@ -121,7 +121,7 @@ When you open the Web UI, you'll see three tool options at the top:
 
 ## Web UI Mode (Default)
 
-The easiest way to use CHD Converter is through the web interface:
+The web interface is the easiest way to run Compressatorium:
 
 ```bash
 docker run -d \
@@ -170,19 +170,19 @@ A three-pane layout: navigation and tool picker on the left, the volume and file
 |-------|------|
 | ![Workspace · CHDMAN, light](docs/screenshots/workspace-chdman-light.png) | ![Workspace · CHDMAN, dark](docs/screenshots/workspace-chdman-dark.png) |
 
-**Batch selection** — tick multiple files and the convert panel arms itself, showing how many sources are queued and a one-click **Start conversion**.
+**Batch selection.** Tick multiple files and the convert panel arms itself, showing how many sources are queued and a one-click **Start conversion**.
 
 | Light | Dark |
 |-------|------|
 | ![Batch selection, light](docs/screenshots/workspace-batch-light.png) | ![Batch selection, dark](docs/screenshots/workspace-batch-dark.png) |
 
-**Dolphin (GameCube / Wii)** — compress discs to RVZ, WIA, or GCZ with a codec and compression-level picker.
+**Dolphin (GameCube / Wii).** Compress discs to RVZ, WIA, or GCZ, with a codec and compression-level picker.
 
 | Light | Dark |
 |-------|------|
 | ![Dolphin tool, light](docs/screenshots/workspace-dolphin-light.png) | ![Dolphin tool, dark](docs/screenshots/workspace-dolphin-dark.png) |
 
-**3DS** — compress `.cci`, `.cia`, and `.3ds` ROMs with z3ds_compressor.
+**3DS.** Compress `.cci`, `.cia`, and `.3ds` ROMs with z3ds_compressor.
 
 | Light | Dark |
 |-------|------|
@@ -228,7 +228,7 @@ The interface reflows cleanly across breakpoints:
 
 ![Mobile View](docs-mobile-view.png)
 
-The mobile interface features a card-based layout with touch-friendly controls (44-48px minimum touch targets), full-width inputs, and optimized spacing for better usability on small screens.
+On small screens the file list switches to a card layout. Controls use 44 to 48px touch targets, inputs go full width, and the spacing opens up so it stays usable on a phone.
 
 ### Features
 
@@ -243,7 +243,7 @@ The mobile interface features a card-based layout with touch-friendly controls (
 - Archives extract temporarily during conversion, then clean up automatically
 - When a `.cue`/`.gdi` is present in the same archive folder, `.bin` entries are suppressed and batch jobs are deduplicated by output path to avoid stalled conversions.
 - Archive listings include safety limits (max entries/size) and expose truncation metadata when limits are hit.
-- **Any convertible source inside an archive can be converted** — CHDMAN (`.gdi`/`.iso`/`.cue`/`.bin`), Dolphin (`.iso`/`.gcz`/`.wia`/`.rvz`/`.wbfs`), and 3DS (`.cci`/`.cia`/`.3ds`). Archive members are surfaced for whichever tool accepts them, exactly like on-disk files.
+- **Any convertible source inside an archive can be converted.** That covers CHDMAN (`.gdi`/`.iso`/`.cue`/`.bin`), Dolphin (`.iso`/`.gcz`/`.wia`/`.rvz`/`.wbfs`), and 3DS (`.cci`/`.cia`/`.3ds`). Archive members show up for whichever tool accepts them, exactly like on-disk files.
 - The only inputs that can't come from an archive are CHDMAN extract/copy modes, which operate on a finished `.chd` (an output, not a convertible source).
 
 **ISO Handling & Dolphin Tools (GameCube/Wii)**
@@ -264,7 +264,7 @@ The mobile interface features a card-based layout with touch-friendly controls (
 **Bulk Operations**
 - **Bulk Delete**: Delete multiple selected files at once
 - **Bulk Verify**: Verify integrity of multiple CHD + Dolphin images simultaneously
-- Smart categorization showing source files with/without CHD backups
+- Sorts sources by whether they already have a CHD backup
 - Warnings for files without verified CHD backups before deletion
 
 **Verification**
@@ -280,11 +280,11 @@ The mobile interface features a card-based layout with touch-friendly controls (
 - SHA1 and Data SHA1 checksums displayed
 - Raw chdman output available for advanced inspection
 - Dolphin disc info shows game ID, region, format, compression, and raw output
-- **Game ID & Title** — PS1, PS2, PSP, and Dreamcast game serials are extracted from CHD sector data (SYSTEM.CNF, PARAM.SFO, IP.BIN) and displayed in the info modal; human-readable titles are shown when available (e.g. "Patapon", "DEAD OR ALIVE 2")
+- **Game ID and title.** PS1, PS2, PSP, and Dreamcast serials are read from CHD sector data (SYSTEM.CNF, PARAM.SFO, IP.BIN) and shown in the info modal, with human-readable titles when available (for example "Patapon", "DEAD OR ALIVE 2")
 
 **CHD Metadata Cache**
 - Background metadata scan with CD/DVD badges
-- **Retroactive game ID tagging** — scan embeds `GAME` and `NAME` metadata tags into existing CHDs that don't have them yet; future scans skip already-tagged files
+- **Retroactive game ID tagging.** The scan writes `GAME` and `NAME` tags into existing CHDs that lack them. Later scans skip files that are already tagged
 - "Scan Metadata" and "Force Rescan" actions to refresh cached metadata
 - Cache stored in `/config/chd_metadata.json`
 
@@ -381,7 +381,7 @@ Dolphin support is available in the Web UI and REST API (CLI mode remains CHDMAN
 | `Z3DS_COMPRESSOR_PATH` | `/usr/local/bin/z3ds_compressor` | Path to z3ds_compressor binary |
 | `MAMEREDUMP_REPO` | `MetalSlug/MAMERedump` | GitHub repo for DAT sync |
 | `MAMEREDUMP_AUTO_SYNC` | `false` | Auto-sync DATs on startup if none loaded |
-| `MAMEREDUMP_GITHUB_TOKEN` | *(unset)* | Optional GitHub PAT — raises API rate limit from 60 to 5 000 req/hr for DAT sync |
+| `MAMEREDUMP_GITHUB_TOKEN` | *(unset)* | Optional GitHub PAT that raises the API rate limit from 60 to 5,000 req/hr for DAT sync |
 
 ### REST API Endpoints
 
@@ -608,7 +608,7 @@ The Web UI communicates with a REST API that can also be used directly. Interact
 | `CHD_VERIFY_PROGRESS_TIMEOUT` | `0` | Timeout in seconds without verify output (0 disables) |
 | `LOGLEVEL` | `INFO` | Log verbosity level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) |
 | `LOG_PATH` | (none) | Path to log file (logs to stdout only if unset) |
-| `LOG_COLOR` | `always` | ANSI-color stdout logs by level. Values: `always` (default — colored `docker logs` out of the box), `auto` (TTY + no `NO_COLOR`), `never`. File logs are never colored. |
+| `LOG_COLOR` | `always` | ANSI-color stdout logs by level. Values: `always` (default, colored `docker logs` out of the box), `auto` (TTY and no `NO_COLOR`), `never`. File logs are never colored. |
 | `CHD_DEBUG_HEARTBEAT` | `30` | Maintenance loop interval in seconds |
 | `CHD_DEBUG_PROGRESS_INTERVAL` | `30` | Debug progress log interval in seconds |
 | `CHD_DEBUG_PROGRESS_TIMEOUT` | `300` | Debug progress timeout in seconds |
@@ -638,7 +638,7 @@ The `/config` volume is **required** and must be mounted for the application to 
 
 #### First-run migration from JSON
 
-On first startup after upgrading from a JSON-backed install, the app automatically imports `dat_store.json`, `verified_chds.json`, `chd_metadata.json`, and `dat_sync.json` into the new SQLite database. The originals are renamed to `<name>.migrated.bak` — **never deleted** — so you can always roll back. Migration is transactional, idempotent, and validates row counts; a failed or corrupt file is quarantined (`.corrupt` suffix) without blocking the other stores. These migration guarantees are described above in this section.
+On the first startup after upgrading from a JSON-backed install, the app imports `dat_store.json`, `verified_chds.json`, `chd_metadata.json`, and `dat_sync.json` into the new SQLite database. The originals are renamed to `<name>.migrated.bak` and never deleted, so you can always roll back. Migration is transactional, idempotent, and checks row counts. A failed or corrupt file is quarantined with a `.corrupt` suffix and the other stores still migrate.
 
 #### Schema changes (for developers)
 
@@ -656,7 +656,7 @@ scripts/new_migration.sh "add foo column to dats"
 # commit the new migration alongside your ORM changes
 ```
 
-The test `test_no_model_drift_after_upgrade` fails if `Base.metadata` drifts from the migration chain — it runs on every test run and catches forgotten migrations.
+The test `test_no_model_drift_after_upgrade` fails if `Base.metadata` drifts from the migration chain. It runs on every test run and catches forgotten migrations.
 
 ### Ephemeral Runtime Data
 
@@ -767,7 +767,7 @@ For production deployment guidance, see [DEPLOYMENT.md](DEPLOYMENT.md).
 
 ## Frontend Development
 
-The Web UI is a **Svelte 5 + Vite** single-page app. Source lives under `src/`, the build pipeline emits `index.html` plus hashed assets into `static/`, and FastAPI serves the result via the existing `/static` mount and root `FileResponse`. Source code follows the architecture documented in `DESIGN_tool_plugin_architecture.md` §3.7 — a declarative tool registry (`src/lib/tools/registry.js`) drives every tool-specific decision so adding a new converter is one entry in `TOOLS`, no `if (tool === ...)` branches anywhere.
+The Web UI is a **Svelte 5 + Vite** single-page app. Source lives under `src/`, the build emits `index.html` plus hashed assets into `static/`, and FastAPI serves the result through the `/static` mount and a root `FileResponse`. The code follows the architecture in `DESIGN_tool_plugin_architecture.md` §3.7. A declarative tool registry (`src/lib/tools/registry.js`) drives every tool-specific decision, so adding a converter is one entry in `TOOLS` with no `if (tool === ...)` branches anywhere.
 
 ### Quick start
 
@@ -789,26 +789,26 @@ Vite proxies `/api` and `/health` to `http://localhost:8080`, so the dev server 
 ```bash
 npm run build       # Vite production build → static/index.html + static/assets/*
 npm run preview     # Serve the built bundle locally on :4173
-npm run lint        # ESLint (JS + .svelte) — flat config in eslint.config.js
+npm run lint        # ESLint (JS + .svelte), flat config in eslint.config.js
 ```
 
 ### Architecture at a glance
 
-* `src/App.svelte` — root shell: sidebar + topbar + routed view, error boundary, focus management on route change, skip-to-content link, mounts `<ModeWatcher />` (theme) and `<Toaster />` (notifications).
-* `src/lib/stores/*.svelte.js` — class-singleton stores with Svelte 5 `$state` fields, one per feature domain (jobs / fileBrowser / conversion / verification / datMatching / chdMetadata / ui).
-* `src/lib/api/` — REST client + auto-reconnecting EventSource (`sse.js`) + POST-body SSE stream parser for batch verify (`sseFetch.js`). Backend snapshot-on-connect (`/api/jobs/events`) hydrates the full job state; no separate REST round-trip needed.
-* `src/lib/tools/registry.js` — every tool fact (id, label, hint, verify URL segment, source/verify exts, modes, groups, default mode, glyph, accent, **compression codecs / style / level range**, API bindings). Adding a 4th tool: one new entry + the backend plugin. Helpers like `registry.allFilterableExts()` keep UI surfaces (file-list filter dropdown, conversion mode dropdown, compression picker, etc.) automatically extended.
-* `src/lib/components/panels/` — `VolumeList`, `Breadcrumb`, `FileList`, `FileRow`, `RowActionsMenu` (file browser); `ModeSelect`, `CompressionPicker`, `ConvertPanel` (conversion config); `JobRow`, `JobsPanel` (queue / completed / failed tabs with global Cancel-all / Clear / stuck-state recovery).
-* `src/lib/components/modals/` — `BaseModal` (bits-ui Dialog wrapper), `ConfirmModal` (canonical confirm/cancel), then `BulkVerifyModal`, `DuplicateModal`, `DeleteModal`, `BulkDeleteModal`, `RenameModal`, `CHDInfoModal`, `CancelAllJobsModal`, `ClearDoneModal`. Each mounts in `App.svelte` and self-renders against a `ui` store target.
-* `src/lib/components/dashboard/` — `StatCard` wrapper + `QueueSummaryCard`, `VolumeOverviewCard`, `RecentConversionsCard`, `VerificationStatusCard`, `QuickToolsCard`. QuickToolsCard iterates `registry.all()` — adding a tool auto-adds a tile.
-* `src/styles/tokens.css` — semantic design tokens keyed by `:root` (light defaults) and `:root.dark` (dark overrides). No hex colors live outside this file.
+* `src/App.svelte`: the root shell. Sidebar, topbar, routed view, error boundary, focus management on route change, skip-to-content link, and the `<ModeWatcher />` (theme) and `<Toaster />` (notifications) mounts.
+* `src/lib/stores/*.svelte.js`: class-singleton stores with Svelte 5 `$state` fields, one per feature domain (jobs / fileBrowser / conversion / verification / datMatching / chdMetadata / ui).
+* `src/lib/api/`: REST client, auto-reconnecting EventSource (`sse.js`), and a POST-body SSE stream parser for batch verify (`sseFetch.js`). Backend snapshot-on-connect (`/api/jobs/events`) hydrates the full job state, so there's no separate REST round-trip.
+* `src/lib/tools/registry.js`: every tool fact (id, label, hint, verify URL segment, source/verify exts, modes, groups, default mode, glyph, accent, **compression codecs / style / level range**, API bindings). Adding a fourth tool is one new entry plus the backend plugin. Helpers like `registry.allFilterableExts()` keep UI surfaces (file-list filter dropdown, conversion mode dropdown, compression picker, and so on) extended automatically.
+* `src/lib/components/panels/`: `VolumeList`, `Breadcrumb`, `FileList`, `FileRow`, `RowActionsMenu` (file browser); `ModeSelect`, `CompressionPicker`, `ConvertPanel` (conversion config); `JobRow`, `JobsPanel` (queue / completed / failed tabs with global Cancel-all / Clear / stuck-state recovery).
+* `src/lib/components/modals/`: `BaseModal` (bits-ui Dialog wrapper), `ConfirmModal` (canonical confirm/cancel), then `BulkVerifyModal`, `DuplicateModal`, `DeleteModal`, `BulkDeleteModal`, `RenameModal`, `CHDInfoModal`, `CancelAllJobsModal`, `ClearDoneModal`. Each mounts in `App.svelte` and self-renders against a `ui` store target.
+* `src/lib/components/dashboard/`: `StatCard` wrapper plus `QueueSummaryCard`, `VolumeOverviewCard`, `RecentConversionsCard`, `VerificationStatusCard`, `QuickToolsCard`. QuickToolsCard iterates `registry.all()`, so adding a tool auto-adds a tile.
+* `src/styles/tokens.css`: semantic design tokens keyed by `:root` (light defaults) and `:root.dark` (dark overrides). No hex colors live outside this file.
 
 ### Runtime dependencies
 
-* [`@lucide/svelte`](https://lucide.dev) — official Lucide icon library for Svelte 5 runes, tree-shakeable per icon.
-* [`bits-ui`](https://bits-ui.com) — headless accessibility primitives (Dialog, DropdownMenu, ContextMenu, Tooltip, etc.). Used incrementally as panels need them; per-component import keeps bundle costs minimal.
-* [`svelte-sonner`](https://svelte-sonner.vercel.app) — toast notifications. Call `toast.success(...)` / `toast.error(...)` / `toast.promise(...)` from anywhere; the `<Toaster />` in `App.svelte` is the surface.
-* [`mode-watcher`](https://mode-watcher.sveco.dev) — light/dark/system mode management with localStorage persistence, system-preference tracking, and cross-tab sync. Applies `.dark` class to `<html>`; a matching inline script in `index.html` prevents FOUC on first paint.
+* [`@lucide/svelte`](https://lucide.dev): the official Lucide icon library for Svelte 5 runes, tree-shakeable per icon.
+* [`bits-ui`](https://bits-ui.com): headless accessibility primitives (Dialog, DropdownMenu, ContextMenu, Tooltip, and so on). Pulled in per component as panels need them, which keeps the bundle small.
+* [`svelte-sonner`](https://svelte-sonner.vercel.app): toast notifications. Call `toast.success(...)` / `toast.error(...)` / `toast.promise(...)` from anywhere. The `<Toaster />` in `App.svelte` is the surface.
+* [`mode-watcher`](https://mode-watcher.sveco.dev): light/dark/system mode with localStorage persistence, system-preference tracking, and cross-tab sync. It adds the `.dark` class to `<html>`, and a matching inline script in `index.html` prevents a flash of the wrong theme on first paint.
 
 ### Docker / CI
 
@@ -826,4 +826,4 @@ This project is a fork of the original Docker CHD Converter project by [MarcTV](
 **Additional Tools:**
 - [z3ds_compress](https://github.com/energeticokay/z3ds_compress) by [energeticokay](https://github.com/energeticokay) - Nintendo 3DS ROM compression
 
-Thank you MarcTV and energeticokay for creating and sharing these tools!
+Thanks to MarcTV and energeticokay for building and sharing these tools.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,12 +4,12 @@
 
 ### Resizable panels and table columns (#120)
 
-#### ✨ New
+#### New
 
 - **The workspace layout is now adjustable.** Drag the divider between the file list and the right Convert/Jobs panel to give the table more room, and drag individual table column borders (Name, Size, Ext, Status) to size them how you like. Double-click a divider or column border to reset it. The handles are keyboard-accessible too (focus, then arrow keys; Enter or Home resets).
 - **Widths are remembered on the server.** Layout preferences persist through a browser or cache wipe and follow you across browsers. This is the first server-stored preference; everything else still lives in localStorage. The panel split is shared, while column widths are kept per tool (chdman / dolphin / z3ds) since each lists different file types.
 
-#### 🔧 Internal
+#### Internal
 
 - New generic `preferences` key/value table (Alembic migration `0002`, idempotent) with a `PreferencesStore` service and `GET`/`PUT /api/preferences`. Single-user, no auth. Reusable for future preferences.
 - A `layout` store loads localStorage synchronously on boot (no flash), reconciles with the server, and writes both back debounced. A dirty flag plus a mutation-version guard keep an in-flight server sync from clobbering a width the user just changed, and keep an unsaved edit from being lost on tab close.
@@ -19,7 +19,7 @@
 
 ### Visible Actions header (#119)
 
-#### ✨ Changed
+#### Changed
 
 - **The file table's Actions column has a visible header.** It was a screen-reader-only label before; now it reads "Actions" like the other column headers.
 
@@ -27,13 +27,13 @@
 
 ### Search all: instant feedback + clear label (#118)
 
-#### 🐛 Fixed
+#### Fixed
 
 - **"Search all" now reacts the instant you click it.** The recursive scan (which walks into archives and can take a few seconds) ran with no loading state, so the button sat silent until results came back. It now flips to a spinner with "Searching…" the moment you click and disables itself while the scan runs, matching the Refresh button. This restores the immediate feedback the old Preact UI had.
 - **The button says what it does.** Replaced the bare folder-search icon with a labelled "Search all" button, so it's no longer a guess.
 - **Stale error banner no longer survives a search.** `_enterSearch` now clears `entriesError` on entry, the same as the directory load paths. A failed search used to leave the error banner up through a retry and even past a later successful search.
 
-#### 🔧 Internal
+#### Internal
 
 - "Search all" uses the shared `Button` component instead of a one-off `<button>` with hand-rolled hover/focus/disabled CSS. The spinner is driven through the `icon` snippet because `Button`'s `loading` prop only dims and changes the cursor.
 - Overlapping `_enterSearch` calls are dropped with an early return, so a finishing request can't clear the busy flag while a later one is still running.
@@ -43,11 +43,11 @@
 
 ### In-app Help content
 
-#### ✨ New
+#### New
 
 - **The Help view is no longer a placeholder.** It now covers the whole workflow end to end: picking a tool, browsing and Search All, a full mode reference per tool, the compression codecs and the zlib / AetherSX2 gotcha, where output lands and the skip / rename / overwrite choice, the job queue, the verify-then-delete safety flow, the CHD inspector, DAT matching, archive conversion, a troubleshooting list, an FAQ for the common edge cases, and how to file bugs and feature requests. All of it written to match the app, not the README.
 
-#### 🔧 Internal
+#### Internal
 
 - **Repo links live in one place.** Added `repository`, `bugs`, and `homepage` to `package.json`. The Help view's GitHub and issues links are derived from those fields with a tree-shaken named import, so moving the repo is a one-line change instead of a hunt through hardcoded URLs.
 
@@ -55,17 +55,17 @@
 
 ### Sidebar: full title + relocated collapse control
 
-#### 🐛 Fixed
+#### Fixed
 
 - **Brand title no longer truncates.** The "Compressatorium" wordmark was being clipped to an ellipsis in the sidebar; `.brand-text` now keeps its full width (no `flex-shrink`, no `overflow`/ellipsis clamp) and fits within the existing 240px rail.
 
-#### ✨ Changed
+#### Changed
 
-- **Collapse toggle promoted to its own section.** The sidebar collapse / expand control moved out of the brand row into a dedicated, full-width labelled row (`Collapse sidebar` / `Expand sidebar`) below the Tool list, set off by a divider — far more visible than the small icon previously tucked beside the logo. Relocating it freed the horizontal space the title needed, so the sidebar width is unchanged at 240px.
+- **Collapse toggle promoted to its own section.** The sidebar collapse / expand control moved out of the brand row into a dedicated, full-width labelled row (`Collapse sidebar` / `Expand sidebar`) below the Tool list, set off by a divider, far more visible than the small icon previously tucked beside the logo. Relocating it freed the horizontal space the title needed, so the sidebar width is unchanged at 240px.
 
 ### Archive conversion test coverage (#117)
 
-#### 🔧 Internal
+#### Internal
 
 - New `tests/test_archive_conversion_e2e.py` exercises end-to-end archive conversion across every supported source extension, locking in the issue #113 fix. `.gcm` dropped from the README's supported-format list.
 
@@ -73,34 +73,34 @@
 
 ### Live job toasts + one-click Search all
 
-#### ✨ New
+#### New
 
-- **Live toast for every running job.** A new `jobToasts` tracker surfaces a svelte-sonner loading toast for each job in the `processing` state, keyed by job id, and resolves it to success / error / cancelled when the job reaches a terminal state. A single reconcile `$effect` in `App.svelte` drives it off `jobs.jobs`, so jobs restored from a snapshot/poll and jobs started by *other* clients get a toast too — not just ones queued in the current tab. External-scan modes (`metadata_scan` / `dat_match`) are excluded unless the user has opted to show them, matching the queue's default visibility.
+- **Live toast for every running job.** A new `jobToasts` tracker surfaces a svelte-sonner loading toast for each job in the `processing` state, keyed by job id, and resolves it to success / error / cancelled when the job reaches a terminal state. A single reconcile `$effect` in `App.svelte` drives it off `jobs.jobs`, so jobs restored from a snapshot/poll and jobs started by *other* clients get a toast too, not just ones queued in the current tab. External-scan modes (`metadata_scan` / `dat_match`) are excluded unless the user has opted to show them, matching the queue's default visibility.
 - **One-click "Search all" restored.** The Preact UI had a one-click action that recursively listed every convertible file under the current folder (including inside archives); the Svelte rebuild had gated the recursive scan behind a text query, so an empty query just exited search. A `FolderSearch` toolbar button now runs the all-files scan (empty filter = show everything), and a forced refresh re-runs it while in that view.
 
-#### 🐛 Fixed
+#### Fixed
 
 - **Correct empty-string toast description.** `runningDescription` used `pct ?? lead ?? 'Processing…'`, but `''` is not nullish, so a job with no message and an unrecognised mode produced a blank description. Truthiness fallbacks now land on the percentage or `Processing…` instead.
 
-#### 🔧 Internal
+#### Internal
 
 - `jobToasts` uses null-prototype object maps (non-reactive): the reconcile effect both reads and writes the collection, so a `SvelteMap` would loop; the plain object map is also `svelte/prefer-svelte-reactivity` clean.
 - Optional chaining on job props in the `App.svelte` reactivity loop, matching reconcile's defensive `job?.id`.
 
 ### Archive conversion for every tool (issue #113)
 
-#### 🐛 Fixed
+#### Fixed
 
-- **Convert any supported file from inside an archive.** A `.zip` (or `.7z`/`.rar`) containing 3DS ROMs previously showed nothing to convert — the archive listing only recognised CHDMAN source extensions, and only CHDMAN create modes accepted archive members. Now every convertible *source* is surfaced and convertible from inside an archive: CHDMAN (`.gdi`/`.iso`/`.cue`/`.bin`), Dolphin (`.iso`/`.gcz`/`.wia`/`.rvz`/`.wbfs`), and 3DS (`.cci`/`.cia`/`.3ds`). CHDMAN extract/copy modes stay archive-disabled because they act on a finished `.chd` (an output, not a source).
+- **Convert any supported file from inside an archive.** A `.zip` (or `.7z`/`.rar`) containing 3DS ROMs previously showed nothing to convert, the archive listing only recognised CHDMAN source extensions, and only CHDMAN create modes accepted archive members. Now every convertible *source* is surfaced and convertible from inside an archive: CHDMAN (`.gdi`/`.iso`/`.cue`/`.bin`), Dolphin (`.iso`/`.gcz`/`.wia`/`.rvz`/`.wbfs`), and 3DS (`.cci`/`.cia`/`.3ds`). CHDMAN extract/copy modes stay archive-disabled because they act on a finished `.chd` (an output, not a source).
 - **Correct output extension for 3DS archive members.** z3ds derives its output extension from the input (`.3ds`→`.z3ds`, `.cci`→`.zcci`, `.cia`→`.zcia`); archive members now preserve their original extension through path routing so the mapping is right (previously they would have defaulted to `.zcci`).
 
-#### 🔧 Internal
+#### Internal
 
 - Archive listing is driven by the tool registry (`registry.archive_input_extensions()`) instead of a hardcoded set, so it stays in lockstep with the on-disk directory view and with the `allows_archive_input` mode flags.
 - `allows_archive_input` is now set on every convertible-source mode (Dolphin + 3DS, alongside CHDMAN create); the frontend tool registry mirrors the same flags.
 - New `ArchiveService._output_name_for_member()` keeps the member's extension on the flattened output name; CHDMAN/Dolphin strip it via `Path.stem`, leaving their output paths unchanged.
 
-## 4.0.0-beta-1 — Svelte 5 frontend rebuild (2026-05-29)
+## 4.0.0-beta-1: Svelte 5 frontend rebuild (2026-05-29)
 
 The first beta of the rebuilt frontend. Backend / REST / SSE contract
 unchanged; the whole `static/js/app.js` Preact-via-htm monolith is
@@ -116,22 +116,22 @@ bits-ui, svelte-sonner, mode-watcher).
 
 ### Duplicate-output preflight (P7 part 2)
 
-#### ✨ New
+#### New
 
-- **DuplicateModal preflight.** ConvertPanel now runs `conversion.checkDuplicates(paths)` before each submit. If the backend reports any output collision (`d.exists === true`), the dialog opens with the conflict list and three choices: Cancel, Skip duplicates, Overwrite all. Resolution flows back into `conversion.submit(paths, { duplicateAction })` via a per-submit `Promise` resolver — no global pending-state to leak. No collisions → submit fires straight through, no modal.
+- **DuplicateModal preflight.** ConvertPanel now runs `conversion.checkDuplicates(paths)` before each submit. If the backend reports any output collision (`d.exists === true`), the dialog opens with the conflict list and three choices: Cancel, Skip duplicates, Overwrite all. Resolution flows back into `conversion.submit(paths, { duplicateAction })` via a per-submit `Promise` resolver, no global pending-state to leak. No collisions → submit fires straight through, no modal.
 
-#### 🔧 Internal
+#### Internal
 
 - Duplicate-modal state lives entirely inside ConvertPanel as a `$state` resolver-or-null. Opening sets the resolver; the modal's `onResolve` callback nulls it and resolves the awaited promise. Avoids stale-prompt bugs when the user submits, cancels, and re-submits.
 
 ### DAT view + dashboard cards (P7/P8)
 
-#### ✨ New
+#### New
 
 - **DAT view shipped.** `src/lib/components/views/DATView.svelte` exposes Import DAT (file picker → `api.importDAT`), Sync MAMERedump (with a 2 s poll loop that auto-stops when `syncStatus.syncing` flips false), per-DAT delete, and a stats strip (total DATs / entries / cached matches). The view drives the existing `datMatching` store; the FileList badges that the store already powers light up once imports complete.
-- **Dashboard shipped.** Five cards composed via a generic `StatCard` wrapper: `QueueSummaryCard` (queued / active / done / failed counts + stuck-state badge), `VolumeOverviewCard` (top 4 volumes + file counts), `RecentConversionsCard` (last 5 terminal jobs across any tool), `VerificationStatusCard` (cached verified count + in-flight batch), `QuickToolsCard` (one tile per registered tool, deep-links to `#/workspace/<tool>` — adding a 4th tool surfaces a 4th tile automatically).
+- **Dashboard shipped.** Five cards composed via a generic `StatCard` wrapper: `QueueSummaryCard` (queued / active / done / failed counts + stuck-state badge), `VolumeOverviewCard` (top 4 volumes + file counts), `RecentConversionsCard` (last 5 terminal jobs across any tool), `VerificationStatusCard` (cached verified count + in-flight batch), `QuickToolsCard` (one tile per registered tool, deep-links to `#/workspace/<tool>`, adding a 4th tool surfaces a 4th tile automatically).
 
-#### 🔧 Internal
+#### Internal
 
 - `datMatching` store gains `dats`, `datsLoading`, `datsError`, `stats` $state fields + `loadDATs()`. The duplicate `importDAT` definition is removed; the kept version refreshes the DATs list (not just hasDats) after import.
 - `StatCard` exposes `title`, `subtitle`, `icon` / `body` / `footer` snippets, and a `--card-accent` CSS variable so each tile can take its own accent color without per-tile style overrides.
@@ -139,28 +139,28 @@ bits-ui, svelte-sonner, mode-watcher).
 
 ### Confirmation + file modals (P7 part 1)
 
-#### ✨ New
+#### New
 
 - **Modal foundation.** `BaseModal.svelte` wraps bits-ui Dialog with shared chrome (header, title, close, description, footer); `ConfirmModal.svelte` provides the standard confirm/cancel pattern. All future modals slot into these via `{#snippet body()}` / `{#snippet footer()}`.
 - **DeleteModal + BulkDeleteModal.** The Delete action in `RowActionsMenu` now opens a destructive-styled confirm dialog; the "Delete" bulk-action in FileList's selection bar opens the bulk version (preview list capped at 20 rows + tail counter, calls `api.deleteBatch`). Both refresh the file listing on success.
 - **RenameModal.** RowActionsMenu Rename opens a file-name input pre-populated with the current name (Enter submits, Esc cancels, bits-ui Dialog handles focus-trap).
-- **CHDInfoModal.** RowActionsMenu Info opens a dialog that calls `tool.getInfo(path)` via `registry.toolForVerifyPath` — no `if (tool === 'chdman')` chains, works for `.chd` / `.rvz` / `.z3ds` identically. Renders the backend payload as a labelled key/value list with JSON pretty-print for nested objects.
+- **CHDInfoModal.** RowActionsMenu Info opens a dialog that calls `tool.getInfo(path)` via `registry.toolForVerifyPath`, no `if (tool === 'chdman')` chains, works for `.chd` / `.rvz` / `.z3ds` identically. Renders the backend payload as a labelled key/value list with JSON pretty-print for nested objects.
 - **CancelAllJobsModal + ClearDoneModal.** Replace the inline `window.confirm()` calls in JobsPanel. The Cancel-all dialog reports the queued+processing count; the Clear dialog reports the completed+failed+cancelled count. Both bind their busy state to the store flags so the buttons disable mid-action.
 
-#### 🔧 Internal
+#### Internal
 
 - New `src/lib/components/modals/` (BaseModal, ConfirmModal, BulkVerifyModal, BulkDeleteModal, DeleteModal, RenameModal, CHDInfoModal, CancelAllJobsModal, ClearDoneModal). Each modal mounts via App.svelte and self-renders against a `ui` store target (`ui.deleteTarget`, `ui.bulkDeleteEntries`, `ui.renameTarget`, `ui.chdInfoTarget`, `ui.showCancelAll`, `ui.showClearDone`, `ui.bulkVerifyItems`).
-- `JobsPanel.handleCancelAll` / `handleClearCompleted` now just toggle `ui.show*` flags instead of running their own try/catch — the modal owns the confirmation + success/error toast.
+- `JobsPanel.handleCancelAll` / `handleClearCompleted` now just toggle `ui.show*` flags instead of running their own try/catch, the modal owns the confirmation + success/error toast.
 
 ### Verify flows (P6)
 
-#### ✨ New
+#### New
 
 - **Single + batch verify shipped.** `RowActionsMenu` already routed Verify to `verification.verifyOne(toolId, path)` via `registry.toolForVerifyPath`; P6 adds the batch flow. The new `BulkVerifyModal` (bits-ui Dialog) opens from a "Verify selected" button in the FileList selection bar. It groups the selection by tool (`.chd` → chdman, `.rvz/.wia/.gcz/.wbfs` → dolphin, `.z3ds/.zcci/.zcia` → z3ds), runs each group as a back-to-back batch, shows live per-file progress + an overall counter, and supports mid-run cancel via `verification.cancelBatch()` (AbortController).
 - **Verified set rehydrates on reload.** `App.svelte` calls `verification.loadVerified()` on mount so `OK` badges and the delete-on-verify gate survive a page refresh.
-- **Selection bulk-action bar.** FileList's selection bar gains `Verify` (hidden when none of the selected files have a verify-extension match — registry-driven) and `Delete` actions; the Delete action sets `ui.bulkDeleteEntries` for the P7 modal to consume.
+- **Selection bulk-action bar.** FileList's selection bar gains `Verify` (hidden when none of the selected files have a verify-extension match, registry-driven) and `Delete` actions; the Delete action sets `ui.bulkDeleteEntries` for the P7 modal to consume.
 
-#### 🔧 Internal
+#### Internal
 
 - New `src/lib/components/modals/` directory; mounted via App.svelte so any panel can launch a modal by writing to a `ui` target (`ui.bulkVerifyItems`, `ui.bulkDeleteEntries`, etc.). bits-ui Dialog handles focus-trap / Escape / overlay-click for free.
 - The bulk-verify dialog tracks its own `running` / `groupIndex` / `runResults` state and uses `verification.batchRun` for the in-flight per-file progress payload (`done`, `currentPath`, `currentFilename`, `currentPercent`, `message`).
@@ -168,36 +168,36 @@ bits-ui, svelte-sonner, mode-watcher).
 
 ### Conversion config + job queue (P5)
 
-#### ✨ New
+#### New
 
 - **P5 conversion config + job queue shipped.** `ModeSelect`, `CompressionPicker`, `ConvertPanel`, `JobRow`, `JobsPanel`, `RowActionsMenu` components under `src/lib/components/panels/`. Pick mode (grouped by tool/group label from registry), pick compression (chdman: chip-multi; Dolphin: single codec + numeric level via codec metadata in registry; z3ds: nothing rendered), set output directory, toggle delete-on-verify, submit. Live progress, queue/completed/failed tabs with badge counts, per-row Cancel / Dismiss, global Cancel all + Clear, stuck-state banner with Recover action, "Show metadata jobs" toggle persists.
-- **Per-row file actions menu.** `bits-ui` DropdownMenu drives the FileRow `⋯` button: Info / Verify / Rename / Delete with keyboard-accessible focus management. Verify wires through `verification.verifyOne(toolId, path)` via registry lookup (`registry.toolForVerifyPath(path)`) — no tool-specific branches. Rename / Delete set `ui.renameTarget` / `ui.deleteTarget` for the modals to be wired in P7.
+- **Per-row file actions menu.** `bits-ui` DropdownMenu drives the FileRow `⋯` button: Info / Verify / Rename / Delete with keyboard-accessible focus management. Verify wires through `verification.verifyOne(toolId, path)` via registry lookup (`registry.toolForVerifyPath(path)`), no tool-specific branches. Rename / Delete set `ui.renameTarget` / `ui.deleteTarget` for the modals to be wired in P7.
 - **Codec metadata in the registry.** Each tool descriptor now declares its `compressionCodecs`, `compressionStyle` (`'multi'` | `'single-with-level'` | `'none'`), and optional `compressionLevelRange`. `CompressionPicker` reads this and renders the right control with zero `if (tool === ...)` checks. chdman: 5 codecs as chips (zlib / lzma / lzma2 / flac / cdfl), comma-joined. Dolphin: 4 codecs + "no compression" via dropdown plus 1–22 level slider (default 19, MAME Redump). z3ds: control hidden.
 
-#### 🔧 Internal
+#### Internal
 
-- `conversion.svelte.js` gains `toggleCodec(codec)` (chdman chip toggle, with `'none'` mutex) and `setSingleCodec(codec)` (Dolphin) — clean store API for the picker.
+- `conversion.svelte.js` gains `toggleCodec(codec)` (chdman chip toggle, with `'none'` mutex) and `setSingleCodec(codec)` (Dolphin), clean store API for the picker.
 - `JobsPanel` consumes `jobs.pageJobs`, `jobs.queuedCount + jobs.processingCount`, etc. directly from the store so the rune-graph tracks updates without intermediate `$state` mirrors.
 - `bind:checked={() => jobs.showExternalScanJobs, (v) => jobs.setShowExternalScanJobs(v)}` uses Svelte 5.9+ function bindings to drive the metadata-jobs toggle through the store setter (which persists to localStorage).
 - `RowActionsMenu` styles its bits-ui primitives via `:global(...)` selectors keyed off the `[data-highlighted]` / `[data-disabled]` attributes the headless components emit.
 - `FileRow` drops its inline `.actions-trigger` styles; `RowActionsMenu` owns them now.
 
-#### 📚 Documentation
+#### Documentation
 
-- `README.md` — Frontend Development section reflects the conversion config + job queue.
-- `AGENTS.md` — adds "Per-row actions live in `RowActionsMenu.svelte`" pointer.
+- `README.md`, Frontend Development section reflects the conversion config + job queue.
+- `AGENTS.md`, adds "Per-row actions live in `RowActionsMenu.svelte`" pointer.
 
 ### File browser + library adoptions (Lucide, Bits UI, svelte-sonner, mode-watcher) (P4)
 
-#### ✨ New
+#### New
 
-- **P4 file browser shipped.** `VolumeList` / `Breadcrumb` / `FileList` / `FileRow` / `ConvertPanel` / `JobsPanel` components under `src/lib/components/panels/`, all driven by the existing `fileBrowser` store. Sort, filter (extension list derived from `registry.allFilterableExts()`), paginate, shift-click range select, click-to-navigate folders, click-to-enter archives — works end-to-end. ConvertPanel + JobsPanel are placeholders for P5.
+- **P4 file browser shipped.** `VolumeList` / `Breadcrumb` / `FileList` / `FileRow` / `ConvertPanel` / `JobsPanel` components under `src/lib/components/panels/`, all driven by the existing `fileBrowser` store. Sort, filter (extension list derived from `registry.allFilterableExts()`), paginate, shift-click range select, click-to-navigate folders, click-to-enter archives, works end-to-end. ConvertPanel + JobsPanel are placeholders for P5.
 - **Lucide Svelte icons** replace every Unicode glyph placeholder. ThemeToggle finally has unambiguous Sun / Moon / Monitor icons; FileRow uses Disc / Disc3 / Gamepad2 / Archive / Folder; etc.
-- **Bits UI** added as a dependency (no components in use yet — reserved for P5 DropdownMenu/ContextMenu row actions and P7 modal Dialog).
+- **Bits UI** added as a dependency (no components in use yet, reserved for P5 DropdownMenu/ContextMenu row actions and P7 modal Dialog).
 - **svelte-sonner** replaces the hand-rolled `Notification.svelte`. Call `toast.success/error/info/warning(...)` from any store; the `<Toaster />` lives in `App.svelte`. Brings rich color, swipe-to-dismiss, keyboard support, multi-toast queueing for free.
 - **mode-watcher** replaces the hand-rolled theme state in `ui.svelte.js`. Cross-tab sync, system-preference tracking, `color-scheme` style management, and the dark/light class on `<html>` all delegated. The inline FOUC-prevention script in `index.html` uses the same storage key (`theme-preference`) for parity with the legacy frontend.
 
-#### 🔧 Internal
+#### Internal
 
 - `src/styles/tokens.css` selectors migrated from `[data-theme="light"|"dark"]` to `:root` (light defaults) + `:root.dark` (mode-watcher's class convention).
 - `ui.svelte.js` deletes ~70 lines: `theme` / `systemIsDark` / `resolvedTheme` / `setTheme` / `cycleTheme` / `applyTheme` / `notification` / `notify` / `dismissNotification`. `reportConnection` rewritten to use `toast.warning` (sticky) + `toast.dismiss(id)` + `toast.success` for the SSE reconnect flow.
@@ -205,42 +205,42 @@ bits-ui, svelte-sonner, mode-watcher).
 - `registry.allSourceExts()`, `registry.allVerifyExts()`, `registry.allFilterableExts()` added so the file-list filter dropdown is now extensible by registry edit alone.
 - `ConvertPanel.svelte` + `JobsPanel.svelte` extracted from `WorkArea.svelte` so P5 can fill them in without touching the layout.
 
-#### 📚 Documentation
+#### Documentation
 
-- `README.md` — Frontend Development section lists the adopted runtime libraries.
-- `AGENTS.md` — explicit "don't reinvent these" list with import patterns for the four libraries.
+- `README.md`, Frontend Development section lists the adopted runtime libraries.
+- `AGENTS.md`, explicit "don't reinvent these" list with import patterns for the four libraries.
 
 ### Svelte 5 frontend rebuild (P0–P3)
 
-#### ✨ New
+#### New
 
 - **Frontend rebuilt on Svelte 5 + Vite.** The 6,096-line Preact-via-htm monolith (`static/js/app.js`) is replaced by a Svelte 5 SPA under `src/`. Per-domain class-singleton stores with `$state` class fields (jobs, fileBrowser, conversion, verification, datMatching, chdMetadata, ui), one declarative `TOOLS` array in `src/lib/tools/registry.js` that drives every tool-specific decision, design tokens (`src/styles/tokens.css`) with `light` / `dark` / `system` themes, sidebar + dashboard layout with deep-linkable hash routes, mobile drawer + `inert` focus trap, skip-to-content link and `<main>` focus management on route change, error boundary around routed views.
-- **Backend SSE snapshot-on-connect.** `/api/jobs/events` now emits a one-time `snapshot` event per known job at connection time (and re-emits on every reconnect). Eliminates the hydration race that existed when clients had to do a separate `/api/jobs` fetch before subscribing. Additive change — legacy clients that don't listen for `snapshot` silently ignore it.
+- **Backend SSE snapshot-on-connect.** `/api/jobs/events` now emits a one-time `snapshot` event per known job at connection time (and re-emits on every reconnect). Eliminates the hydration race that existed when clients had to do a separate `/api/jobs` fetch before subscribing. Additive change, legacy clients that don't listen for `snapshot` silently ignore it.
 - **Docker `frontend-builder` stage.** New `node:lts-slim` stage runs `npm ci && npm run build`; the runtime image stays Python-only. The existing multi-arch buildx pipeline (`linux/amd64` + `linux/arm64`) works unchanged because `node:lts-slim` ships both arches and the SPA has no native deps.
 
-#### 🔧 Internal
+#### Internal
 
 - Legacy frontend removed: `static/js/app.js` (6,096 lines), `static/js/api.js` (874 lines), `static/css/style.css` (2,424 lines), `static/vendor/*.mjs` (Preact + htm bundles). Git history preserves them.
 - New `npm run dev` / `npm run build` / `npm run preview` / `npm run lint` scripts. Vite dev server proxies `/api` and `/health` to the FastAPI sidecar.
 - ESLint flat config extended with `eslint-plugin-svelte` + `svelte-eslint-parser` for `.svelte` and `.svelte.js` files.
 - Per the project contract: every `.svelte` file is verified via the Svelte MCP `svelte-autofixer`.
 
-#### 📚 Documentation
+#### Documentation
 
-- `README.md` — new "Frontend Development" section documenting Svelte as the default.
-- `ADDING_PLATFORMS_AND_TOOLS.md` — the "frontend" steps for adding a tool collapse to "one entry in `TOOLS`"; the per-file list at §3.3 is updated; §5.10 rewritten end-to-end with the new registry pattern.
-- `DESIGN_tool_plugin_architecture.md` — §3.7 marked implemented; descriptor updated to match what shipped (per-tool `groups`, `defaultMode`, `glyph`, `accent`; `verifyPrefix` is the URL segment).
-- `AGENTS.md` — §1 covers both prod-style and HMR dev loops.
+- `README.md`, new "Frontend Development" section documenting Svelte as the default.
+- `ADDING_PLATFORMS_AND_TOOLS.md`, the "frontend" steps for adding a tool collapse to "one entry in `TOOLS`"; the per-file list at §3.3 is updated; §5.10 rewritten end-to-end with the new registry pattern.
+- `DESIGN_tool_plugin_architecture.md`, §3.7 marked implemented; descriptor updated to match what shipped (per-tool `groups`, `defaultMode`, `glyph`, `accent`; `verifyPrefix` is the URL segment).
+- `AGENTS.md`, §1 covers both prod-style and HMR dev loops.
 
 ## v3.7.8 - Optional PUID/PGID ownership remap for Unraid/home servers
 
-### ✨ New Features
+### New Features
 
 - **Added optional `PUID`/`PGID` support for container file ownership mapping.** On startup, the entrypoint now accepts `PUID`/`PGID` (default `999:999`) and remaps the internal `converter` account before launching the app. This aligns output ownership with host conventions used by Unraid and other home-server setups.
 - **Safe GID fallback for common Unraid defaults.** When `PGID` points to a GID that already exists in the base image (for example `100`), the startup remap falls back from `groupmod` to `usermod -g` so `converter` is reassigned to the existing group instead of failing.
 - **Privilege drop now handled by `gosu` in entrypoint.** The image installs `gosu`, keeps startup as root only long enough to perform optional remapping, then immediately re-execs as `converter`.
 
-### 🔧 Internal
+### Internal
 
 - `Dockerfile` now installs `gosu` and no longer sets `USER converter` at build time.
 - `entrypoint.sh` now:
@@ -249,7 +249,7 @@ bits-ui, svelte-sonner, mode-watcher).
   - preserves old behavior when env vars are unset (`999:999`),
   - drops privileges with `exec gosu converter "$0" "$@"`.
 
-### 📚 Documentation
+### Documentation
 
 - Updated `README.md`, `DOCKER-COMPOSE.md`, `DEPLOYMENT.md`, and compose examples to document `PUID`/`PGID` as an optional runtime ownership setting.
 
@@ -257,54 +257,54 @@ bits-ui, svelte-sonner, mode-watcher).
 
 ## v3.7.7 - Cancellable metadata scan and DAT match jobs
 
-### ✨ New Features
+### New Features
 
-- **Metadata scan and DAT match jobs are now cancellable from the UI.** Both job types are "external jobs" (they bypass the conversion queue and drive their own execution), and until this release were deliberately excluded from cancellation — once started, a full-volume metadata scan or DAT match had to run to completion, even if the user realised they kicked it off on the wrong volume or wanted to free the workload lane for something else. The existing per-row **Cancel** button and the **Cancel All** button now both accept these jobs. No new endpoints — the existing `DELETE /api/jobs/{id}` and `POST /api/jobs/cancel-all` routes were widened.
-- **Partial results are preserved on cancel.** Any match entries already written to `dat_matches`, or metadata/disc-id tags already extracted and committed to `chd_metadata`, stay durable. This matches the pre-existing "durable mid-run" comment in `_run_match_job` — cancelling mid-loop gives you a partial cache, not a rollback.
+- **Metadata scan and DAT match jobs are now cancellable from the UI.** Both job types are "external jobs" (they bypass the conversion queue and drive their own execution), and until this release were deliberately excluded from cancellation, once started, a full-volume metadata scan or DAT match had to run to completion, even if the user realised they kicked it off on the wrong volume or wanted to free the workload lane for something else. The existing per-row **Cancel** button and the **Cancel All** button now both accept these jobs. No new endpoints, the existing `DELETE /api/jobs/{id}` and `POST /api/jobs/cancel-all` routes were widened.
+- **Partial results are preserved on cancel.** Any match entries already written to `dat_matches`, or metadata/disc-id tags already extracted and committed to `chd_metadata`, stay durable. This matches the pre-existing "durable mid-run" comment in `_run_match_job`, cancelling mid-loop gives you a partial cache, not a rollback.
 - **Cancel-All now cancels every kind of job.** `cancel_all_jobs()` no longer filters out external modes, and the matching three frontend guards (`handleRequestCancelAll` activeCount, `handleCancelAllJobs` per-job state map, `queuedJobsCount` / `processingJobsCount`) were removed so the button's visibility, the summary counts, and the optimistic "Cancelling..." state update all apply uniformly.
 
-### 🐛 Bug Fixes & Hardening
+### Bug Fixes & Hardening
 
 - **`_run_match_job` releases the match-job lock *before* its finalize awaits.** Previously the `async with _get_match_job_lock(): _active_match_job_id = None` cleanup was the last statement in the `finally` block, after both `finish_external_job` and `finish_external_job_cancelled`. If either finalize call raised (e.g. a subscriber queue throwing), `_active_match_job_id` stayed pinned to the dead job id and every subsequent match request returned HTTP 409 until process restart. The reset now runs at the top of the `finally`, so the lock is released even if finalize blows up.
-- **Startup migrated from deprecated `@app.on_event("startup")` to FastAPI lifespan context manager.** Silences the `DeprecationWarning: on_event is deprecated, use lifespan event handlers instead` the test suite was emitting, and puts us on the supported path for future FastAPI upgrades. No behaviour change — same startup body, same ordering (`configure_logging` → DB init → Alembic → JSON→SQLite import → background tasks → auto-sync).
+- **Startup migrated from deprecated `@app.on_event("startup")` to FastAPI lifespan context manager.** Silences the `DeprecationWarning: on_event is deprecated, use lifespan event handlers instead` the test suite was emitting, and puts us on the supported path for future FastAPI upgrades. No behaviour change, same startup body, same ordering (`configure_logging` → DB init → Alembic → JSON→SQLite import → background tasks → auto-sync).
 - **"Cancelling..." string unified across backend and frontend.** The new external-job cancel path briefly used a Unicode ellipsis (`"Cancelling…"`) while the pre-existing conversion-job path and the frontend's optimistic update used ASCII (`"Cancelling..."`). Because SSE delivery races the local optimistic write, the displayed string would flip between the two forms. Backend now emits ASCII everywhere.
 
-### 🔧 Internal
+### Internal
 
 - **New cancellation primitives on `JobManager`.**
-    - `ExternalJobCancelled` — purpose-built exception raised inside external-job loops when `cancel_job()` has been requested. Only caught by the dedicated `except` branch in each loop; will never mask a real `Exception`.
-    - `is_cancelled(job_id) -> bool` — cheap polling check used at the top of each loop iteration in `_run_match_job` and both phases of `scan_metadata_task`.
-    - `get_cancel_event(job_id) -> asyncio.Event | None` — awaitable form for future use.
-    - `finish_external_job_cancelled(job_id, *, message)` — terminal finalize that sets `JobStatus.CANCELLED`, clears cancel state, emits the `cancelled` SSE event, and archives the job. Symmetric with `finish_external_job(success=...)`.
+    - `ExternalJobCancelled`, purpose-built exception raised inside external-job loops when `cancel_job()` has been requested. Only caught by the dedicated `except` branch in each loop; will never mask a real `Exception`.
+    - `is_cancelled(job_id) -> bool`, cheap polling check used at the top of each loop iteration in `_run_match_job` and both phases of `scan_metadata_task`.
+    - `get_cancel_event(job_id) -> asyncio.Event | None`, awaitable form for future use.
+    - `finish_external_job_cancelled(job_id, *, message)`, terminal finalize that sets `JobStatus.CANCELLED`, clears cancel state, emits the `cancelled` SSE event, and archives the job. Symmetric with `finish_external_job(success=...)`.
 - **Tri-state `job_success`** in both loops (`True` = success, `False` = failure, `None` = cancelled). Cancelled path takes `finish_external_job_cancelled`; non-cancelled path keeps the pre-existing `finish_external_job(success=...)` call so DAT match's "all files errored → mark failed" signal is unchanged.
 - **Cancel events auto-register on external-job creation.** `create_external_job` now populates `_cancel_events[job_id]` when a running loop is available (falls back silently under sync test setups).
 
-### 🧪 Tests (+16, total 324)
+### Tests (+16, total 324)
 
-- `test_cancel_job_signals_metadata_scan` / `..._signals_dat_match` / `..._emits_status_event_for_external_job` — cancel_job on a PROCESSING external job sets the event, flips the message, returns True, and emits a `status` SSE event.
-- `test_cancel_all_includes_external_jobs` — Cancel-All requests both a metadata scan and a DAT match.
-- `test_cancel_job_returns_false_for_terminal_external_job` — terminal external jobs are not re-cancellable.
-- `test_finish_external_job_cancelled_sets_status_and_message` / `..._emits_cancelled_event` / `..._clears_cancel_state` / `..._noop_for_unknown_id` — terminal-finalize semantics.
-- `test_run_match_job_cancellation_ends_in_cancelled_status` — mid-loop cancel flips the job to CANCELLED and clears `_active_match_job_id`.
-- `test_run_match_job_cancellation_keeps_partial_cache` — per-file matches written before cancel stay in `dat_store`.
-- `test_scan_metadata_cancellation_flips_to_cancelled` — Phase 1 cancel path.
-- `test_scan_metadata_cancellation_during_phase2` — Phase 2 (disc-id) cancel path covered independently.
+- `test_cancel_job_signals_metadata_scan` / `..._signals_dat_match` / `..._emits_status_event_for_external_job`, cancel_job on a PROCESSING external job sets the event, flips the message, returns True, and emits a `status` SSE event.
+- `test_cancel_all_includes_external_jobs`, Cancel-All requests both a metadata scan and a DAT match.
+- `test_cancel_job_returns_false_for_terminal_external_job`, terminal external jobs are not re-cancellable.
+- `test_finish_external_job_cancelled_sets_status_and_message` / `..._emits_cancelled_event` / `..._clears_cancel_state` / `..._noop_for_unknown_id`, terminal-finalize semantics.
+- `test_run_match_job_cancellation_ends_in_cancelled_status`, mid-loop cancel flips the job to CANCELLED and clears `_active_match_job_id`.
+- `test_run_match_job_cancellation_keeps_partial_cache`, per-file matches written before cancel stay in `dat_store`.
+- `test_scan_metadata_cancellation_flips_to_cancelled`, Phase 1 cancel path.
+- `test_scan_metadata_cancellation_during_phase2`, Phase 2 (disc-id) cancel path covered independently.
 - Two pre-existing tests (`test_cancel_job_returns_false_for_metadata_scan`, `test_cancel_all_skips_metadata_scan_jobs`) were rewritten to reflect the new behaviour.
 
 324 tests pass, 0 warnings (was 323 + 2 FastAPI deprecation warnings before this release).
 
-### 📁 Files Changed
+### Files Changed
 
-- `app/services/job_manager.py` — `ExternalJobCancelled`, `is_cancelled` / `get_cancel_event`, `finish_external_job_cancelled`, cancel-event registration in `create_external_job`, `cancel_job` external-job branch, `cancel_all_jobs` no longer filters external modes.
-- `app/routes/dat.py` — `_run_match_job` gains a per-iteration cancel check, tri-state `job_success`, dedicated `except ExternalJobCancelled` branch, and early match-lock release in the `finally`.
-- `app/routes/info.py` — `scan_metadata_task` gains cancel checks at the top of both Phase 1 and Phase 2 loops, and a cancelled branch in the `finally` that calls `finish_external_job_cancelled`.
-- `app/main.py` — `@app.on_event("startup")` → `@asynccontextmanager async def lifespan(app)` passed to `FastAPI(lifespan=...)`. Startup body unchanged.
-- `static/js/app.js` — Cancel button on `JobList` row is no longer suppressed for external scan modes; Cancel-All count filter, per-job state map, and `queuedJobsCount` / `processingJobsCount` no longer exclude them.
+- `app/services/job_manager.py`, `ExternalJobCancelled`, `is_cancelled` / `get_cancel_event`, `finish_external_job_cancelled`, cancel-event registration in `create_external_job`, `cancel_job` external-job branch, `cancel_all_jobs` no longer filters external modes.
+- `app/routes/dat.py`, `_run_match_job` gains a per-iteration cancel check, tri-state `job_success`, dedicated `except ExternalJobCancelled` branch, and early match-lock release in the `finally`.
+- `app/routes/info.py`, `scan_metadata_task` gains cancel checks at the top of both Phase 1 and Phase 2 loops, and a cancelled branch in the `finally` that calls `finish_external_job_cancelled`.
+- `app/main.py`, `@app.on_event("startup")` → `@asynccontextmanager async def lifespan(app)` passed to `FastAPI(lifespan=...)`. Startup body unchanged.
+- `static/js/app.js`, Cancel button on `JobList` row is no longer suppressed for external scan modes; Cancel-All count filter, per-job state map, and `queuedJobsCount` / `processingJobsCount` no longer exclude them.
 
-### ⚠️ Upgrade Notes
+### Upgrade Notes
 
 - **No action required.** The `DELETE /api/jobs/{id}` endpoint keeps its existing contract (returns 200 on success, 404 on unknown id); external jobs just no longer fall through to a silent `False` return.
-- **Cancelling a metadata scan mid-run leaves partial metadata cached.** If you cancel and re-trigger, the re-triggered scan skips already-refreshed entries via the normal `is_stale` check — no duplicate work, no lost data.
+- **Cancelling a metadata scan mid-run leaves partial metadata cached.** If you cancel and re-trigger, the re-triggered scan skips already-refreshed entries via the normal `is_stale` check, no duplicate work, no lost data.
 - **Cancelling a DAT match mid-run leaves per-file matches cached.** Re-matching the same paths skips the ones already in `dat_matches`; size-cap and missing-file skips are re-evaluated.
 - **"Cancel All" now cancels scans too.** If you were relying on Cancel-All stopping only conversion jobs while a metadata scan kept running, use the per-row Cancel button on the conversion jobs instead.
 
@@ -312,28 +312,28 @@ bits-ui, svelte-sonner, mode-watcher).
 
 ## v3.7.6 - ACL enforcement on post-sync rematch + UI signals
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
-- **Post-sync rematch now re-validates every path against `CONFIGURED_VOLUMES`.** v3.7.5's rematch hook snapshotted paths from `DATMatch` and handed them to `schedule_match_job` unchanged. Those paths were ACL-approved at write time, but a later tightening of `CONFIGURED_VOLUMES` (a mount unmounted, a library removed) or a symlink retargeted since the original scan would slip through undetected. `schedule_match_job` now runs every incoming path through `os.path.realpath` + `is_within_configured_volumes` and drops denied entries with a `WARNING` log (`"schedule_match_job: dropped N path(s) outside configured volumes"`). The check is idempotent — the HTTP `/dat/match-batch/job` handler pre-filters, so duplicate filtering is a no-op for the HTTP path.
-- **`_background_match_tasks` set-membership invariant is now self-checking.** `schedule_match_job` logs a warning if the strong-ref set is non-empty when a new task is about to be scheduled — the concurrency guard should make this impossible, so a warning here surfaces a guard-bypass regression that would otherwise be silent.
+- **Post-sync rematch now re-validates every path against `CONFIGURED_VOLUMES`.** v3.7.5's rematch hook snapshotted paths from `DATMatch` and handed them to `schedule_match_job` unchanged. Those paths were ACL-approved at write time, but a later tightening of `CONFIGURED_VOLUMES` (a mount unmounted, a library removed) or a symlink retargeted since the original scan would slip through undetected. `schedule_match_job` now runs every incoming path through `os.path.realpath` + `is_within_configured_volumes` and drops denied entries with a `WARNING` log (`"schedule_match_job: dropped N path(s) outside configured volumes"`). The check is idempotent, the HTTP `/dat/match-batch/job` handler pre-filters, so duplicate filtering is a no-op for the HTTP path.
+- **`_background_match_tasks` set-membership invariant is now self-checking.** `schedule_match_job` logs a warning if the strong-ref set is non-empty when a new task is about to be scheduled, the concurrency guard should make this impossible, so a warning here surfaces a guard-bypass regression that would otherwise be silent.
 
-### ✨ UX Improvements
+### UX Improvements
 
-- **Sync result / status payload carries `rematch_status` + `rematch_job_id`.** `GET /dat/sync/status` now reports whether the post-sync rematch was `scheduled` (with a `rematch_job_id` the UI can poll), `deferred` (another match job held the concurrency lock — user can retry after it completes), `failed` (scheduling raised; DAT import still succeeded), or `None` (sync had errors; no rematch attempted). Previously the UI had to infer rematch progress from log-tailing.
+- **Sync result / status payload carries `rematch_status` + `rematch_job_id`.** `GET /dat/sync/status` now reports whether the post-sync rematch was `scheduled` (with a `rematch_job_id` the UI can poll), `deferred` (another match job held the concurrency lock, user can retry after it completes), `failed` (scheduling raised; DAT import still succeeded), or `None` (sync had errors; no rematch attempted). Previously the UI had to infer rematch progress from log-tailing.
 
-### 🧪 Tests (+5, total 313)
+### Tests (+5, total 313)
 
-- `test_schedule_match_job_returns_none_when_all_paths_denied` — empty allow-list short-circuits before job creation.
-- `test_schedule_match_job_filters_denied_paths_but_schedules_remainder` — mixed allow/deny list drops the deny with a warning log, schedules the rest.
-- `test_do_sync_surfaces_rematch_scheduled_status` / `..._deferred_status` / `..._failed_status` — each rematch outcome propagates into the progress payload and result dict.
+- `test_schedule_match_job_returns_none_when_all_paths_denied`, empty allow-list short-circuits before job creation.
+- `test_schedule_match_job_filters_denied_paths_but_schedules_remainder`, mixed allow/deny list drops the deny with a warning log, schedules the rest.
+- `test_do_sync_surfaces_rematch_scheduled_status` / `..._deferred_status` / `..._failed_status`, each rematch outcome propagates into the progress payload and result dict.
 - Existing `test_schedule_match_job_uses_create_task_without_background_tasks` now additionally asserts `_background_match_tasks` set membership before the task completes and cleanup afterward.
 
-### 📁 Files Changed
+### Files Changed
 
-- `app/routes/dat.py` — new `_filter_paths_within_volumes` helper; `schedule_match_job` runs it before claiming the concurrency slot; `_background_match_tasks` size-guard warning; inline comment explaining why scheduling lives outside the lock.
-- `app/services/dat_sync.py` — `_do_sync()` captures `rematch_status` + `rematch_job_id` and surfaces them through `_update_progress` and the return dict.
+- `app/routes/dat.py`, new `_filter_paths_within_volumes` helper; `schedule_match_job` runs it before claiming the concurrency slot; `_background_match_tasks` size-guard warning; inline comment explaining why scheduling lives outside the lock.
+- `app/services/dat_sync.py`, `_do_sync()` captures `rematch_status` + `rematch_job_id` and surfaces them through `_update_progress` and the return dict.
 
-### ⚠️ Upgrade Notes
+### Upgrade Notes
 
 - **No action required.** The ACL re-check is idempotent on already-admitted paths, so existing workflows are unaffected.
 - **Frontend integration:** existing UI consumers of `/dat/sync/status` see two new optional keys inside `progress` (`rematch_status`, `rematch_job_id`). Old clients that ignore unknown keys keep working unchanged.
@@ -342,97 +342,97 @@ bits-ui, svelte-sonner, mode-watcher).
 
 ## v3.7.5 - Post-sync auto-rematch + hardened match-job error handling
 
-### ✨ New Features
+### New Features
 
 - **DAT re-syncs now auto-rematch previously-scanned files.** When a DAT re-sync wipes the match cache (via `_persist_sync` in `app/services/dat_store.py`), the sync now snapshots the pre-wipe path list and enqueues a background `/dat/match-batch/job` against those paths. Before this, `GET /dat/stats` would read `matched=0, scanned=0` immediately after a sync until the user manually browsed every affected directory to re-trigger the frontend's match-batch effect. On a typical install with 1500+ scanned files across a dozen volumes, that was easy to miss. Now the stats counter refreshes on its own within a few minutes of sync completion.
-- **`schedule_match_job()` helper.** Extracted from the `/dat/match-batch/job` HTTP handler so non-HTTP callers (like the new post-sync hook) can reuse the same concurrency-guarded scheduling path. Works with or without a FastAPI `BackgroundTasks` — `asyncio.create_task` with a module-level strong-reference set (`_background_match_tasks`) is used for non-HTTP callers so the task can't be garbage-collected mid-run.
+- **`schedule_match_job()` helper.** Extracted from the `/dat/match-batch/job` HTTP handler so non-HTTP callers (like the new post-sync hook) can reuse the same concurrency-guarded scheduling path. Works with or without a FastAPI `BackgroundTasks`, `asyncio.create_task` with a module-level strong-reference set (`_background_match_tasks`) is used for non-HTTP callers so the task can't be garbage-collected mid-run.
 
-### 🐛 Bug Fixes & Hardening
+### Bug Fixes & Hardening
 
-- **Failure counting in `_run_match_job`.** Previously a dropped volume produced a misleading `"complete, 0 matched"` signal — every per-file OSError was WARN-logged and the job finished green. Two new counters (`errors` + `skips`) now track real failures vs. policy skips. When `errors == total` the job flips to `failed` with a `"check volume accessibility"` error message so operators see a red signal instead of a DAT-coverage-gap illusion.
+- **Failure counting in `_run_match_job`.** Previously a dropped volume produced a misleading `"complete, 0 matched"` signal, every per-file OSError was WARN-logged and the job finished green. Two new counters (`errors` + `skips`) now track real failures vs. policy skips. When `errors == total` the job flips to `failed` with a `"check volume accessibility"` error message so operators see a red signal instead of a DAT-coverage-gap illusion.
 - **Mid-loop exception preserves counter context.** When the outer `except Exception` in `_run_match_job` fires (e.g., `job_manager.update_external_job` starts throwing), the error message now includes `processed N/M, K error(s)` so operators know how far the job got before failure.
 - **Programmer-error tracebacks surface.** Two broad `except Exception` blocks in `_hash_one_for_job` and `_run_match_job`'s cache-write path now use `logger.exception` (ERROR level with full traceback) rather than `logger.warning`. A `KeyError`/`AttributeError` from a refactor bug is visible in logs instead of buried as a one-line warning.
 - **Background match-task exceptions surface too.** If `_run_match_job` raises past its own `try/finally` (rare, but possible if `finish_external_job` throws), the exception is now routed through the project logger instead of only appearing as asyncio's "Task exception was never retrieved" warning on GC.
-- **`list_match_paths` failure no longer leaks staged DATs.** If the snapshot SELECT raised (DB locked, disk error), the sync would abort before `persist()` committed, leaving DATs staged in `_pending_imports` — the next sync would double-stage and corrupt the store. Snapshot failure is now best-effort: empty list + `logger.exception`, and `persist()` still runs so the DAT import is durable.
-- **Rematch `ImportError` no longer silently swallowed.** The rematch scheduling's `try/except Exception` would hide a missing-module deployment bug as a silent "complete" sync. `from routes.dat import schedule_match_job` is now outside the try/except — a real ImportError propagates and fails the sync loudly so operators notice.
+- **`list_match_paths` failure no longer leaks staged DATs.** If the snapshot SELECT raised (DB locked, disk error), the sync would abort before `persist()` committed, leaving DATs staged in `_pending_imports`, the next sync would double-stage and corrupt the store. Snapshot failure is now best-effort: empty list + `logger.exception`, and `persist()` still runs so the DAT import is durable.
+- **Rematch `ImportError` no longer silently swallowed.** The rematch scheduling's `try/except Exception` would hide a missing-module deployment bug as a silent "complete" sync. `from routes.dat import schedule_match_job` is now outside the try/except, a real ImportError propagates and fails the sync loudly so operators notice.
 - **`schedule_match_job` scheduling failure rolls back `_active_match_job_id`.** If `asyncio.create_task` or `background_tasks.add_task` raises after the lock was claimed, future match jobs would return HTTP 409 forever. The rollback clears the id and finalizes the phantom external job before re-raising.
 - **Canonical internal imports.** Removed three `try: from services.x / except ImportError: from app.services.x` fallback pairs in `app/services/dat_sync.py`. Under the project's `PYTHONPATH=app` convention the fallback path was unreachable, and the `except ImportError` would silently absorb a real circular-import bug if one ever arose. Production-only feature-gate imports in `archive.py` / `disc_id.py` are untouched.
 
-### 🧪 Tests
+### Tests
 
-- `test_do_sync_schedules_rematch_after_success` / `..._when_no_previous_matches` / `..._on_partial_failure` / `..._logs_when_skipped_due_to_active_job` — post-sync rematch hook.
-- `test_do_sync_list_match_paths_failure_is_best_effort` — snapshot SELECT failure is handled.
-- `test_do_sync_rematch_schedule_exception_does_not_poison_sync` — rematch failure doesn't mark sync as errored.
-- `test_run_match_job_reports_errors_in_final_message` / `..._marks_failure_when_all_files_error` / `..._skip_count_does_not_trip_failure` / `..._cache_write_failure_counts_as_error` / `..._outer_exception_includes_counter_context` — failure-counter coverage.
-- `test_hash_one_for_job_logs_match_error_with_traceback` — programmer-error tracebacks land at ERROR level.
-- `test_schedule_match_job_returns_none_on_empty_paths` / `..._returns_none_when_active` / `..._rolls_back_active_id_on_scheduling_failure` / `..._uses_create_task_without_background_tasks` — helper behavior.
-- `test_list_match_paths_returns_empty_on_fresh_store` / `..._returns_all_paths` — snapshot query.
+- `test_do_sync_schedules_rematch_after_success` / `..._when_no_previous_matches` / `..._on_partial_failure` / `..._logs_when_skipped_due_to_active_job`, post-sync rematch hook.
+- `test_do_sync_list_match_paths_failure_is_best_effort`, snapshot SELECT failure is handled.
+- `test_do_sync_rematch_schedule_exception_does_not_poison_sync`, rematch failure doesn't mark sync as errored.
+- `test_run_match_job_reports_errors_in_final_message` / `..._marks_failure_when_all_files_error` / `..._skip_count_does_not_trip_failure` / `..._cache_write_failure_counts_as_error` / `..._outer_exception_includes_counter_context`, failure-counter coverage.
+- `test_hash_one_for_job_logs_match_error_with_traceback`, programmer-error tracebacks land at ERROR level.
+- `test_schedule_match_job_returns_none_on_empty_paths` / `..._returns_none_when_active` / `..._rolls_back_active_id_on_scheduling_failure` / `..._uses_create_task_without_background_tasks`, helper behavior.
+- `test_list_match_paths_returns_empty_on_fresh_store` / `..._returns_all_paths`, snapshot query.
 
 308 tests pass (+14 new since v3.7.3).
 
-### 📁 Files Changed
+### Files Changed
 
-- `app/routes/dat.py` — `schedule_match_job` helper + `_log_background_match_task_error` callback; `_run_match_job` refactored for error/skip counting, `logger.exception` for broad catches, counter context in outer-except message.
-- `app/services/dat_store.py` — `has_stale_dats()` and `list_match_paths()` helpers.
-- `app/services/dat_sync.py` — `_do_sync()` now snapshots match paths (best-effort) and schedules rematch after successful commit; three `except ImportError` fallbacks removed.
-- `app/main.py` — startup lifespan now auto-triggers self-heal sync when any DAT has `file_count=0` (shipped in v3.7.3).
+- `app/routes/dat.py`, `schedule_match_job` helper + `_log_background_match_task_error` callback; `_run_match_job` refactored for error/skip counting, `logger.exception` for broad catches, counter context in outer-except message.
+- `app/services/dat_store.py`, `has_stale_dats()` and `list_match_paths()` helpers.
+- `app/services/dat_sync.py`, `_do_sync()` now snapshots match paths (best-effort) and schedules rematch after successful commit; three `except ImportError` fallbacks removed.
+- `app/main.py`, startup lifespan now auto-triggers self-heal sync when any DAT has `file_count=0` (shipped in v3.7.3).
 
-### ⚠️ Upgrade Notes
+### Upgrade Notes
 
 - **No action required.** After restart, if your DAT store has stale rows they self-heal (v3.7.3 behavior), and if that sync runs it now auto-rematches your scanned files. If a match job is already active when the post-sync hook fires, the rematch is skipped with a log line and you can re-trigger manually via `POST /dat/sync {"force": true}`.
-- **Jobs panel:** after a sync you'll see a `"DAT Match"` external job tick through your previously-scanned files. If a volume is offline while it runs, the job now finishes with `failed` + `"all N file(s) failed — check volume accessibility"` instead of a misleading `"0 matched"` success.
+- **Jobs panel:** after a sync you'll see a `"DAT Match"` external job tick through your previously-scanned files. If a volume is offline while it runs, the job now finishes with `failed` + `"all N file(s) failed, check volume accessibility"` instead of a misleading `"0 matched"` success.
 
 ---
 
 ## v3.7.3 - DAT self-heal fires automatically on startup
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
-- **Stale DATs now repair themselves on server restart.** v3.7.2 taught `DATSyncService` to skip its `already_synced` fast-path whenever any DAT had `file_count=0`, but the self-heal only ran when `sync()` was explicitly called — via the UI sync button or `POST /api/dat/sync`. Users who had never clicked sync stayed stuck with 67 empty DATs (the classic pre-#49 state: every CD/softlist `<disk>` DAT showing 0 entries while Nintendo GameCube + Wii — the two `<rom>`-based ones — were healthy). Startup auto-sync previously gated on `MAMEREDUMP_AUTO_SYNC=true` AND an empty DAT store, so it never fired for someone who already had 69 DATs sitting in broken state.
+- **Stale DATs now repair themselves on server restart.** v3.7.2 taught `DATSyncService` to skip its `already_synced` fast-path whenever any DAT had `file_count=0`, but the self-heal only ran when `sync()` was explicitly called, via the UI sync button or `POST /api/dat/sync`. Users who had never clicked sync stayed stuck with 67 empty DATs (the classic pre-#49 state: every CD/softlist `<disk>` DAT showing 0 entries while Nintendo GameCube + Wii, the two `<rom>`-based ones, were healthy). Startup auto-sync previously gated on `MAMEREDUMP_AUTO_SYNC=true` AND an empty DAT store, so it never fired for someone who already had 69 DATs sitting in broken state.
 
   Startup now has a second trigger: whenever any DAT has `file_count=0`, a background sync kicks off unconditionally (no env-var gate, no empty-store gate). The service's existing self-heal logic then rebuilds the DAT set in place using the current parser. Fresh-install behaviour (`MAMEREDUMP_AUTO_SYNC=true` + empty store) is unchanged.
 
-### 🧪 Tests
+### Tests
 
-- `test_has_stale_dats_empty_store_returns_false` / `_all_healthy_returns_false` / `_detects_zero_count` — unit tests for the new `DATStore.has_stale_dats()` existence check.
+- `test_has_stale_dats_empty_store_returns_false` / `_all_healthy_returns_false` / `_detects_zero_count`, unit tests for the new `DATStore.has_stale_dats()` existence check.
 
-### 📁 Files Changed
+### Files Changed
 
-- `app/services/dat_store.py` — new `has_stale_dats()` method (single-row SQL existence check, cheap enough for startup).
-- `app/main.py` — startup auto-sync split into two independent triggers; shared task-spawn helper extracted.
-- `tests/test_db_store_operations.py` — three new tests for `has_stale_dats()`.
+- `app/services/dat_store.py`, new `has_stale_dats()` method (single-row SQL existence check, cheap enough for startup).
+- `app/main.py`, startup auto-sync split into two independent triggers; shared task-spawn helper extracted.
+- `tests/test_db_store_operations.py`, three new tests for `has_stale_dats()`.
 
-### ⚠️ Upgrade Notes
+### Upgrade Notes
 
-- **No action required.** Restart the server once and stale DATs heal within ~60 s (given network access to the MAMERedump repo). If GitHub is unreachable the sync errors into the log and state is preserved — identical to the existing manual-sync behaviour.
+- **No action required.** Restart the server once and stale DATs heal within ~60 s (given network access to the MAMERedump repo). If GitHub is unreachable the sync errors into the log and state is preserved, identical to the existing manual-sync behaviour.
 
 ---
 
 ## v3.7.2 - Self-healing DAT re-sync after the softlist &lt;disk&gt; parser fix
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
-- **DATs with only `<disk>` hash entries no longer stay stuck at 0 entries after an upgrade.** The v3.7.0 parser (PR #49) added `<disk>` support so MAME-Redump softlist DATs for disc-based systems (Amiga CD / CD32 / CDTV, Bandai Pippin, Konami FireBeat / System 573, Sega Naomi / Chihiro / Lindbergh, Atari Jaguar CD, IBM PC, etc.) import correctly. However, anyone who ran the DAT sync *before* that parser change ended up with DAT rows whose `file_count=0` because the old parser silently ignored `<disk>` elements, and the `DATSyncService` treated the (cached, correct) tag as "already synced" — trapping users in the stale state.
+- **DATs with only `<disk>` hash entries no longer stay stuck at 0 entries after an upgrade.** The v3.7.0 parser (PR #49) added `<disk>` support so MAME-Redump softlist DATs for disc-based systems (Amiga CD / CD32 / CDTV, Bandai Pippin, Konami FireBeat / System 573, Sega Naomi / Chihiro / Lindbergh, Atari Jaguar CD, IBM PC, etc.) import correctly. However, anyone who ran the DAT sync *before* that parser change ended up with DAT rows whose `file_count=0` because the old parser silently ignored `<disk>` elements, and the `DATSyncService` treated the (cached, correct) tag as "already synced", trapping users in the stale state.
 
   The sync service now self-heals: if `last_sync_tag` matches but any existing DAT has `file_count=0`, the fast-path is skipped and the DAT set is rebuilt in place. The old DATs are only deleted after the new set is fully imported, so there's never a window with zero DATs.
 
-### ✨ New Features
+### New Features
 
-- **`POST /api/dat/sync` accepts `"force": true`** — bypasses the `already_synced` fast-path unconditionally, useful when operators want to rebuild the DAT set for any reason (repo-side fixes, local DB corruption, etc.). Default remains `false`.
+- **`POST /api/dat/sync` accepts `"force": true`**, bypasses the `already_synced` fast-path unconditionally, useful when operators want to rebuild the DAT set for any reason (repo-side fixes, local DB corruption, etc.). Default remains `false`.
 
-### 🧪 Tests
+### Tests
 
-- `test_sync_auto_forces_when_any_dat_has_zero_entries` — regression test for the self-heal path.
-- `test_sync_force_bypasses_already_synced_guard` — covers the explicit `force=True` opt-in.
-- `test_sync_already_synced_requires_nonzero_file_counts` — the fast-path still fires when every DAT is healthy.
+- `test_sync_auto_forces_when_any_dat_has_zero_entries`, regression test for the self-heal path.
+- `test_sync_force_bypasses_already_synced_guard`, covers the explicit `force=True` opt-in.
+- `test_sync_already_synced_requires_nonzero_file_counts`, the fast-path still fires when every DAT is healthy.
 
-### 📁 Files Changed
+### Files Changed
 
-- `app/routes/dat.py` — `SyncRequest` gains `force: bool = False`; route forwards it to the service.
-- `app/services/dat_sync.py` — `sync()` / `_do_sync()` take `force`; the fast-path skips when any DAT has `file_count=0`.
-- `tests/test_dat_sync.py`, `tests/test_dat_routes.py` — new regressions + existing assertions updated for the new kwarg.
+- `app/routes/dat.py`, `SyncRequest` gains `force: bool = False`; route forwards it to the service.
+- `app/services/dat_sync.py`, `sync()` / `_do_sync()` take `force`; the fast-path skips when any DAT has `file_count=0`.
+- `tests/test_dat_sync.py`, `tests/test_dat_routes.py`, new regressions + existing assertions updated for the new kwarg.
 
-### ⚠️ Upgrade Notes
+### Upgrade Notes
 
 - **No action required.** On next sync click the service notices the stale state and rebuilds automatically. If you prefer to trigger it explicitly, POST `/api/dat/sync` with `{"force": true}`.
 
@@ -440,188 +440,188 @@ bits-ui, svelte-sonner, mode-watcher).
 
 ## v3.7.1 - Color-coded stdout logs
 
-### ✨ New Features
+### New Features
 
-- **ANSI-colored log levels on stdout** — Log lines now highlight `%(levelname)s` with an SGR color so severity is easy to skim in `docker logs` output: `DEBUG` dim, `INFO` green, `WARNING` yellow, `ERROR` red, `CRITICAL` bold red. Message bodies are left uncolored so copy-paste stays clean.
-- **`LOG_COLOR` env var** — Controls the stream-handler color policy. Values:
-  - `always` (**default**) — colored stdout out of the box, so Docker users see colors without any configuration. `docker logs` does not allocate a TTY, so this was the right default rather than `auto`.
-  - `auto` — color iff stdout is a TTY and the `NO_COLOR` env var (<https://no-color.org>) is unset.
-  - `never` — disable entirely.
+- **ANSI-colored log levels on stdout**, Log lines now highlight `%(levelname)s` with an SGR color so severity is easy to skim in `docker logs` output: `DEBUG` dim, `INFO` green, `WARNING` yellow, `ERROR` red, `CRITICAL` bold red. Message bodies are left uncolored so copy-paste stays clean.
+- **`LOG_COLOR` env var**, Controls the stream-handler color policy. Values:
+  - `always` (**default**), colored stdout out of the box, so Docker users see colors without any configuration. `docker logs` does not allocate a TTY, so this was the right default rather than `auto`.
+  - `auto`, color iff stdout is a TTY and the `NO_COLOR` env var (<https://no-color.org>) is unset.
+  - `never`, disable entirely.
   Invalid values log a warning and fall back to `auto`.
-- **File logs are never colored** — `LOG_PATH` output always uses the plain formatter regardless of `LOG_COLOR`, keeping `grep` / log-aggregator pipelines intact.
+- **File logs are never colored**, `LOG_PATH` output always uses the plain formatter regardless of `LOG_COLOR`, keeping `grep` / log-aggregator pipelines intact.
 
-### 📁 Files Changed
+### Files Changed
 
-- `app/main.py` — added `ColorFormatter`, `_resolve_color()`, wired into `configure_logging()`.
-- `app/config.py` — added `log_color: str` setting.
-- `README.md` — `LOG_COLOR` row in the env-var table.
-- `tests/test_logging_config.py` — +14 tests: default value, resolver TTY/`NO_COLOR` logic, formatter round-trip, end-to-end colored stream, and a guarantee that the file handler never emits ANSI escapes even with `LOG_COLOR=always`.
+- `app/main.py`, added `ColorFormatter`, `_resolve_color()`, wired into `configure_logging()`.
+- `app/config.py`, added `log_color: str` setting.
+- `README.md`, `LOG_COLOR` row in the env-var table.
+- `tests/test_logging_config.py`, +14 tests: default value, resolver TTY/`NO_COLOR` logic, formatter round-trip, end-to-end colored stream, and a guarantee that the file handler never emits ANSI escapes even with `LOG_COLOR=always`.
 
 ---
 
 ## v3.7.0 - Unified SQLite Store, Alembic Migrations, and Wider DAT Matching
 
-### ✨ New Features
+### New Features
 
-- **Unified SQLite persistence layer** — The four legacy JSON stores (`dat_store.json`, `chd_metadata.json`, `verified_chds.json`, `dat_sync.json`) are consolidated into a single `compressatorium.db` SQLite file backed by SQLAlchemy 2.0. Tuned for this workload: WAL journal mode, `synchronous=NORMAL`, `foreign_keys=ON`, 30s `busy_timeout`. Composite primary keys let sha1/md5 coexist; foreign keys give cascade-on-DAT-delete for hashes and set-null semantics for cached matches so UI history survives DAT removal.
-- **One-shot JSON → SQLite migration on startup** — On first boot against the new release, legacy JSON stores are imported into the DB and the source files are renamed to `*.migrated.bak` (never deleted). Migration is isolated per store: a failure in one does not block the others, leaves that store's JSON untouched, rolls the transaction back, and retries on the next startup. Corrupt JSON is renamed to `*.corrupt` and logged loudly.
-- **Alembic schema versioning** — Schema is driven by Alembic migrations (`migrations/versions/0001_baseline_schema.py`) rather than `create_all`. Pre-Alembic databases (anyone who ran the SQLite-migration build before Alembic landed) are detected by baseline-table presence and auto-stamped to `0001` before upgrade — existing rows are preserved untouched.
-- **DAT match badge widened to raw disc images with bounded hashing** — The match badge now evaluates raw `.iso`/`.bin`/`.cue`/`.gdi` sources in addition to CHDs, with a bounded hashing window so large images can't stall the scan. Softlist `<disk>` elements are parsed as part of DAT matching, and matches run as a background job so the UI stays responsive.
-- **`:beta` Docker tag for pre-releases** — Pre-release GitHub releases now publish a moving `:beta` tag (in addition to the semver tag) on both Docker Hub and GHCR; stable releases continue to publish `:latest`. Consumers opting in to betas pull `pacnpal/compressatorium:beta`. See the README "Opting in to beta updates" section for the data-loss warning — running a beta against a production data volume can irreversibly migrate the DB, and downgrading to `:latest` afterwards is not supported.
+- **Unified SQLite persistence layer**, The four legacy JSON stores (`dat_store.json`, `chd_metadata.json`, `verified_chds.json`, `dat_sync.json`) are consolidated into a single `compressatorium.db` SQLite file backed by SQLAlchemy 2.0. Tuned for this workload: WAL journal mode, `synchronous=NORMAL`, `foreign_keys=ON`, 30s `busy_timeout`. Composite primary keys let sha1/md5 coexist; foreign keys give cascade-on-DAT-delete for hashes and set-null semantics for cached matches so UI history survives DAT removal.
+- **One-shot JSON → SQLite migration on startup**, On first boot against the new release, legacy JSON stores are imported into the DB and the source files are renamed to `*.migrated.bak` (never deleted). Migration is isolated per store: a failure in one does not block the others, leaves that store's JSON untouched, rolls the transaction back, and retries on the next startup. Corrupt JSON is renamed to `*.corrupt` and logged loudly.
+- **Alembic schema versioning**, Schema is driven by Alembic migrations (`migrations/versions/0001_baseline_schema.py`) rather than `create_all`. Pre-Alembic databases (anyone who ran the SQLite-migration build before Alembic landed) are detected by baseline-table presence and auto-stamped to `0001` before upgrade, existing rows are preserved untouched.
+- **DAT match badge widened to raw disc images with bounded hashing**, The match badge now evaluates raw `.iso`/`.bin`/`.cue`/`.gdi` sources in addition to CHDs, with a bounded hashing window so large images can't stall the scan. Softlist `<disk>` elements are parsed as part of DAT matching, and matches run as a background job so the UI stays responsive.
+- **`:beta` Docker tag for pre-releases**, Pre-release GitHub releases now publish a moving `:beta` tag (in addition to the semver tag) on both Docker Hub and GHCR; stable releases continue to publish `:latest`. Consumers opting in to betas pull `pacnpal/compressatorium:beta`. See the README "Opting in to beta updates" section for the data-loss warning, running a beta against a production data volume can irreversibly migrate the DB, and downgrading to `:latest` afterwards is not supported.
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
-- **DAT match no longer leaks `OSError` internals to clients** (#56) — `_match_single_file` previously surfaced filesystem error detail (paths, errno strings) in the API response. It now returns a generic failure code and logs the detail server-side.
+- **DAT match no longer leaks `OSError` internals to clients** (#56), `_match_single_file` previously surfaced filesystem error detail (paths, errno strings) in the API response. It now returns a generic failure code and logs the detail server-side.
 
-### 🧪 Tests
+### Tests
 
-A comprehensive test suite has been added around the new SQLite feature — 26 new tests across 5 files covering every documented invariant end-to-end:
+A full test suite has been added around the new SQLite feature, 26 new tests across 5 files covering every documented invariant end-to-end:
 
-- **`tests/test_db_engine_pragmas.py`** — verifies WAL, `synchronous=NORMAL`, `busy_timeout ≥ 30s`, and `foreign_keys=ON` are actually applied on every checked-out connection (SQLite PRAGMAs are per-connection), and that FK enforcement raises `IntegrityError` on orphaned inserts.
-- **`tests/test_db_startup_integration.py`** — replays the exact `startup_event` ordering: fresh disk, full legacy migration, pre-Alembic + JSON coexistence, and cross-restart idempotency.
-- **`tests/test_db_store_operations.py`** — DAT cascade-delete wipes hashes; DAT delete sets cached match `dat_id` to `NULL` (not delete); `_set_matches_batch_sync` round-trips at the 899/900/901/1800 boundary against SQLite's 999-bind-parameter limit; `VerificationStore._mark_sync` is idempotent; CHDMetadata JSON column survives unicode, nested structures, and emoji; `DATSyncState` singleton never duplicates.
-- **`tests/test_db_migration_edge_cases.py`** — backup-filename collision preserves the source JSON, mid-migration rollback preserves JSON and doesn't block other stores, unicode + ~1800-char paths round-trip, empty collections migrate cleanly, orphaned match `dat_id` becomes `NULL` rather than failing, and truncated JSON bodies land as `.corrupt` (not `.migrated.bak`).
-- **`tests/test_verification_store.py`** — added a concurrent-writer test (two asyncio tasks × 200 writes each) proving WAL + busy_timeout end-to-end through `mark_verified`.
-- **`tests/test_db_migration.py` and `tests/test_alembic_migrations.py`** (introduced during the beta cycle) — cover the five no-data-loss migration invariants and the five Alembic invariants (fresh DB, pre-Alembic stamp-then-upgrade, idempotency, ORM drift guard, called-before-init guard).
+- **`tests/test_db_engine_pragmas.py`**, verifies WAL, `synchronous=NORMAL`, `busy_timeout ≥ 30s`, and `foreign_keys=ON` are actually applied on every checked-out connection (SQLite PRAGMAs are per-connection), and that FK enforcement raises `IntegrityError` on orphaned inserts.
+- **`tests/test_db_startup_integration.py`**, replays the exact `startup_event` ordering: fresh disk, full legacy migration, pre-Alembic + JSON coexistence, and cross-restart idempotency.
+- **`tests/test_db_store_operations.py`**, DAT cascade-delete wipes hashes; DAT delete sets cached match `dat_id` to `NULL` (not delete); `_set_matches_batch_sync` round-trips at the 899/900/901/1800 boundary against SQLite's 999-bind-parameter limit; `VerificationStore._mark_sync` is idempotent; CHDMetadata JSON column survives unicode, nested structures, and emoji; `DATSyncState` singleton never duplicates.
+- **`tests/test_db_migration_edge_cases.py`**, backup-filename collision preserves the source JSON, mid-migration rollback preserves JSON and doesn't block other stores, unicode + ~1800-char paths round-trip, empty collections migrate cleanly, orphaned match `dat_id` becomes `NULL` rather than failing, and truncated JSON bodies land as `.corrupt` (not `.migrated.bak`).
+- **`tests/test_verification_store.py`**, added a concurrent-writer test (two asyncio tasks × 200 writes each) proving WAL + busy_timeout end-to-end through `mark_verified`.
+- **`tests/test_db_migration.py` and `tests/test_alembic_migrations.py`** (introduced during the beta cycle), cover the five no-data-loss migration invariants and the five Alembic invariants (fresh DB, pre-Alembic stamp-then-upgrade, idempotency, ORM drift guard, called-before-init guard).
 
 Total suite: 270 tests, all green.
 
-### 🛠 CI / Infrastructure
+### CI / Infrastructure
 
-- **Docker workflow** — `docker-image.yml` now emits `:beta` for pre-releases and `:latest` only for stable releases. Semver tags (`X.Y.Z`, `X.Y.Z-beta-N`, `X.Y`, `X` for non-v0.x) and `sha-<short>` tags continue to be emitted for all releases.
-- **Code scanning noise reduced** — Project-wide linter configs expanded, Codacy bandit engine disabled, and remaining flagged false positives silenced with inline rationale.
-- **Dependabot** — bumped `actions/stale` 5→10, `docker/build-push-action` 7.0.0→7.1.0, `docker/login-action` 3.7.0→4.1.0, `actions/labeler` 4.3.0→6.0.1, `actions/attest-build-provenance`, and `globals` 17.4.0→17.5.0.
+- **Docker workflow**, `docker-image.yml` now emits `:beta` for pre-releases and `:latest` only for stable releases. Semver tags (`X.Y.Z`, `X.Y.Z-beta-N`, `X.Y`, `X` for non-v0.x) and `sha-<short>` tags continue to be emitted for all releases.
+- **Code scanning noise reduced**, Project-wide linter configs expanded, Codacy bandit engine disabled, and remaining flagged false positives silenced with inline rationale.
+- **Dependabot**, bumped `actions/stale` 5→10, `docker/build-push-action` 7.0.0→7.1.0, `docker/login-action` 3.7.0→4.1.0, `actions/labeler` 4.3.0→6.0.1, `actions/attest-build-provenance`, and `globals` 17.4.0→17.5.0.
 
-### 📁 Files Added / Changed (high-level)
+### Files Added / Changed (high-level)
 
-- `app/services/db.py` (new) — engine init, PRAGMA hook, Alembic bootstrap (`apply_migrations`), `init_and_migrate`, per-store migrators.
-- `app/services/dat_store.py`, `verification_store.py`, `chd_metadata_store.py`, `dat_sync.py` — re-pointed at the SQLAlchemy session factory; chunked upserts where bulk operations cross SQLite's 999-bind-parameter limit.
-- `migrations/` (new) — `alembic.ini`, `env.py`, `versions/0001_baseline_schema.py`.
-- `app/main.py` — `startup_event` initialises the DB, runs Alembic, then `init_and_migrate` before any store is touched.
-- `.github/workflows/docker-image.yml` — `:beta` tag for pre-releases.
-- `README.md` — "Available Tags" table expanded with `:beta` and pre-release semver entries; new "Opting in to beta updates" section with data-loss warning.
-- `tests/` — 5 new DB test modules plus shared `conftest.py` with sample JSON payloads and the `reset_db_engine` fixture.
+- `app/services/db.py` (new), engine init, PRAGMA hook, Alembic bootstrap (`apply_migrations`), `init_and_migrate`, per-store migrators.
+- `app/services/dat_store.py`, `verification_store.py`, `chd_metadata_store.py`, `dat_sync.py`, re-pointed at the SQLAlchemy session factory; chunked upserts where bulk operations cross SQLite's 999-bind-parameter limit.
+- `migrations/` (new), `alembic.ini`, `env.py`, `versions/0001_baseline_schema.py`.
+- `app/main.py`, `startup_event` initialises the DB, runs Alembic, then `init_and_migrate` before any store is touched.
+- `.github/workflows/docker-image.yml`, `:beta` tag for pre-releases.
+- `README.md`, "Available Tags" table expanded with `:beta` and pre-release semver entries; new "Opting in to beta updates" section with data-loss warning.
+- `tests/`, 5 new DB test modules plus shared `conftest.py` with sample JSON payloads and the `reset_db_engine` fixture.
 
-### ⚠️ Upgrade Notes
+### Upgrade Notes
 
-- **Back up your `data_dir`** before upgrading, especially if you have a large `dat_store.json` — this is a one-way migration. The legacy JSON is preserved as `*.migrated.bak` on successful import, but the new DB is the source of truth after restart.
+- **Back up your `data_dir`** before upgrading, especially if you have a large `dat_store.json`, this is a one-way migration. The legacy JSON is preserved as `*.migrated.bak` on successful import, but the new DB is the source of truth after restart.
 - **Downgrading to v3.6.x** after `compressatorium.db` has accepted writes is not supported. If you need to roll back, restore the `.migrated.bak` files (remove the suffix) and delete `compressatorium.db` before starting the older image.
-- **Read-only `/config` volumes** — the DB falls back to `$TMPDIR/compressatorium/compressatorium.db` if `data_dir` is unwritable, matching the legacy JSON-store fallback. Set `CHD_DB_PATH` explicitly if you want a different location.
+- **Read-only `/config` volumes**, the DB falls back to `$TMPDIR/compressatorium/compressatorium.db` if `data_dir` is unwritable, matching the legacy JSON-store fallback. Set `CHD_DB_PATH` explicitly if you want a different location.
 
 ---
 
 ## v3.3.2 - CD CHD Sector Extraction Fix
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
-- **PS1 serial extraction from CD CHDs** — `_extract_from_chd_sectors` previously returned `None` for all CD-based CHDs (unit_bytes=2352/2448), meaning PS1 game serials could only be extracted from companion `.bin`/`.cue` files or if those CHDs were already tagged at conversion time.  The function now probes both **Mode 2 Form 1** (24-byte header) and **Mode 1** (16-byte header) sector framing when reading 2352- or 2448-byte CD sectors, allowing it to walk the embedded ISO 9660 filesystem directly — exactly as libchdr-based emulators (PCSX2, AetherSX2, NetherSX2) do.  For CHDs created from Mode 2 Form 1 BIN/CUE images (the most common PS1 format), extraction now succeeds without requiring a companion source file.
+- **PS1 serial extraction from CD CHDs**, `_extract_from_chd_sectors` previously returned `None` for all CD-based CHDs (unit_bytes=2352/2448), meaning PS1 game serials could only be extracted from companion `.bin`/`.cue` files or if those CHDs were already tagged at conversion time. The function now probes both **Mode 2 Form 1** (24-byte header) and **Mode 1** (16-byte header) sector framing when reading 2352- or 2448-byte CD sectors, allowing it to walk the embedded ISO 9660 filesystem directly, exactly as libchdr-based emulators (PCSX2, AetherSX2, NetherSX2) do. For CHDs created from Mode 2 Form 1 BIN/CUE images (the most common PS1 format), extraction now succeeds without requiring a companion source file.
 
-### 🧪 Tests
+### Tests
 
-- Added `test_extract_from_chd_sectors_ps1_cd_mode1` — verifies PS1 serial extraction from a CD CHD with 2352-byte Mode 1 sectors.
-- Added `test_extract_from_chd_sectors_ps1_cd_mode2` — verifies PS1 serial extraction from a CD CHD with 2352-byte Mode 2 Form 1 sectors.
-- Added `test_extract_from_chd_sectors_cd_no_recognizable_content` — confirms that a CD CHD with no ISO 9660 filesystem still returns `None` gracefully.
+- Added `test_extract_from_chd_sectors_ps1_cd_mode1`, verifies PS1 serial extraction from a CD CHD with 2352-byte Mode 1 sectors.
+- Added `test_extract_from_chd_sectors_ps1_cd_mode2`, verifies PS1 serial extraction from a CD CHD with 2352-byte Mode 2 Form 1 sectors.
+- Added `test_extract_from_chd_sectors_cd_no_recognizable_content`, confirms that a CD CHD with no ISO 9660 filesystem still returns `None` gracefully.
 - Replaced the now-obsolete `test_extract_from_chd_sectors_non_dvd_returns_none` test (which verified the old early-return shortcut) with the three new tests above.
 
-### 📁 Files Changed
+### Files Changed
 
-- `app/services/disc_id.py` — `_extract_from_chd_sectors` extended to handle CD CHDs; docstrings updated throughout
-- `tests/test_disc_id.py` — Three new CD CHD extraction tests; module docstring updated
+- `app/services/disc_id.py`, `_extract_from_chd_sectors` extended to handle CD CHDs; docstrings updated throughout
+- `tests/test_disc_id.py`, Three new CD CHD extraction tests; module docstring updated
 
 ---
 
 ## v3.3.1 - Structured Logging with LOGLEVEL
 
-### ✨ New Features
+### New Features
 
-- **`LOGLEVEL` environment variable** — Replaces the removed `CHD_DEBUG` flag. Set to `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` to control log verbosity. Defaults to `INFO` so useful operational logs are visible out of the box without any configuration. Legacy `CHD_DEBUG=true` is still honoured and maps to `LOGLEVEL=DEBUG` for backwards compatibility.
-- **`LOG_PATH`** — Replaces the removed `CHD_DEBUG_LOG_PATH`. Optionally write logs to a file in addition to stdout, at any log level (not just debug). Legacy `CHD_DEBUG_LOG_PATH` is still read for backwards compatibility.
+- **`LOGLEVEL` environment variable**, Replaces the removed `CHD_DEBUG` flag. Set to `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` to control log verbosity. Defaults to `INFO` so useful operational logs are visible out of the box without any configuration. Legacy `CHD_DEBUG=true` is still honoured and maps to `LOGLEVEL=DEBUG` for backwards compatibility.
+- **`LOG_PATH`**, Replaces the removed `CHD_DEBUG_LOG_PATH`. Optionally write logs to a file in addition to stdout, at any log level (not just debug). Legacy `CHD_DEBUG_LOG_PATH` is still read for backwards compatibility.
 
-### 🔍 Enhanced Metadata Scan Logging
+### Enhanced Metadata Scan Logging
 
 Metadata scans now emit detailed, structured `INFO`-level logs covering every stage, so users can fully understand what the application is doing by inspecting logs:
 
-- **Scan start** — Logs `force` mode, number of volumes, and their paths.
-- **Discovery** — Logs how many CHD files were found across how many volumes; warns on any missing/inaccessible volume.
-- **Phase 1 (metadata extraction)** — Logs each file with a `[n/total]` counter as its `chdman info` metadata is extracted and cached. Logs success per file; warns on failure.
-- **Phase 1 summary** — Reports how many files were refreshed vs already up-to-date.
-- **Phase 2 (disc ID tagging)** — Logs when each previously-unchecked CHD is scanned for a GAME/NAME tag. When a disc ID is successfully embedded into the CHD file, logs the filename and extracted `game_id`. When no disc ID can be found, logs that the file was marked as checked.
-- **Phase 2 summary** — Reports already-checked, newly-checked, and embedded tag counts.
-- **Flush** — Logs when the metadata store is being persisted and when it completes.
-- **Final summary** — Reports total metadata refreshed, disc IDs embedded, and total elapsed time.
+- **Scan start**, Logs `force` mode, number of volumes, and their paths.
+- **Discovery**, Logs how many CHD files were found across how many volumes; warns on any missing/inaccessible volume.
+- **Phase 1 (metadata extraction)**, Logs each file with a `[n/total]` counter as its `chdman info` metadata is extracted and cached. Logs success per file; warns on failure.
+- **Phase 1 summary**, Reports how many files were refreshed vs already up-to-date.
+- **Phase 2 (disc ID tagging)**, Logs when each previously-unchecked CHD is scanned for a GAME/NAME tag. When a disc ID is successfully embedded into the CHD file, logs the filename and extracted `game_id`. When no disc ID can be found, logs that the file was marked as checked.
+- **Phase 2 summary**, Reports already-checked, newly-checked, and embedded tag counts.
+- **Flush**, Logs when the metadata store is being persisted and when it completes.
+- **Final summary**, Reports total metadata refreshed, disc IDs embedded, and total elapsed time.
 
 Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also promoted from `DEBUG` to `INFO` so the source of each embedded tag (CHD sectors, GDRO, or companion file) is visible in normal operation.
 
-### 🛠 Internal Changes
+### Internal Changes
 
 - The background maintenance loop (stuck-job detection, stale lock cleanup) now always runs, not only when `LOGLEVEL=DEBUG`. It was previously gated behind `CHD_DEBUG=true`, meaning stuck-job recovery silently didn't operate in production.
 
-### 📁 Files Changed
+### Files Changed
 
-- `app/config.py` — Removed `debug`/`CHD_DEBUG`; added `log_level`/`LOGLEVEL` (default `INFO`) and `log_path`/`LOG_PATH`
-- `app/main.py` — `configure_logging()` parses `LOGLEVEL` instead of the old boolean flag
-- `app/services/job_manager.py` — Maintenance loop always starts; removed `settings.debug` gate
-- `app/routes/info.py` — Comprehensive structured INFO logging throughout `scan_metadata_task`
-- `app/services/disc_id.py` — Embedding log calls promoted from `DEBUG` to `INFO`
-- `README.md`, `DEPLOYMENT.md`, `DOCKER-COMPOSE.md` — Updated env var tables
+- `app/config.py`, Removed `debug`/`CHD_DEBUG`; added `log_level`/`LOGLEVEL` (default `INFO`) and `log_path`/`LOG_PATH`
+- `app/main.py`, `configure_logging()` parses `LOGLEVEL` instead of the old boolean flag
+- `app/services/job_manager.py`, Maintenance loop always starts; removed `settings.debug` gate
+- `app/routes/info.py`, Detailed structured INFO logging throughout `scan_metadata_task`
+- `app/services/disc_id.py`, Embedding log calls promoted from `DEBUG` to `INFO`
+- `README.md`, `DEPLOYMENT.md`, `DOCKER-COMPOSE.md`, Updated env var tables
 
 ---
 
 ## v3.3.0 - Game ID & Title Extraction for CD and DVD CHDs
 
-### ✨ New Features
+### New Features
 
-- **Game ID & Title in CHD Inspector** — PS1, PS2, PSP, and Dreamcast game serials are extracted from CHD sector data (via `SYSTEM.CNF`, `PARAM.SFO`, and `IP.BIN`) and displayed in the CHD info modal. Human-readable titles (e.g. "Patapon", "DEAD OR ALIVE 2") are shown when available; the serial is used as a fallback title.
-- **CHD metadata tagging at conversion time** — When a CD or DVD CHD is created, the game serial is embedded as a `GAME` tag and the title as a `NAME` tag inside the CHD file itself, making it readable by emulator frontends and database scrapers.
-- **Retroactive game ID tagging** — The metadata scan (Phase 2) now loops over all CHDs and embeds `GAME`/`NAME` tags into any file that doesn't have them yet. Already-tagged and previously-scanned files are skipped efficiently.
-- **Persistent disc-ID cache** — Extracted game IDs and titles are stored in the metadata cache (`chd_metadata.json`). The `/api/info` endpoint reads from the cache first; `chdman dumpmeta` subprocesses are only spawned on a cache miss, and "nothing found" results are also cached to prevent repeated subprocess calls for unsupported discs.
+- **Game ID & Title in CHD Inspector**, PS1, PS2, PSP, and Dreamcast game serials are extracted from CHD sector data (via `SYSTEM.CNF`, `PARAM.SFO`, and `IP.BIN`) and displayed in the CHD info modal. Human-readable titles (e.g. "Patapon", "DEAD OR ALIVE 2") are shown when available; the serial is used as a fallback title.
+- **CHD metadata tagging at conversion time**, When a CD or DVD CHD is created, the game serial is embedded as a `GAME` tag and the title as a `NAME` tag inside the CHD file itself, making it readable by emulator frontends and database scrapers.
+- **Retroactive game ID tagging**, The metadata scan (Phase 2) now loops over all CHDs and embeds `GAME`/`NAME` tags into any file that doesn't have them yet. Already-tagged and previously-scanned files are skipped efficiently.
+- **Persistent disc-ID cache**, Extracted game IDs and titles are stored in the metadata cache (`chd_metadata.json`). The `/api/info` endpoint reads from the cache first; `chdman dumpmeta` subprocesses are only spawned on a cache miss, and "nothing found" results are also cached to prevent repeated subprocess calls for unsupported discs.
 
-### 🔬 Implementation Details
+### Implementation Details
 
-- `app/services/disc_id.py` — New service implementing:
-  - `_CHDReader` — minimal CHD v5 sector reader (ZLIB, LZMA, ZSTD, NONE, MINI compression)
-  - `extract_from_source()` — PS1/PS2 `.iso`/`.bin`/`.cue`/`.gdi` serial extractor
-  - `extract_from_chd()` — four-strategy extractor (embedded GAME tag → sector read → Dreamcast GDRO → companion source files)
-  - `ensure_disc_id_embedded()` — retroactive CHD tagger called during metadata scan
-- `app/services/chd_metadata_store.py` — Added `get_disc_id_info()`, `update_disc_id_info()`, `is_disc_id_checked()`, and `mark_disc_id_checked()`; `set_metadata()` now preserves `game_id`, `title`, `disc_id_checked`, and `disc_id_checked_mtime` during Phase 1 metadata refreshes
-- `app/routes/info.py` — `/api/info` uses the metadata cache; CHDs already scanned (Phase 2 or prior `/api/info` call) with no game ID skip re-extraction
-- `app/models.py` — `CHDInfo` model extended with optional `game_id` and `title` fields
-- `static/js/app.js` — CHD info modal shows "Game ID" and "Title" rows when values are present
+- `app/services/disc_id.py`, New service implementing:
+  - `_CHDReader`, minimal CHD v5 sector reader (ZLIB, LZMA, ZSTD, NONE, MINI compression)
+  - `extract_from_source()`, PS1/PS2 `.iso`/`.bin`/`.cue`/`.gdi` serial extractor
+  - `extract_from_chd()`, four-strategy extractor (embedded GAME tag → sector read → Dreamcast GDRO → companion source files)
+  - `ensure_disc_id_embedded()`, retroactive CHD tagger called during metadata scan
+- `app/services/chd_metadata_store.py`, Added `get_disc_id_info()`, `update_disc_id_info()`, `is_disc_id_checked()`, and `mark_disc_id_checked()`; `set_metadata()` now preserves `game_id`, `title`, `disc_id_checked`, and `disc_id_checked_mtime` during Phase 1 metadata refreshes
+- `app/routes/info.py`, `/api/info` uses the metadata cache; CHDs already scanned (Phase 2 or prior `/api/info` call) with no game ID skip re-extraction
+- `app/models.py`, `CHDInfo` model extended with optional `game_id` and `title` fields
+- `static/js/app.js`, CHD info modal shows "Game ID" and "Title" rows when values are present
 
-### 🧪 Tests
+### Tests
 
 - 12 new tests covering `_CHDReader` MINI hunk decoding, `_extract_cue` (including missing-file fallback and multi-file fallback), source-file extraction, CHD sector extraction, metadata store disc-ID methods, and retroactive embedding
 
-### 📁 Files Changed
+### Files Changed
 
-- `app/services/disc_id.py` — New service (source extractor + CHD reader + retroactive tagger)
-- `app/services/job_manager.py` — Embeds `GAME`/`NAME` tags at conversion time
-- `app/services/chd_metadata_store.py` — Disc-ID cache methods; `set_metadata()` field preservation
-- `app/routes/info.py` — `/api/info` disc-ID cache lookup + Phase 2 retroactive tagging
-- `app/models.py` — `CHDInfo.game_id` / `CHDInfo.title` fields
-- `static/js/app.js` — Game ID and Title rows in CHD info modal
-- `tests/test_disc_id.py` — Comprehensive disc-ID extraction tests
-- `tests/test_metadata.py` — Metadata store disc-ID caching tests
+- `app/services/disc_id.py`, New service (source extractor + CHD reader + retroactive tagger)
+- `app/services/job_manager.py`, Embeds `GAME`/`NAME` tags at conversion time
+- `app/services/chd_metadata_store.py`, Disc-ID cache methods; `set_metadata()` field preservation
+- `app/routes/info.py`, `/api/info` disc-ID cache lookup + Phase 2 retroactive tagging
+- `app/models.py`, `CHDInfo.game_id` / `CHDInfo.title` fields
+- `static/js/app.js`, Game ID and Title rows in CHD info modal
+- `tests/test_disc_id.py`, Full disc-ID extraction tests
+- `tests/test_metadata.py`, Metadata store disc-ID caching tests
 
 ---
 
 ## v3.2.3 - Batched Notifications, Deferred UI Updates & Job Index
 
-### 🎨 UI / UX
+### UI / UX
 
 - **Batched terminal notifications** - Completed, failed, and cancelled job notifications are now aggregated per flush cycle. Instead of one toast per job, a single summary toast is shown (e.g. "Completed 5 jobs", "2 jobs failed"). Individual filenames are still shown when only one job completes.
 - **Batched verified-CHD set updates** - `setVerifiedCHDs` is called once per flush with all added/removed paths collected during the batch, eliminating per-job Set cloning.
 - **Deferred UI updates during dropdown interaction** - A `deferJobUiUpdatesRef` flag pauses job-driven React re-renders while a `<select>` dropdown (mode, filter, page-size) is focused or has its menu open. This prevents the dropdown from closing mid-selection when an SSE update or poll cycle triggers a state change. Dropdowns set the flag on `focus`/`mousedown` and clear it on `blur`/`change`.
 - **Capped placeholder rows** - Optimistic "creating" placeholders are capped at `MAX_VISIBLE_CREATING_PLACEHOLDERS` (100). For larger batches, remaining jobs are counted but not rendered, with an info toast showing the total queued count.
 
-### ⚙️ Reliability & Performance
+### Reliability & Performance
 
 - **Job index map** - `applyQueuedJobUpdates` now builds a lazy `Map<jobId, index>` via `ensureJobIndex()` on first lookup, replacing O(n) `findIndex` per update with O(1) map lookups. The index is maintained as jobs are inserted or replaced.
 - **Extracted `applyPolledJobs` helper** - The poll-interval and initial-fetch merge logic is deduplicated into a single `applyPolledJobs(serverJobs)` function. It also checks `deferJobUiUpdatesRef` to skip state updates while a dropdown is open.
 - **Stuck-state polling guard** - `checkStuckStatus` responses are silently discarded when `deferJobUiUpdatesRef` is active, preventing spurious stuck-state banner flickers during dropdown interaction.
 - **New-job insertion order** - Hydrated jobs arriving via SSE for unknown IDs are now appended (`push`) instead of prepended (`unshift`), maintaining chronological order and avoiding unnecessary array shifts.
 
-### 📁 Files Changed
+### Files Changed
 
 - `static/js/app.js` - All changes above: batched notifications, deferred UI flag, `ensureJobIndex`, `applyPolledJobs`, placeholder cap, dropdown `onFocus`/`onBlur`/`onMouseDown` handlers
 
@@ -629,28 +629,28 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v3.2.2 - Search View Snapshot & Auto-Return
 
-### ✨ New Features
+### New Features
 
 - **Search view snapshot / restore** - Before "Search All" runs, the current file-list state (entries, archive path, selection, page) is captured. The "← File List" button restores this snapshot exactly, preserving scroll position context instead of re-fetching the directory.
 - **Auto-return to file list** - After a successful conversion from search results, the UI automatically restores the pre-search file-list view when `COMPRESSATORIUM_SEARCH_AUTO_RETURN_TO_FILE_LIST` is `true` (default). The setting is served from `/api/version` and respected by the frontend at runtime.
 - **New config setting** - `COMPRESSATORIUM_SEARCH_AUTO_RETURN_TO_FILE_LIST` (default `true`) with legacy alias `CHD_SEARCH_AUTO_RETURN_TO_FILE_LIST` via Pydantic `AliasChoices`.
 
-### 🐞 Bug Fixes
+### Bug Fixes
 
 - **Conversion return values** - `executeConversion` and `maybeConfirmDeletePlan` now return `boolean` success indicators, enabling callers to decide post-conversion behavior (e.g. auto-return).
 - **Snapshot invalidation** - Pre-search snapshot is cleared on volume switch and directory navigation so stale state is never restored.
 
-### 📖 Documentation
+### Documentation
 
 - **README** - Added `COMPRESSATORIUM_SEARCH_AUTO_RETURN_TO_FILE_LIST` and legacy alias to env var table.
 - **DEPLOYMENT.md** - Added new env var to deployment reference.
 - **DOCKER-COMPOSE.md** - Added new env var to compose reference.
 
-### 🧪 Tests
+### Tests
 
 - **Search auto-return config** - New `test_search_auto_return_default_and_legacy_alias` verifies the setting defaults to `true` and respects the legacy `CHD_` alias.
 
-### 📁 Files Changed
+### Files Changed
 
 - `app/config.py` - `search_auto_return_to_file_list` field with `AliasChoices`
 - `app/routes/info.py` - `/api/version` response includes `search_auto_return_to_file_list`
@@ -662,14 +662,14 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v3.2.1 - CI Release Notes from Commit Log
 
-### ⚙️ CI / CD
+### CI / CD
 
 - **Auto-generated release body** - The `create-release` job now checks out the repo with full history and tags, derives the previous semver tag, and builds a changelog from `git log --no-merges` between the two tags. The result is written to `RELEASE_BODY.md` and passed via `body_path` instead of relying on GitHub's `generate_release_notes`.
 - **Previous-tag derivation** - New `previous_tag` output in the `release_meta` step finds the most recent `v*.*.*` tag excluding the current one, enabling accurate commit-range changelogs.
 - **Full changelog link** - The generated release body includes a GitHub compare URL (`previous_tag...current_tag`) for easy diff browsing.
 - **Fallback handling** - If no previous tag exists (first release) or no non-merge commits are found, sensible defaults are emitted instead of an empty body.
 
-### 📁 Files Changed
+### Files Changed
 
 - `.github/workflows/docker-image.yml` - Added checkout step with `fetch-depth: 0` and `fetch-tags: true`, commit-log changelog generation, `body_path` release body
 
@@ -677,18 +677,18 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v3.2.0 - Job Tabs & Queue Pagination
 
-### ✨ New Features
+### New Features
 
 - **Job tabs** - The jobs panel is now split into three tabs: **Queue** (queued + processing + creating), **Completed**, and **Failed/Cancelled**. Each tab shows its own count. The "Failed/Cancelled" tab auto-hides when empty and auto-switches back to Queue if emptied while active.
 - **Job pagination** - Jobs within each tab are paginated with configurable page-size (10 / 25 / 50 / 100 / All), page navigation buttons, and a "Showing X–Y of Z" summary. Current page is clamped when the list shrinks.
 
-### 🎨 UI / UX
+### UI / UX
 
 - **Tab bar styling** - Pill-shaped tab buttons with uppercase labels, accent-color active state, hover highlights, and full-width equal-sizing on mobile (≤768 px).
 - **Job header count** - The "Jobs" heading now displays the combined total across all tabs rather than the raw `jobs.length`.
 - **Empty-state messaging** - Each tab shows contextual empty titles and help text (e.g. "Select files and click Convert" for Queue, "Successfully completed jobs will appear here" for Completed).
 
-### 📁 Files Changed
+### Files Changed
 
 - `static/js/app.js` - Job tab state, `displayedJobs` / `queueJobs` / `completedJobs` / `issueJobs` memos, `jobsPagination` / `paginatedJobs` computed values, tab bar and pagination controls, contextual empty-state props
 - `static/css/style.css` - `.job-tabs`, `.job-tab`, `.job-tab.active`, `.job-tab:hover` styles + mobile responsive rules
@@ -697,25 +697,25 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v3.1.1 - SSE Batching, Verify Concurrency & Test Coverage
 
-### 🐞 Bug Fixes
+### Bug Fixes
 
 - **Verify concurrency default** - `MAX_VERIFY_CONCURRENCY` default changed from `2` to `1` to match serial-first processing policy, preventing unexpected parallel verify workloads on low-resource hosts.
 
-### 🎨 UI / UX
+### UI / UX
 
 - **SSE job-update batching** - Rapid Server-Sent Events are now coalesced in a micro-batch window (`JOB_UPDATE_BATCH_WINDOW_MS`) before applying to React state. Only the latest update per job is kept, drastically reducing re-renders during high-throughput conversions.
 - **Lazy state cloning** - `setJobs` updater uses an `ensureMutable()` helper that clones the jobs array at most once per flush, avoiding unnecessary allocations when no fields actually changed.
 - **Flush-on-terminal** - Terminal events (`complete`, `error`, `cancelled`) force an immediate flush of the pending batch so the UI reflects final state without waiting for the batch timer.
 
-### 📖 Documentation
+### Documentation
 
 - **README** - Updated `MAX_VERIFY_CONCURRENCY` default from `2` to `1` in the environment variable table.
 
-### 🧪 Tests
+### Tests
 
 - **Serial concurrency defaults** - New `test_concurrency_defaults_are_serial` in `tests/test_volume_discovery.py` asserts both `max_concurrent_jobs` and `max_verify_concurrency` default to `1`.
 
-### 📁 Files Changed
+### Files Changed
 
 - `app/config.py` - `max_verify_concurrency` default `2` → `1`
 - `static/js/app.js` - SSE micro-batching, lazy array cloning, flush-on-terminal
@@ -726,14 +726,14 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v3.1.0 - Volume Discovery, Queue Controls & UI Refresh
 
-### ✨ New Features
+### New Features
 
 - **Automatic volume discovery** - When `COMPRESSATORIUM_VOLUMES` is not set, the app discovers mounted libraries from `COMPRESSATORIUM_MOUNT_ROOT/*` at startup. Mount-point children are preferred over plain directories; results are cached for stable runtime behavior.
 - **Queue-wide cancellation** - New `POST /api/jobs/cancel-all` endpoint with `X-CHD-Action-Confirm: cancel-all-jobs` header guard. A confirmation modal in the UI prevents accidental bulk cancellation.
 - **Clear completed jobs** - New `DELETE /api/jobs/completed` endpoint with `X-CHD-Action-Confirm: clear-completed-jobs` header guard. Adds a "Clear Done" button with a confirmation modal showing the count of jobs to remove.
 - **Entrypoint volume discovery** - `entrypoint.sh` now runs the same discover-volumes logic at container startup and logs whether volumes are explicit or auto-discovered, with proper comma-delimited iteration and whitespace trimming.
 
-### 🐞 Bug Fixes
+### Bug Fixes
 
 - **Serial queue enforcement** - When `MAX_CONCURRENT_JOBS=1`, the dispatcher now awaits `_run_job()` inline instead of spawning a detached task, preventing race-condition parallel processing.
 - **Serial verify default** - `MAX_VERIFY_CONCURRENCY` now defaults to `1` so verification workloads are single-lane unless explicitly increased.
@@ -743,7 +743,7 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 - **Progress update deduplication** - SSE event handler skips `setJobs` when all tracked fields are identical, eliminating unnecessary React re-renders.
 - **File-list auto-refresh paused during work** - Auto-refresh interval is suppressed while any jobs are creating, queued, or processing, preventing disruptive list flickers mid-batch.
 
-### 🎨 UI / UX
+### UI / UX
 
 - **Header and footer logo** - `logo.png` is displayed in the header alongside the title and in the app footer.
 - **Favicon** - `index.html` now uses `favicon.ico` from `/static/images/`.
@@ -753,13 +753,13 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 - **Stale progress ref cleanup** - `progressRenderAtRef` entries are pruned on terminal events and during `mergeJobs`, preventing memory leaks from long sessions.
 - **Clear Done confirmation modal** - New `ClearDoneModal` component shows job count and guards accidental clears. Button shows a spinner (`clearingCompletedJobs` state) during the API call.
 
-### ⚙️ Reliability & Maintenance
+### Reliability & Maintenance
 
 - **Environment variable standardization** - Preferred env names are `COMPRESSATORIUM_MOUNT_ROOT` and `COMPRESSATORIUM_VOLUMES`. Legacy `CHD_MOUNT_ROOT` / `CHD_VOLUMES` remain supported via Pydantic `AliasChoices`.
 - **Startup volume caching** - `Settings.scan_data_mounts_on_startup()` snapshots discovered volumes once at boot so the runtime volume list is stable even if mount points change later.
 - **Data mount root config** - New `data_mount_root` setting (default `/data`) controls where the auto-discovery scan looks.
 
-### 📖 Documentation
+### Documentation
 
 - **README** - Updated batch conversion docs, added cancel-all / clear-done mentions, documented confirmation headers on destructive API actions, added new 3DS verify endpoints, updated environment variable table with `COMPRESSATORIUM_*` names and legacy aliases, updated example docker-compose snippet.
 - **DEPLOYMENT.md** - Refreshed for new environment variable names.
@@ -768,7 +768,7 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 - **Docker Compose files** - All three compose files (`docker-compose.yml`, `docker-compose.multi-volume.yml`, `docker-compose.cli.yml`) updated from `CHD_VOLUMES` to `COMPRESSATORIUM_MOUNT_ROOT=/data`.
 - **run_dev.sh** - Updated to use `COMPRESSATORIUM_MOUNT_ROOT` / `COMPRESSATORIUM_VOLUMES` with fallback to legacy names.
 
-### 🧪 Tests
+### Tests
 
 - **Volume discovery** - New `tests/test_volume_discovery.py` covering explicit volumes, auto-discovery from children, and startup cache stability.
 - **Cancel-all confirmation header** - Test that `cancel_all_jobs` rejects requests missing the confirmation header with `400`.
@@ -777,7 +777,7 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 - **Serial dispatcher concurrency** - End-to-end test proving `max_concurrent=1` never exceeds one simultaneous conversion.
 - **z3ds / Dolphin test fixtures** - Added `data_mount_root` monkeypatch to `test_z3ds_routes.py`, `test_metadata.py`, `test_dolphin_routes.py`, and `test_mode_parity_fixes.py` to satisfy the new required setting.
 
-### 📁 Files Changed
+### Files Changed
 
 - `app/config.py` - Volume discovery engine, `data_mount_root`, `AliasChoices`, startup scan cache
 - `app/main.py` - Index `Cache-Control: no-store`, version query param on `app.js`
@@ -802,7 +802,7 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v3.0.1 - Clear Queue Feature
 
-### ✨ New Features
+### New Features
 
 - **Clear Queue** - Added a "Clear Queue" button to the job queue header that allows users to cancel all running and queued jobs at once.
     - **API Endpoint** - `POST /api/jobs/cancel-all` endpoint exposed for bulk cancellation.
@@ -812,7 +812,7 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v3.0.0 - Nintendo 3DS Support & Docker Compose Overhaul
 
-### ✨ New Features
+### New Features
 
 - **Nintendo 3DS Support** - Native support for compressing `.cci`, `.cia`, and `.3ds` ROMs using `z3ds_compress`.
     - **New Tool Option** - Select **3DS** from the main tool selector to access 3DS compression modes.
@@ -823,13 +823,13 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
     - `docker-compose.multi-volume.yml` - Template for multiple volume mounts.
     - `docker-compose.cli.yml` - Dedicated CLI batch processing configuration.
 
-### ⚠️ Breaking Changes
+### Breaking Changes
 
 - **ISO Handling Policy** - The "ISO Handling" setting no longer defaults to Dolphin.
     - **Explicit Selection Required** - Users must now explicitly choose between "CHDMAN" (for PS2/DVD) or "Dolphin" (for GameCube/Wii) when processing `.iso` files.
     - **UI Validation** - The interface prevents conversion of ISO files until a handler is selected, preventing accidental invalid conversions.
 
-### 🐞 Bug Fixes
+### Bug Fixes
 
 - **Delete-on-verify messaging** - Corrected messaging for z3ds mode delete-on-verify operations in `static/js/app.js`.
 - **Lock Manager** - Fixed `ensure_lock_manager` usage in `services/job_manager.py` to prevent race conditions during z3ds detection.
@@ -841,10 +841,10 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 - **UI Accessibility** - Increased warning text size and improved color contrast for better readability in `static/css/style.css`.
 - **ISO Handling Validation** - Added strict check for `iso_handling` parameter in `routes/convert.py`, rejecting requests where it is null.
 
-### ⚙️ Reliability & Maintenance
+### Reliability & Maintenance
 
 - **Periodic Lock Cleanup** - Added `cleanup_stale_locks_periodic` to `JobManager` (services/job_manager.py), running every 10 debug heartbeats (approx. 5 minutes) to automatically remove stale lock files.
-- **Z3DS Metadata Optimization** - Added `has_z3ds` and `z3ds_convertible` flags to file search responses in `routes/files.py` to optimize frontend filtering.
+- **Z3DS metadata flags** - Added `has_z3ds` and `z3ds_convertible` flags to file search responses in `routes/files.py` to speed up frontend filtering.
 - **Conversion Queue Backpressure** - Added queue depth limiting for job creation endpoints:
     - New `MAX_QUEUE_DEPTH` guard applies to `/api/jobs` and `/api/jobs/batch`.
     - Requests now return HTTP `429` when queued + processing jobs exceed configured capacity.
@@ -857,7 +857,7 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
     - Adds `CHD_PROGRESS_TIMEOUT_PER_GIB` seconds per GiB of input.
     - Enforces upper bound with `CHD_PROGRESS_TIMEOUT_CAP`.
 
-### 🔧 Technical Details
+### Technical Details
 
 - **Z3DS Integration** - Implemented `Z3DS_INFO_EXTENSIONS` and `Z3DS_VERIFY_EXTENSIONS` constants for centralized file type management.
 - **Path Helper Methods** - Added `_is_z3ds_info_file` and `_is_z3ds_verify_file` helpers in `routes/info.py` for consistent file type checking.
@@ -869,13 +869,13 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 - **Regression Coverage** - Added tests for queue-capacity `429`, verify-lane `429`, and adaptive timeout math.
 
 
-### 🛡️ Deployment & Security
+### Deployment & Security
 
 - **New Deployment Guide** - `DEPLOYMENT.md` covers security best practices, resource limits, and production hardening.
 - **Docker Documentation** - `DOCKER-COMPOSE.md` provides a quick reference for common commands and troubleshooting.
 - **Security Audit** - verified path traversal protections, secret scanning, and container security.
 
-### 📁 Files Changed
+### Files Changed
 
 - `static/js/app.js` - Added 3DS tool logic and frontend integration.
 - `app/services/z3ds_compress.py` - New service for 3DS compression.
@@ -898,31 +898,31 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v2.0.1 - Mobile-Responsive Design
 
-### 🎨 UI/UX Improvements
+### UI/UX Improvements
 
-- **Mobile-responsive Web UI** - Complete mobile optimization with card-based file list layout, touch-friendly controls (44-48px minimum touch targets), and single-column layout for screens under 768px.
-- **Responsive breakpoints** - Added media queries at 480px, 768px, 900px, and 1200px for seamless experience across all devices.
-- **Touch-optimized controls** - All interactive elements meet WCAG accessibility standards with proper touch target sizing.
+- **Mobile-responsive Web UI** - A full mobile layout with a card-based file list, touch-friendly controls (44-48px minimum touch targets), and a single column for screens under 768px.
+- **Responsive breakpoints** - Added media queries at 480px, 768px, 900px, and 1200px for a consistent layout across phones, tablets, and desktops.
+- **Touch-friendly controls** - Interactive elements meet WCAG touch-target sizing.
 - **Card-based file list** - On mobile, file list converts from table layout to vertical cards with better information hierarchy.
 - **Full-width inputs** - Form controls, dropdowns, and buttons span full width on mobile for easier interaction.
 - **Vertical stacking** - ISO handling options, toolbar elements, and compression options stack vertically on mobile.
 - **Modal improvements** - Modals now use 95% viewport width on mobile with proper scrolling (90vh max-height).
 - **Screenshots documentation** - Added responsive design screenshots to README showcasing desktop, tablet, and mobile views.
 
-### 🔧 Technical Details
+### Technical Details
 
 - Pure CSS solution with no JavaScript changes required
 - Zero breaking changes to desktop functionality
 - 627 lines of responsive CSS added
 - Desktop layout (3-column) fully preserved for screens ≥1200px
 
-### 📁 Files Changed
+### Files Changed
 
-- `static/css/style.css` - Added comprehensive mobile-responsive styles with multiple breakpoints
+- `static/css/style.css` - Added mobile-responsive styles with multiple breakpoints
 - `README.md` - Added Screenshots section with responsive design examples
 - `docs-desktop-view.png`, `docs-tablet-view.png`, `docs-mobile-view.png` - Added documentation screenshots
 
-### ✨ New Features
+### New Features
 
 - **Archive delete-on-verify** - Archive inputs can now delete the entire archive after a successful conversion + verification, with an explicit warning in the delete plan.
 
@@ -930,24 +930,24 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v1.2.1 - Archive Safety Limits & Timeout Controls
 
-### ✨ New Features
+### New Features
 
 - **Archive safety limits** - Configure maximum archive entries, per-member size, and total extraction size with `CHD_ARCHIVE_MAX_ENTRIES`, `CHD_ARCHIVE_MAX_MEMBER_SIZE`, and `CHD_ARCHIVE_MAX_TOTAL_SIZE`.
 - **Archive truncation metadata** - File listing/search responses now report when archive listings are truncated by safety limits.
 - **Verification timeouts** - New `CHD_VERIFY_TIMEOUT` and `CHD_VERIFY_PROGRESS_TIMEOUT` allow you to stop long-running or stalled `chdman verify` operations.
 
-### 🛡️ Safety Improvements
+### Safety Improvements
 
 - **Output directory validation** - Output directories are trimmed and rejected if empty, preventing accidental writes to invalid paths.
 - **Safe temp cleanup** - Temporary directories are only removed if they are within expected temp locations.
 - **Chdman info timeout** - `CHD_INFO_TIMEOUT` prevents `chdman info` from hanging indefinitely.
 
-### 🐞 Bug Fixes
+### Bug Fixes
 
 - **Archive enumeration errors** - Directory scans skip problematic entries instead of failing entire requests.
 - **Output path creation** - Output directories are only created when a directory component exists.
 
-### 📁 Files Changed
+### Files Changed
 
 - `app/config.py` - Added archive and timeout configuration values
 - `app/models.py` - Archive truncation metadata
@@ -963,25 +963,25 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v1.2.0 - Delete-on-Verify & Safer File Ops
 
-### ✨ New Features
+### New Features
 
 - **Delete-on-verify** - Optional post-conversion verification that deletes the original source only after a successful CHD verify (create/copy modes).
 - **Delete plan confirmation** - New `/api/jobs/delete-plan` endpoint + UI modal showing exactly which files will be removed before conversion starts.
 - **Track-aware deletes** - `.cue`/`.gdi` companion tracks are included in the delete plan and removed as a set.
 
-### 🛡️ Safety Improvements
+### Safety Improvements
 
 - **Snapshot + fingerprint validation** - Delete plans are revalidated at completion and must match original fingerprints before any deletion.
 - **In-use protection** - File delete/rename operations are blocked while a path is used by an active job (including cue/gdi track files).
 - **Lock hygiene** - Hash-based lock filenames and startup cleanup for stale file locks.
 - **Cancel-safe** - If a cancel occurs after verify, deletion is skipped.
 
-### 🎛️ UI/UX
+### UI/UX
 
 - **Always-visible Select All** checkbox with indeterminate state.
 - **Conversion panel refresh** with clearer post-conversion options and copy-mode warnings.
 
-### 📁 Files Changed
+### Files Changed
 
 - `app/utils/delete_plan.py` - Track parsing, delete plan snapshotting, safety checks
 - `app/services/job_manager.py` - Delete-on-verify orchestration + safety validation
@@ -997,13 +997,13 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v1.1.5 - Archive Conversion Safety & Stall Watchdog
 
-### 🐞 Bug Fixes
+### Bug Fixes
 
 - **Archive member selection** - When both `.cue`/`.gdi` and `.bin` exist in the same archive folder, `.bin` entries are now suppressed. This prevents conversions from starting with an incomplete input set (missing TOC/track layout), which can stall `chdman` and never reach completion.
 - **Batch dedupe by output path** - Batch job creation now keeps only one job per output CHD and prefers `.cue`/`.gdi` > `.iso` > `.bin` when multiple archive members map to the same output. This avoids duplicate work, conflicting locks, and stuck jobs.
 - **Stall watchdog** - New `CHD_PROGRESS_TIMEOUT` fails a conversion if both progress and output size stay unchanged for the configured period (default 600s). The job is marked failed with a clear error instead of lingering at 99%.
 
-### 📁 Files Changed
+### Files Changed
 
 - `app/services/archive.py` - Prefer `.cue`/`.gdi` over `.bin` for archive listings
 - `app/routes/convert.py` - Deduplicate batch jobs by output path and prioritize safe inputs
@@ -1016,12 +1016,12 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v1.1.4 - Python 3.8 Compatibility Fix
 
-### 🐞 Bug Fix
+### Bug Fix
 
 - **Conversion completion regression** - On Python 3.8, the new `list[str]` annotation in `app/services/chdman.py` raises `TypeError: 'type' object is not subscriptable` at runtime. That exception happens inside the conversion generator before the "complete" event is emitted, so jobs never transition to `completed` on the frontend even if `chdman` finishes. The annotation is now `typing.List[str]` to keep Python 3.8 compatibility.
 - **Guardrail test** - Added a test that fails if `list[...]` annotations appear in `chdman.py` without `from __future__ import annotations`, preventing this regression.
 
-### 📁 Files Changed
+### Files Changed
 
 - `app/services/chdman.py` - Python 3.8-safe annotation for output buffering
 - `tests/test_chdman_annotations.py` - Regression test for annotation compatibility
@@ -1030,7 +1030,7 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 ## v1.1.1 - Async I/O & Reliability Improvements
 
-### 🔧 Internal Improvements
+### Internal Improvements
 
 - **Async I/O Refactor** - Filesystem operations on request paths (info, files, stores) now offload to threadpool, preventing event loop blocking
 - **Version-Gated Persistence** - Metadata and verification stores implement last-write-wins with version checks to prevent stale overwrites
@@ -1038,10 +1038,10 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 - **Timezone-Aware Timestamps** - Replaced deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`
 - **Concurrency Tests** - Added test coverage for concurrent metadata/verification store writes
 
-### 📁 Files Changed
+### Files Changed
 
 - `app/services/chd_metadata_store.py` - Async persistence, version-gated replace
-- `app/services/verification_store.py` - Async I/O, version-gated replace  
+- `app/services/verification_store.py` - Async I/O, version-gated replace
 - `app/services/job_manager.py` - Timezone-aware timestamps
 - `app/routes/info.py` - Threadpool offloading for filesystem checks
 - `app/routes/files.py` - Async filesystem operations
@@ -1053,13 +1053,13 @@ Disc ID embedding operations inside `disc_id.py` (strategies 2–4) are also pro
 
 # Release Notes - v1.0.0
 
-## 🎉 Major Release: CHD Metadata Caching & Version System
+## Major Release: CHD Metadata Caching & Version System
 
 This release introduces significant new features including intelligent CHD metadata caching, a unified version system, and enhanced UI capabilities.
 
 ---
 
-## ✨ New Features
+## New Features
 
 ### CHD Metadata Caching System
 - **Persistent metadata cache** - CHD file metadata is now cached to disk, avoiding repeated `chdman info` calls
@@ -1083,7 +1083,7 @@ This release introduces significant new features including intelligent CHD metad
 
 ---
 
-## 🔧 Technical Improvements
+## Technical Improvements
 
 ### Performance
 - **Non-blocking persistence** - Metadata cache writes use thread pool to avoid blocking event loop
@@ -1101,7 +1101,7 @@ This release introduces significant new features including intelligent CHD metad
 
 ---
 
-## 📁 Files Changed
+## Files Changed
 
 - `.version` - New version source of truth
 - `scripts/sync-version.sh` - New version sync utility
@@ -1118,6 +1118,6 @@ This release introduces significant new features including intelligent CHD metad
 
 ---
 
-## 🔄 Upgrade Notes
+## Upgrade Notes
 
 This release is backwards compatible. The metadata cache will be built automatically as CHD files are accessed or when "Scan Metadata" is clicked.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,45 +1,55 @@
-# Walkthrough - Blocking I/O Fixes & Thread Safety
+# Walkthrough: blocking I/O and thread-safety fixes
 
-I have fixed critical blocking I/O issues and ensured thread safety in core services.
+This writeup covers a round of fixes to blocking I/O and thread safety in the core services.
 
-## Key Changes
+## Key changes
 
-### 1. VerificationStore (Async & Thread Safe)
-- **Problem**: Previously performed sync file I/O on the main loop, and earlier async versions had locking race conditions.
-- **Solution**:
-  - Converted to `async/await` using `run_in_threadpool` for disk persistence.
-  - Implemented a dual-lock strategy: `_lock` for in-memory data integrity and `_write_lock` to serialize file writes.
-  - Added **versioning** (`_version` counter) to prevent race conditions where an older snapshot overwrites a newer one.
-  - Persistence employs a **latched state** pattern: `_persist` acquires `_write_lock`, then captures the snapshot. It replaces the file **only** if the captured version matches the current global version at the moment of commit. If the version has advanced, the write is discarded (as a newer persistence task is guaranteed to be queued). This prevents both stale writes and busy loops.
-  - Updated `mark_verified`, `clear`, `move`, and `prune_missing` to use this safe pattern (increment version, trigger persist) and now perform **async path normalization** (`os.path.realpath` in threadpool) to prevent blocking on slow filesystems.
+### 1. VerificationStore (async and thread-safe)
 
-### 2. JobManager (Async Cleanup)
-- **Problem**: Blocking `shutil.rmtree` could freeze the server during large directory deletions.
-- **Solution**: Moved `_cleanup_temp_dir` to `run_in_threadpool`.
+**Problem.** It did synchronous file I/O on the main event loop, and an earlier async version had locking races.
 
-### 3. Files Route (Async I/O)
-- **Problem**: `rename_file` and `delete_file` performed blocking checks on the event loop.
-- **Solution**: Refactored to perform `os.path.exists`, `os.listdir`, `os.rename`, and `os.remove` in the threadpool.
+**Fix.**
+- Moved to `async`/`await`, with disk persistence running through `run_in_threadpool`.
+- Split the locking in two: `_lock` guards the in-memory data, `_write_lock` serializes file writes.
+- Added a `_version` counter so an older snapshot can't overwrite a newer one.
+- Persistence uses a latched-state pattern. `_persist` takes `_write_lock`, captures the snapshot, and replaces the file only if the captured version still matches the current global version at commit time. If the version moved on, the write is dropped, because a newer persist task is already queued. That avoids both stale writes and busy loops.
+- `mark_verified`, `clear`, `move`, and `prune_missing` all use this pattern (bump the version, trigger a persist) and normalize paths off the loop (`os.path.realpath` in the threadpool) so a slow filesystem can't block.
 
-### 4. Development Artifacts
-- Added `requirements-dev.txt` and `tests/` to the repository.
+### 2. JobManager (async cleanup)
 
-## Verification Strategy
+**Problem.** A blocking `shutil.rmtree` could freeze the server while deleting a large directory.
 
-### Thread Safety & Concurrency
-The system uses a combination of techniques to ensure thread safety without blocking the asyncio event loop:
-1.  **Dual Locking**: `_lock` protects in-memory state; `_write_lock` serializes disk I/O.
-2.  **Snapshotting**: Data is copied under lock, then written to disk without holding the main lock.
-3.  **Versioning**: Monotonically increasing versions ensure that late writes do not overwrite newer data.
-4.  **Threadpool Offloading**: Filesystem operations on refactored request paths (info, files rename/delete, stores) are offloaded to a threadpool. Store initialization and some ancillary checks (e.g., volume listing, convert path validation) remain synchronous by design.
+**Fix.** Moved `_cleanup_temp_dir` onto `run_in_threadpool`.
 
-### Automated Tests
-The repository includes comprehensive tests in the `tests/` directory covering:
--   **Locking & Concurrency**: Verifying no deadlocks or race conditions.
--   **Async I/O**: Ensuring blocking calls are properly offloaded.
--   **Metadata**: Validating parsing and caching logic.
+### 3. Files route (async I/O)
 
-Run tests using:
+**Problem.** `rename_file` and `delete_file` ran blocking checks on the event loop.
+
+**Fix.** `os.path.exists`, `os.listdir`, `os.rename`, and `os.remove` now run in the threadpool.
+
+### 4. Dev artifacts
+
+Added `requirements-dev.txt` and the `tests/` directory.
+
+## How thread safety holds up
+
+The services stay thread-safe without blocking the asyncio loop:
+
+1. **Dual locking.** `_lock` protects in-memory state; `_write_lock` serializes disk I/O.
+2. **Snapshotting.** Data is copied under the lock, then written to disk without holding it.
+3. **Versioning.** Monotonic versions keep a late write from clobbering newer data.
+4. **Threadpool offloading.** Filesystem work on the refactored request paths (info, files rename/delete, stores) runs in a threadpool. Store init and a few side checks (volume listing, convert path validation) stay synchronous on purpose.
+
+## Tests
+
+The `tests/` directory covers:
+
+- **Locking and concurrency.** No deadlocks or races.
+- **Async I/O.** Blocking calls get offloaded.
+- **Metadata.** Parsing and caching.
+
+Run them:
+
 ```bash
-./venv/bin/python -m pytest tests/
+./.venv/bin/python -m pytest tests/
 ```


### PR DESCRIPTION
Rewrote all nine markdown docs in a plainer voice and fixed the spots where they had drifted from the code.

## Voice

Dropped em dashes, decorative emoji, and marketing words (seamless, comprehensive, optimize, robust) across every doc. README, walkthrough, DOCKER-COMPOSE, DEPLOYMENT, CHANGES_SUMMARY, and AGENTS were rewritten or hand-edited. DESIGN, ADDING_PLATFORMS, and RELEASE_NOTES got a scripted em-dash and emoji cleanup (code blocks left untouched) plus hand fixes for the awkward spots and buzzwords.

## Accuracy fixes

While going through them I found a fair amount of stale content and corrected it:

- **DEPLOYMENT.md** was an old readiness audit. It told you to add a `.dockerignore` and a multi-stage build that already exist, showed a `static/css/js` tree that is now `static/assets`, and described a Python 3.8 `commonpath` fallback the code no longer uses. Rewrote it as a current deployment guide.
- **AGENTS.md** pointed at a `.version` file and `scripts/sync-version.sh` that don't exist (the version lives in `package.json`), claimed CI runs on push/PR/manual dispatch when it only runs on a published GitHub Release, and referenced the retired `static/js` frontend. Fixed all three and made the command paths repo-relative.
- **CHANGES_SUMMARY.md** recommended a non-root user and resource limits that already ship. Rewrote it as an accurate historical record.
- **ADDING_PLATFORMS_AND_TOOLS.md** said there is no frontend build step and to lint `static/js`. The frontend is Svelte/Vite under `src/` with `npm run build`. Fixed the build-step rule, the lint command, and the lint table row.
- **walkthrough.md** test command pointed at `venv/` instead of `.venv/`.

## Notes

- **RELEASE_NOTES.md** keeps every historical fact and file path. Only the wording changed.
- **DESIGN_tool_plugin_architecture.md** keeps its design-time references to the old `static/js` frontend on purpose, since it documents that refactor.
- I verified the README endpoint tables, env vars, formats, and `chdman 0.285` against the actual routes, `config.py`, and the Dockerfile. They were already correct.

Diff is large but net negative: 662 insertions, 1078 deletions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed production deployment guide with updated security practices, configuration guidance, and operational checklists
  * Enhanced README with refined feature descriptions, safety documentation, and improved quick-start instructions
  * Updated Docker Compose reference and operational guidance for common setup scenarios
  * Improved tool integration documentation and architecture specifications for contributors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->