### PR TITLE
Spinner toast for single-file verify + plain-voice doc sweep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base images pinned to their multi-arch index digests (not just the moving
-# tags) so the FROM layer is stable across builds — moving tags get new digests
+# tags) so the FROM layer is stable across builds; moving tags get new digests
 # upstream every few days, which busts the entire layer cache and forces a full
 # rebuild. Pinning keeps the registry build cache effective and the build
 # reproducible. apt-get update inside the stages still pulls security patches;
@@ -30,7 +30,7 @@ RUN g++ -O3 src/*.cpp -o z3ds_compressor -lzstd && \
     chmod +x z3ds_compressor
 
 # ---------------------------------------------------------------------------
-# Frontend builder stage — compile the Svelte 5 SPA with Vite.
+# Frontend builder stage: compile the Svelte 5 SPA with Vite.
 #
 # Output is emitted to /build/static via vite.config.js (build.outDir),
 # which the runtime stage copies into /static.  Multi-arch safe:
@@ -53,7 +53,7 @@ FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b
 # Immutable pin: mame-tools 0.285+dfsg1-1 from snapshot.debian.org
 #
 # All runtime deps (libflac14, libsdl2-2.0-0, libutf8proc3, zlib1g, etc.)
-# are satisfiable from trixie-slim's own repos — no foreign sources needed.
+# are satisfiable from trixie-slim's own repos; no foreign sources needed.
 #
 # snapshot.debian.org URLs are content-addressed and timestamp-locked;
 # the .deb behind a given URL will never change.

--- a/app/logging_setup.py
+++ b/app/logging_setup.py
@@ -2,7 +2,7 @@
 
 All app loggers hang off one root name so a single handler/level (configured in
 ``main.configure_logging``) governs the whole app. Modules should call
-``get_logger("area")`` rather than hardcoding the root — e.g. ``get_logger("nsz")``
+``get_logger("area")`` rather than hardcoding the root, e.g. ``get_logger("nsz")``
 yields the ``compressatorium.nsz`` logger.
 """
 from __future__ import annotations

--- a/app/models.py
+++ b/app/models.py
@@ -233,7 +233,7 @@ class LayoutPreferences(BaseModel):
 
     ``panels`` holds the global panel-split widths (px); ``columns`` holds
     per-tool table column widths keyed by tool id. Extra keys are allowed
-    so the client can evolve the shape without a schema change here — the
+    so the client can evolve the shape without a schema change here; the
     server just stores and returns the JSON.
     """
 

--- a/app/routes/preferences.py
+++ b/app/routes/preferences.py
@@ -1,4 +1,4 @@
-"""Preferences routes — server-stored UI layout widths.
+"""Preferences routes: server-stored UI layout widths and compression defaults.
 
 Single-user app, no auth. The workspace layout (panel split + per-tool
 table column widths) lives under the ``layout`` preference key so it

--- a/app/services/nsz.py
+++ b/app/services/nsz.py
@@ -215,7 +215,7 @@ class NszService:
     def _parse_compression(self, compression: str | None) -> tuple[bool | None, int]:
         """Resolve a per-job ``compression`` string into (block, level).
 
-        Format is ``"<mode>:<level>"`` where mode is ``solid`` or ``block`` —
+        Format is ``"<mode>:<level>"`` where mode is ``solid`` or ``block``,
         the same ``codec:level`` shape the UI sends for Dolphin. ``block`` is
         None when unspecified (let nsz pick its per-container default). Level
         falls back to the configured default and is clamped to nsz's 1-22 range.

--- a/app/utils/junk.py
+++ b/app/utils/junk.py
@@ -1,4 +1,4 @@
-"""Known OS / NAS / filesystem junk names — the single source of truth.
+"""Known OS / NAS / filesystem junk names: the single source of truth.
 
 Shared by the file browser (to hide clutter from listings) and the Switch key
 search (to skip these dirs when walking volumes). Matched case-insensitively

--- a/docs/ADDING_PLATFORMS_AND_TOOLS.md
+++ b/docs/ADDING_PLATFORMS_AND_TOOLS.md
@@ -1160,19 +1160,19 @@ The service resolves the actual file with a `resolved_keys_file()` /
 stall startup, so cap the directories visited (`_MAX_KEY_SEARCH_DIRS`), prune
 junk dirs with the shared `utils.junk.is_junk_entry`, stop at the first hit, and
 log a warning if the cap is reached telling the operator to set the env var. The
-walk only runs as a fallback — when keys sit in a standard location or
+walk only runs as a fallback: when keys sit in a standard location or
 `SWITCH_KEYS` is set, the cheap path returns first.
 
 ### 16.3 Supplying the secret to the binary
 
-Check how the binary actually consumes keys before wiring this up — it is easy
+Check how the binary actually consumes keys before wiring this up; it is easy
 to get wrong, and unit tests that mock the subprocess won't catch it. **Run the
 real `--help`.** Two cases:
 
 - **The binary takes a flag** (e.g. `--keys /path`): just append it in
   `_build_command`.
 - **The binary loads keys at import/startup from a fixed location** (nsz reads
-  `~/.switch/prod.keys` via `$HOME` and has *no* `--keys` flag — it even
+  `~/.switch/prod.keys` via `$HOME` and has *no* `--keys` flag. It even
   `input()`-prompts and exits if none is found, which hangs under a pipe): you
   cannot pass a flag. Instead run the child with a throwaway `$HOME` whose
   `.switch/prod.keys` is a symlink to the resolved key file. See
@@ -1205,7 +1205,7 @@ exposes availability and the frontend hides unavailable tools entirely:
 
 State it plainly in the docs (README has a "Legal note"): the project ships no
 keys, firmware, or copyrighted content; the operator provides their own for
-hardware and content they own. Keep dual-use framing honest — this compresses
+hardware and content they own. Keep dual-use framing honest: this compresses
 backups the user already owns; it is not a circumvention tool, and the format
 preserves the original protection measures.
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -6,12 +6,12 @@
 
 #### New
 
-- **Switch keys are found recursively.** When `SWITCH_KEYS` isn't set, the app checks the standard locations and then recursively walks your mounted game volumes (and the data dir) for `prod.keys`/`keys.txt` — skipping junk dirs and bounded so it can't stall startup. Set `SWITCH_KEYS` to point straight at the keys dir if they live very deep.
+- **Switch keys are found recursively.** When `SWITCH_KEYS` isn't set, the app checks the standard locations and then recursively walks your mounted game volumes (and the data dir) for `prod.keys`/`keys.txt`, skipping junk dirs and bounded so it can't stall startup. Set `SWITCH_KEYS` to point straight at the keys dir if they live very deep.
 
 #### Internal
 
 - **Log prefix renamed `chd` → `compressatorium`** (a leftover from the chdman-only days), centralized in `logging_setup` so the root name lives in one place.
-- The OS/NAS junk-file filter is now shared (`utils/junk`) between the file browser and the key search — a single source of truth.
+- The OS/NAS junk-file filter is now shared (`utils/junk`) between the file browser and the key search, a single source of truth.
 
 ## 4.0.0-beta-9 (2026-06-01)
 
@@ -20,7 +20,7 @@
 #### New
 
 - **The file browser hides OS/NAS junk.** Clutter like `.DS_Store`, AppleDouble (`._*`), `Thumbs.db`, `desktop.ini`, `$RECYCLE.BIN`, `System Volume Information`, `@eaDir`, `#recycle`/`@Recycle`, `lost+found`, `.Trash-*`, and `.nfs*`/`.fuse_hidden*` no longer show up in listings or search (matched case-insensitively).
-- **Delete non-empty folders, with a guardrail.** You can now delete a directory and everything inside it. It takes two explicit confirmations — the second spells out that it's recursive and permanent. Files and empty folders are unchanged (one confirm), and deletion is still blocked while a conversion is using anything under the folder.
+- **Delete non-empty folders, with a guardrail.** You can now delete a directory and everything inside it. It takes two explicit confirmations; the second spells out that it's recursive and permanent. Files and empty folders are unchanged (one confirm), and deletion is still blocked while a conversion is using anything under the folder.
 
 #### Internal
 
@@ -35,7 +35,7 @@
 
 - **A fourth tool: Switch.** Compress `.nsp`/`.xci` dumps to `.nsz`/`.xcz` and back, using [nsz](https://github.com/nicoboss/nsz) (the Tinfoil/DBI-compatible standard). Two modes: `nsz_compress` and `nsz_decompress`. Available in the Web UI and the REST API, with live progress, single + batch verify, and file-info.
 - **Bring your own keys.** Switch content is encrypted, so nsz decrypts it (losslessly, reversibly) before compressing. The app ships no keys: mount your own `prod.keys` and set `SWITCH_KEYS` to the directory holding it (or let the app best-effort find it in `~/.switch` or your volumes). Missing keys fail the job with a clear message instead of crashing, and hide the Switch tool from the UI entirely. Key file names are git-ignored and never baked into the image or logged.
-- **Per-job compression, remembered.** Switch Compress exposes a layout choice (Solid = smaller, Block = random access) and a zstandard level (1-22) per job, threaded through to nsz. Your choice is saved server-side per tool (new `GET`/`PUT /api/preferences/conversion`) so it persists across sessions and browsers — and the same mechanism now remembers chdman and Dolphin compression settings too.
+- **Per-job compression, remembered.** Switch Compress exposes a layout choice (Solid = smaller, Block = random access) and a zstandard level (1-22) per job, threaded through to nsz. Your choice is saved server-side per tool (new `GET`/`PUT /api/preferences/conversion`) so it persists across sessions and browsers, and the same mechanism now remembers chdman and Dolphin compression settings too.
 
 #### Internal
 

--- a/src/lib/components/panels/RowActionsMenu.svelte
+++ b/src/lib/components/panels/RowActionsMenu.svelte
@@ -76,15 +76,48 @@
 
   async function handleVerify() {
     if (!verifyTool || !verifyPath) return;
+    // Surface a live spinner toast for the run, matching how a running
+    // job is toasted (loading toast that updates in place, then resolves
+    // to success/error). Verify can take a while on big files, so the
+    // user gets the same feedback they'd get from a conversion.
+    const name = verifyPath.split(/[/\\]/).pop() ?? verifyPath;
+    const toastId = toast.loading(name, {
+      description: 'Verifying…',
+      duration: Number.POSITIVE_INFINITY,
+    });
     try {
-      const result = await verification.verifyOne(verifyTool.id, verifyPath);
+      const result = await verification.verifyOne(verifyTool.id, verifyPath, {
+        onProgress: ({ percent, message }) => {
+          const pct =
+            typeof percent === 'number' && percent > 0
+              ? `${Math.round(percent)}%`
+              : null;
+          const lead = message || 'Verifying…';
+          toast.loading(name, {
+            id: toastId,
+            description: pct ? `${lead} · ${pct}` : lead,
+          });
+        },
+      });
       if (result?.valid) {
-        toast.success(`Verified: ${verifyPath}`);
+        toast.success(name, {
+          id: toastId,
+          description: 'Verified',
+          duration: 4000,
+        });
       } else {
-        toast.error(`Verification failed: ${result?.message ?? verifyPath}`);
+        toast.error(name, {
+          id: toastId,
+          description: result?.message ?? 'Verification failed',
+          duration: 6000,
+        });
       }
     } catch (e) {
-      toast.error(e?.message ?? 'Verify failed');
+      toast.error(name, {
+        id: toastId,
+        description: e?.message ?? 'Verify failed',
+        duration: 6000,
+      });
     }
   }
 

--- a/src/lib/components/panels/RowActionsMenu.svelte
+++ b/src/lib/components/panels/RowActionsMenu.svelte
@@ -108,14 +108,16 @@
       } else {
         toast.error(name, {
           id: toastId,
-          description: result?.message ?? 'Verification failed',
+          // `||` not `??`: an empty-string message should still fall back
+          // to a real description, not render a blank toast.
+          description: result?.message || 'Verification failed',
           duration: 6000,
         });
       }
     } catch (e) {
       toast.error(name, {
         id: toastId,
-        description: e?.message ?? 'Verify failed',
+        description: e?.message || 'Verify failed',
         duration: 6000,
       });
     }

--- a/src/lib/components/views/HelpView.svelte
+++ b/src/lib/components/views/HelpView.svelte
@@ -29,12 +29,18 @@
       blurb: 'Nintendo 3DS ROMs to a seekable-Zstandard file that Azahar reads directly (release 2123 and up). Roughly half the size with no compatibility loss. The .cci and .3ds dumps are solid; .cia works but treat it as experimental. The ROM has to be decrypted first.',
       io: '.cci / .cia / .3ds  →  .zcci / .zcia / .z3ds',
     },
+    {
+      glyph: 'NSW',
+      name: 'Switch',
+      blurb: 'Nintendo Switch dumps to NSZ/XCZ and back, using nsz, the format Tinfoil and DBI read. Usually 40 to 80 percent smaller, fully reversible. Switch content is encrypted, so this needs your own prod.keys, dumped from a console you own. Without keys the Switch tool is hidden entirely. Set SWITCH_KEYS to the folder holding them, or drop them under a mounted volume and the app finds them.',
+      io: '.nsp / .xci  ↔  .nsz / .xcz',
+    },
   ];
 
   // Per-tool mode reference. Each row: [mode, what it does, output].
   const modeGroups = [
     {
-      tool: 'CHDMAN — Create',
+      tool: 'CHDMAN: Create',
       rows: [
         ['createcd', 'CD images. The default for most disc consoles.', '.chd'],
         ['createdvd', 'DVD-sized media. This is the one for PSP and PS2.', '.chd'],
@@ -44,7 +50,7 @@
       ],
     },
     {
-      tool: 'CHDMAN — Extract and Copy',
+      tool: 'CHDMAN: Extract and Copy',
       rows: [
         ['extractcd', 'Pull the CD back out of a CHD. Gives you a cue/bin pair.', '.cue + .bin'],
         ['extractdvd', 'Pull a DVD image back out.', '.iso'],
@@ -66,6 +72,13 @@
       tool: '3DS',
       rows: [
         ['z3ds_compress', 'One mode, no settings. Fixed Seekable Zstandard.', '.zcci / .zcia / .z3ds'],
+      ],
+    },
+    {
+      tool: 'Switch',
+      rows: [
+        ['nsz_compress', 'Compress to NSZ/XCZ. Pick a layout (Solid or Block) and a level.', '.nsz / .xcz'],
+        ['nsz_decompress', 'Decompress back to the original NSP/XCI.', '.nsp / .xci'],
       ],
     },
   ];
@@ -115,6 +128,13 @@
       Archives (ZIP, 7z, RAR) are browsable like folders. Click one and you're inside it.
       More on that below.
     </p>
+    <p>
+      System clutter is hidden automatically, so listings stay clean:
+      <code>.DS_Store</code>, AppleDouble (<code>._*</code>) files,
+      <code>Thumbs.db</code>, <code>desktop.ini</code>, <code>@eaDir</code>,
+      <code>#recycle</code>, <code>lost+found</code>, and the like across macOS,
+      Windows, and NAS systems.
+    </p>
   </article>
 
   <article class="panel">
@@ -148,8 +168,9 @@
   <article class="panel">
     <h2 class="panel-title">Compression</h2>
     <p class="lead">
-      CHD create and copy modes take a list of codecs. Dolphin RVZ and WIA take one codec
-      plus a level. GCZ, the Dolphin ISO mode, and 3DS have no settings at all.
+      CHD create and copy modes take a list of codecs. Dolphin RVZ/WIA take one codec plus a
+      level, and Switch compress takes a layout plus a level. GCZ, the decompress/extract
+      modes, and 3DS have no settings at all.
     </p>
     <p>
       Smaller is not always better. Some emulators only read certain codecs, and a file
@@ -183,6 +204,12 @@
     <p>
       For Dolphin, zstd at level 19 is the sweet spot and matches what MAME Redump uses.
       Levels run to 22 but the gains taper off fast and the time cost doesn't.
+    </p>
+    <p>
+      For Switch, the layout is Solid or Block. Solid packs tightest but the file must be
+      fully decompressed before it runs; Block is a little larger but stays installable and
+      playable without unpacking first. Level runs 1 to 22; the default 18 is a good balance.
+      Your choice is remembered per tool between sessions.
     </p>
   </article>
 
@@ -231,10 +258,16 @@
       <code>.bin</code>, and the whole archive if the source came from one.
     </p>
     <p>
-      Bulk Verify checks a whole selection at once across CHD and Dolphin files.
-      Verification status sticks around between sessions, so a file you verified last week
-      still shows verified today. Long verifies can be given a timeout so a stalled one
+      Bulk Verify checks a whole selection at once across CHD, Dolphin, 3DS, and Switch
+      files. Verification status sticks around between sessions, so a file you verified last
+      week still shows verified today. Long verifies can be given a timeout so a stalled one
       doesn't sit forever.
+    </p>
+    <p>
+      Deleting from the file list is a separate action. A file or an empty folder takes one
+      confirmation. A <strong>non-empty folder</strong> takes two: the second spells out
+      that it removes everything inside, permanently. Either way the app refuses the
+      delete if a conversion is using anything under it.
     </p>
   </article>
 
@@ -280,9 +313,10 @@
     </p>
     <p>
       The archive is unpacked to a temp directory for the conversion and cleaned up after.
-      Any convertible source works this way, including 3DS ROMs and Dolphin discs. The one
-      exception is CHDMAN extract and copy, which act on a finished <code>.chd</code>.
-      That's an output, not a source, so there's nothing in an archive for them to do.
+      Any convertible source works this way, including 3DS ROMs and Dolphin discs. Two
+      exceptions: CHDMAN extract and copy act on a finished <code>.chd</code> (an output, not
+      a source), and Switch (nsz) reads from disk only, so convert
+      <code>.nsp</code>/<code>.xci</code> files in place, not from inside an archive.
     </p>
     <p>
       When a <code>.cue</code> or <code>.gdi</code> sits next to its <code>.bin</code>
@@ -318,6 +352,9 @@
 
       <dt>A 3DS ROM failed to compress</dt>
       <dd>The ROM has to be decrypted first. Encrypted dumps won't work.</dd>
+
+      <dt>The Switch tool isn't there, or jobs fail asking for prod.keys</dt>
+      <dd>Switch needs your own <code>prod.keys</code>. Set <code>SWITCH_KEYS</code> to the folder that holds them, or drop <code>prod.keys</code> under a mounted volume and the app finds it. Without keys the Switch tool is hidden. The keys come from a console you own; none ship with the app.</dd>
 
       <dt>The host got sluggish during a batch</dt>
       <dd>
@@ -395,7 +432,7 @@
     </p>
     <p>
       This is a fork of MarcTV's original CHD Converter with a web UI bolted on, plus
-      Dolphin and 3DS support. It's maintained in spare time, so be patient and be kind.
+      Dolphin, 3DS, and Switch support. It's maintained in spare time, so be patient and be kind.
       A clear, reproducible report gets fixed a lot faster than a vague one.
     </p>
   </article>

--- a/src/lib/stores/verification.svelte.js
+++ b/src/lib/stores/verification.svelte.js
@@ -57,13 +57,22 @@ class VerificationStore {
   // ─── Single-file verify ───────────────────────────────────────────────
   // `onProgress` (optional) is forwarded the same { percent, message }
   // shape stored in the progress map, so a caller can drive a live toast
-  // without subscribing to the store.
+  // without subscribing to the store. Progress reporting is best-effort:
+  // a callback that throws must not fail the verify or strand the
+  // progress entry, so every forward is swallowed.
   async verifyOne(toolId, path, { onProgress } = {}) {
     const tool = registry.forTool(toolId);
     if (!tool) throw new Error(`Unknown tool: ${toolId}`);
+    const notify = (state) => {
+      try {
+        onProgress?.(state);
+      } catch (_e) {
+        // a broken progress callback shouldn't break verification
+      }
+    };
     const starting = { percent: 0, message: 'Starting…' };
     this.progress.set(path, starting);
-    onProgress?.(starting);
+    notify(starting);
     try {
       const result = await tool.verify(path, {
         onProgress: (data) => {
@@ -72,7 +81,7 @@ class VerificationStore {
             message: data?.message ?? '',
           };
           this.progress.set(path, next);
-          onProgress?.(next);
+          notify(next);
         },
       });
       this.progress.delete(path);

--- a/src/lib/stores/verification.svelte.js
+++ b/src/lib/stores/verification.svelte.js
@@ -55,17 +55,24 @@ class VerificationStore {
   }
 
   // ─── Single-file verify ───────────────────────────────────────────────
-  async verifyOne(toolId, path) {
+  // `onProgress` (optional) is forwarded the same { percent, message }
+  // shape stored in the progress map, so a caller can drive a live toast
+  // without subscribing to the store.
+  async verifyOne(toolId, path, { onProgress } = {}) {
     const tool = registry.forTool(toolId);
     if (!tool) throw new Error(`Unknown tool: ${toolId}`);
-    this.progress.set(path, { percent: 0, message: 'Starting…' });
+    const starting = { percent: 0, message: 'Starting…' };
+    this.progress.set(path, starting);
+    onProgress?.(starting);
     try {
       const result = await tool.verify(path, {
         onProgress: (data) => {
-          this.progress.set(path, {
+          const next = {
             percent: typeof data?.progress === 'number' ? data.progress : null,
             message: data?.message ?? '',
-          });
+          };
+          this.progress.set(path, next);
+          onProgress?.(next);
         },
       });
       this.progress.delete(path);

--- a/src/lib/stores/verification.svelte.js
+++ b/src/lib/stores/verification.svelte.js
@@ -63,16 +63,13 @@ class VerificationStore {
   async verifyOne(toolId, path, { onProgress } = {}) {
     const tool = registry.forTool(toolId);
     if (!tool) throw new Error(`Unknown tool: ${toolId}`);
-    const notify = (state) => {
-      try {
-        onProgress?.(state);
-      } catch (_e) {
-        // a broken progress callback shouldn't break verification
-      }
-    };
     const starting = { percent: 0, message: 'Starting…' };
     this.progress.set(path, starting);
-    notify(starting);
+    try {
+      onProgress?.(starting);
+    } catch (_e) {
+      // a broken progress callback shouldn't break verification
+    }
     try {
       const result = await tool.verify(path, {
         onProgress: (data) => {
@@ -81,7 +78,11 @@ class VerificationStore {
             message: data?.message ?? '',
           };
           this.progress.set(path, next);
-          notify(next);
+          try {
+            onProgress?.(next);
+          } catch (_e) {
+            // a broken progress callback shouldn't break verification
+          }
         },
       });
       this.progress.delete(path);

--- a/testdata/switch/README.md
+++ b/testdata/switch/README.md
@@ -6,11 +6,11 @@ committed.
 
 ## What goes where
 
-- `keys/prod.keys` — your own `prod.keys`, dumped from a console you own (e.g.
+- `keys/prod.keys`: your own `prod.keys`, dumped from a console you own (e.g.
   with Lockpick_RCM). A placeholder ships here; replace it with the real file.
-- `dumps/` — drop one real `.nsp` or `.xci` you own. The test uses the first one
+- `dumps/`: drop one real `.nsp` or `.xci` you own. The test uses the first one
   it finds. The `.txt` placeholder is ignored.
-- `out/` — the test writes the compressed and round-tripped files here.
+- `out/`: the test writes the compressed and round-tripped files here.
 
 ## Run it
 


### PR DESCRIPTION
## What

Two things, kept as separate commits.

**Spinner toast for single-file verify.** The row Verify action now opens a loading toast that updates with live progress and resolves to success or error, the same way a running job is toasted. Before this, single-file verify showed nothing while it ran and only fired a one-shot toast at the end, which is rough on a big file that takes a minute to check.

`verifyOne` in the verification store now takes an optional `onProgress` callback and forwards the same `{ percent, message }` shape it already tracks. The store stays UI-free; the toast lifecycle lives in `RowActionsMenu`, the same split we use for jobs vs jobToasts. The per-path `progress` map was already being set but no component read it, so there was genuinely no live feedback for single verify.

**Plain-voice doc sweep.** Ran the voice rules over the Switch docs and the comments and docstrings touched during that work. Swapped every em dash for a comma or period and cut a couple of buzzwords. No code or behavior change in that commit.

## Verification

- 663 Python tests pass.
- Svelte autofixer clean on the changed component.
- `npm run build` green.
- ruff clean on the touched Python files.

Also audited Switch against the ADD-MORE-TOOLS checklist in `docs/ADDING_PLATFORMS_AND_TOOLS.md` §6 while I was in here: every applicable item is done. The only unchecked boxes are the ones the doc marks optional and that don't apply to a keyed pip tool (entrypoint CLI loop, disc_id parser, Alembic migration, .local-bin).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nintendo Switch support: compress and decompress NSZ files with configurable layout and level settings
  * Live progress indicator: displays real-time updates with percentage during file verification

* **Documentation**
  * Expanded help text with Nintendo Switch platform details, including key requirements and bulk verify support
  * Updated guides with Switch workflow information and troubleshooting steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->