### PR TITLE
Make archive-member listings registry-driven (#128)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -71,7 +71,9 @@ class FileEntry(BaseModel):
     nsz_ready: bool = False
     nsz_path: str | None = None
     archive_items: int | None = None
-    archive_has_chd: int | None = None
+    # Count of archive members that already have an existing output from any
+    # registered tool (.chd/.rvz/.z3ds/.nsz/…), finished or mid-conversion.
+    archive_has_output: int | None = None
     archive_truncated: bool | None = None
     media_type: str | None = None  # "dvd", "cd", or None - for CHD files
     convertible_by: list[str] = []   # tool ids whose input_extensions accept this file

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -46,6 +46,59 @@ def _detect_file_outputs(
     return convertible_by, outputs, by_tool
 
 
+def _detect_archive_member_outputs(
+    entry: dict, archive_dir: str,
+) -> tuple[str, list[str], list[OutputStatus], dict[str, OutputStatus]]:
+    """Registry-driven convertibility + output detection for an archive member.
+
+    The member doesn't exist on disk yet, but each tool's ``detect_output``
+    resolves its sibling output by swapping the suffix on the input path. So we
+    synthesise the path the extracted member *would* occupy next to its archive
+    (``<archive_dir>/<output_stem><ext>``) and reuse the same on-disk detection
+    the regular file scan uses. This keeps the listing in lock-step with the
+    job pipeline — which extracts the member into the archive's directory before
+    converting — and means any newly registered archive-aware tool surfaces in
+    the browse/search views without another CHD-style special case.
+    """
+    output_stem = (
+        entry.get("output_stem") or Path(entry["internal_path"]).stem
+    )
+    member_ext = (entry.get("extension") or Path(entry["name"]).suffix).lower()
+    synthetic_input = os.path.join(archive_dir, f"{output_stem}{member_ext}")
+    convertible_by, outputs, by_tool = _detect_file_outputs(
+        synthetic_input, member_ext,
+    )
+    return output_stem, convertible_by, outputs, by_tool
+
+
+def _legacy_output_fields(
+    convertible_by: list[str], by_tool: dict[str, OutputStatus],
+) -> dict:
+    """Derive the legacy per-tool booleans/paths from registry detection.
+
+    Single source of truth shared by the on-disk and archive-member listing
+    paths so the flat ``has_*`` / ``*_ready`` / ``*_convertible`` flags the
+    frontend still reads can't drift from ``convertible_by`` / ``outputs``.
+    """
+    fields: dict = {}
+    for tool_id, has_key, ready_key, path_key in (
+        ("chdman", "has_chd", "chd_ready", None),
+        ("dolphin", "has_rvz", "dolphin_ready", "dolphin_path"),
+        ("z3ds", "has_z3ds", "z3ds_ready", "z3ds_path"),
+        ("nsz", "has_nsz", "nsz_ready", "nsz_path"),
+    ):
+        status = by_tool.get(tool_id)
+        fields[has_key] = status is not None
+        fields[ready_key] = status.exists if status else False
+        if path_key is not None:
+            fields[path_key] = status.path if status else None
+    fields["convertible"] = "chdman" in convertible_by
+    fields["dolphin_convertible"] = "dolphin" in convertible_by
+    fields["z3ds_convertible"] = "z3ds" in convertible_by
+    fields["nsz_convertible"] = "nsz" in convertible_by
+    return fields
+
+
 async def _assert_path_not_in_use(path: str, *, is_dir: bool = False) -> None:
     _, is_locked = await run_in_threadpool(lock_manager.check_file_status, path)
     if is_locked:
@@ -152,25 +205,7 @@ async def list_files(
                             convertible_by, outputs, by_tool = _detect_file_outputs(
                                 item_path, ext,
                             )
-                        is_convertible = "chdman" in convertible_by
-                        is_dolphin_convertible = "dolphin" in convertible_by
-                        is_z3ds_convertible = "z3ds" in convertible_by
-                        is_nsz_convertible = "nsz" in convertible_by
-                        chd_status = by_tool.get("chdman")
-                        dolphin_status = by_tool.get("dolphin")
-                        z3ds_status = by_tool.get("z3ds")
-                        nsz_status = by_tool.get("nsz")
-                        has_chd = chd_status is not None
-                        chd_ready = chd_status.exists if chd_status else False
-                        has_rvz = dolphin_status is not None
-                        dolphin_ready = dolphin_status.exists if dolphin_status else False
-                        dolphin_path = dolphin_status.path if dolphin_status else None
-                        has_z3ds = z3ds_status is not None
-                        z3ds_ready = z3ds_status.exists if z3ds_status else False
-                        z3ds_path = z3ds_status.path if z3ds_status else None
-                        has_nsz = nsz_status is not None
-                        nsz_ready = nsz_status.exists if nsz_status else False
-                        nsz_path = nsz_status.path if nsz_status else None
+                        tool_fields = _legacy_output_fields(convertible_by, by_tool)
 
                         archive_items = None
                         archive_has_chd = None
@@ -196,7 +231,7 @@ async def list_files(
                                 )
                                 if file_exists or is_converting:
                                     archive_has_chd += 1
-                            has_chd = archive_has_chd > 0
+                            tool_fields["has_chd"] = archive_has_chd > 0
 
                         entry = FileEntry(
                             name=item,
@@ -204,21 +239,6 @@ async def list_files(
                             type="archive" if is_archive else "file",
                             size=size,
                             extension=ext,
-                            convertible=is_convertible,
-                            has_chd=has_chd,
-                            has_rvz=has_rvz,
-                            dolphin_ready=dolphin_ready,
-                            dolphin_path=dolphin_path,
-                            chd_ready=chd_ready,
-                            dolphin_convertible=is_dolphin_convertible,
-                            z3ds_convertible=is_z3ds_convertible,
-                            has_z3ds=has_z3ds,
-                            z3ds_ready=z3ds_ready,
-                            z3ds_path=z3ds_path,
-                            nsz_convertible=is_nsz_convertible,
-                            has_nsz=has_nsz,
-                            nsz_ready=nsz_ready,
-                            nsz_path=nsz_path,
                             archive_items=archive_items,
                             archive_has_chd=archive_has_chd,
                             archive_truncated=archive_truncated
@@ -226,6 +246,7 @@ async def list_files(
                             else None,
                             convertible_by=convertible_by,
                             outputs=outputs,
+                            **tool_fields,
                         )
                         entries.append(entry)
                 except OSError:
@@ -295,34 +316,14 @@ async def search_files(
                                     item_path, ext,
                                 )
                             if convertible_by:
-                                is_chd_convertible = "chdman" in convertible_by
-                                is_dolphin_convertible = "dolphin" in convertible_by
-                                is_z3ds_convertible = "z3ds" in convertible_by
-                                is_nsz_convertible = "nsz" in convertible_by
-                                chd_status = by_tool.get("chdman")
-                                dolphin_status = by_tool.get("dolphin")
-                                z3ds_status = by_tool.get("z3ds")
-                                nsz_status = by_tool.get("nsz")
+                                tool_fields = _legacy_output_fields(
+                                    convertible_by, by_tool,
+                                )
                                 chd_path = (
                                     str(Path(item_path).with_suffix(".chd"))
-                                    if is_chd_convertible
+                                    if tool_fields["convertible"]
                                     else None
                                 )
-                                has_chd = chd_status is not None
-                                chd_ready = chd_status.exists if chd_status else False
-                                has_rvz = dolphin_status is not None
-                                dolphin_ready = (
-                                    dolphin_status.exists if dolphin_status else False
-                                )
-                                dolphin_path = (
-                                    dolphin_status.path if dolphin_status else None
-                                )
-                                has_z3ds = z3ds_status is not None
-                                z3ds_ready = z3ds_status.exists if z3ds_status else False
-                                z3ds_path = z3ds_status.path if z3ds_status else None
-                                has_nsz = nsz_status is not None
-                                nsz_ready = nsz_status.exists if nsz_status else False
-                                nsz_path = nsz_status.path if nsz_status else None
                                 files.append(
                                     {
                                         "name": item,
@@ -330,24 +331,10 @@ async def search_files(
                                         "size": os.path.getsize(item_path),
                                         "extension": ext,
                                         "chd_path": chd_path,
-                                        "has_chd": has_chd,
-                                        "has_rvz": has_rvz,
-                                        "dolphin_ready": dolphin_ready,
-                                        "dolphin_path": dolphin_path,
-                                        "chd_ready": chd_ready,
-                                        "convertible": is_chd_convertible,
-                                        "dolphin_convertible": is_dolphin_convertible,
-                                        "z3ds_convertible": is_z3ds_convertible,
-                                        "has_z3ds": has_z3ds,
-                                        "z3ds_ready": z3ds_ready,
-                                        "z3ds_path": z3ds_path,
-                                        "nsz_convertible": is_nsz_convertible,
-                                        "has_nsz": has_nsz,
-                                        "nsz_ready": nsz_ready,
-                                        "nsz_path": nsz_path,
                                         "in_archive": False,
                                         "convertible_by": convertible_by,
                                         "outputs": outputs,
+                                        **tool_fields,
                                     },
                                 )
                             elif include_archive_scan and is_archive:
@@ -360,15 +347,16 @@ async def search_files(
                                     archives_truncated.add(item_path)
                                 archive_dir = os.path.dirname(item_path)
                                 for entry in archive_contents:
-                                    output_stem = (
-                                        entry.get("output_stem")
-                                        or Path(entry["internal_path"]).stem
+                                    (
+                                        output_stem,
+                                        member_convertible_by,
+                                        member_outputs,
+                                        member_by_tool,
+                                    ) = _detect_archive_member_outputs(
+                                        entry, archive_dir,
                                     )
-                                    chd_path = os.path.join(
-                                        archive_dir, f"{output_stem}.chd",
-                                    )
-                                    file_exists, is_converting = (
-                                        lock_manager.check_file_status(chd_path)
+                                    tool_fields = _legacy_output_fields(
+                                        member_convertible_by, member_by_tool,
                                     )
                                     archives.append(
                                         {
@@ -379,19 +367,13 @@ async def search_files(
                                             "size": entry["size"],
                                             "extension": entry["extension"],
                                             "output_stem": output_stem,
-                                            "chd_path": chd_path,
-                                            "has_chd": file_exists or is_converting,
-                                            "has_rvz": False,
-                                            "dolphin_ready": False,
-                                            "dolphin_path": None,
-                                            "chd_ready": file_exists,
-                                            "convertible": (
-                                                entry.get("extension")
-                                                in registry.get("chdman").input_extensions
+                                            "chd_path": os.path.join(
+                                                archive_dir, f"{output_stem}.chd",
                                             ),
-                                            "dolphin_convertible": False,
-                                            "z3ds_ready": False,
                                             "in_archive": True,
+                                            "convertible_by": member_convertible_by,
+                                            "outputs": member_outputs,
+                                            **tool_fields,
                                         },
                                     )
                     except OSError:
@@ -443,17 +425,19 @@ async def list_archive(
     contents = contents_result["entries"]
     truncated = bool(contents_result["truncated"])
 
-    # Check for existing CHD files in the archive's directory
+    # Registry-driven convertibility + sibling-output detection for each
+    # member, mirroring the on-disk file scan so every archive-aware tool
+    # (chdman, dolphin, z3ds, nsz, …) gets badged — not just CHDMAN.
     archive_dir = os.path.dirname(path)
     for file_entry in contents:
-        # Get the base name without extension and add .chd
-        base_name = file_entry.get("output_stem") or Path(file_entry["name"]).stem
-        chd_path = os.path.join(archive_dir, f"{base_name}.chd")
-        # Use atomic check to get both file existence and lock status
-        file_exists, is_converting = lock_manager.check_file_status(chd_path)
-        file_entry["has_chd"] = file_exists or is_converting
-        file_entry["chd_ready"] = file_exists
-        file_entry["chd_path"] = chd_path
+        output_stem, convertible_by, outputs, by_tool = (
+            _detect_archive_member_outputs(file_entry, archive_dir)
+        )
+        file_entry.update(_legacy_output_fields(convertible_by, by_tool))
+        file_entry["output_stem"] = output_stem
+        file_entry["chd_path"] = os.path.join(archive_dir, f"{output_stem}.chd")
+        file_entry["convertible_by"] = convertible_by
+        file_entry["outputs"] = outputs
 
     return {
         "archive": path,

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -427,17 +427,23 @@ async def list_archive(
 
     # Registry-driven convertibility + sibling-output detection for each
     # member, mirroring the on-disk file scan so every archive-aware tool
-    # (chdman, dolphin, z3ds, nsz, …) gets badged — not just CHDMAN.
+    # (chdman, dolphin, z3ds, nsz, …) gets badged — not just CHDMAN. Each
+    # member probes every tool's sibling output via lock_manager (blocking
+    # disk I/O), so run the whole loop off the event loop.
     archive_dir = os.path.dirname(path)
-    for file_entry in contents:
-        output_stem, convertible_by, outputs, by_tool = (
-            _detect_archive_member_outputs(file_entry, archive_dir)
-        )
-        file_entry.update(_legacy_output_fields(convertible_by, by_tool))
-        file_entry["output_stem"] = output_stem
-        file_entry["chd_path"] = os.path.join(archive_dir, f"{output_stem}.chd")
-        file_entry["convertible_by"] = convertible_by
-        file_entry["outputs"] = outputs
+
+    def _annotate_members() -> None:
+        for file_entry in contents:
+            output_stem, convertible_by, outputs, by_tool = (
+                _detect_archive_member_outputs(file_entry, archive_dir)
+            )
+            file_entry.update(_legacy_output_fields(convertible_by, by_tool))
+            file_entry["output_stem"] = output_stem
+            file_entry["chd_path"] = os.path.join(archive_dir, f"{output_stem}.chd")
+            file_entry["convertible_by"] = convertible_by
+            file_entry["outputs"] = outputs
+
+    await run_in_threadpool(_annotate_members)
 
     return {
         "archive": path,

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -208,7 +208,7 @@ async def list_files(
                         tool_fields = _legacy_output_fields(convertible_by, by_tool)
 
                         archive_items = None
-                        archive_has_chd = None
+                        archive_has_output = None
                         if is_archive and summarize_archives_flag:
                             archive_result = archive_service.list_archive_contents(
                                 item_path, include_meta=True,
@@ -216,22 +216,21 @@ async def list_files(
                             contents = archive_result["entries"]
                             archive_items = len(contents)
                             archive_truncated = bool(archive_result["truncated"])
-                            archive_has_chd = 0
+                            archive_has_output = 0
                             archive_dir = os.path.dirname(item_path)
+                            member_has_chd = False
                             for entry in contents:
-                                output_stem = (
-                                    entry.get("output_stem")
-                                    or Path(entry["internal_path"]).stem
+                                _, _, _, member_by_tool = (
+                                    _detect_archive_member_outputs(entry, archive_dir)
                                 )
-                                chd_path = os.path.join(
-                                    archive_dir, f"{output_stem}.chd",
-                                )
-                                file_exists, is_converting = (
-                                    lock_manager.check_file_status(chd_path)
-                                )
-                                if file_exists or is_converting:
-                                    archive_has_chd += 1
-                            tool_fields["has_chd"] = archive_has_chd > 0
+                                # A member counts as "converted" once any tool
+                                # already has a sibling output for it, not just
+                                # CHDMAN.
+                                if member_by_tool:
+                                    archive_has_output += 1
+                                if "chdman" in member_by_tool:
+                                    member_has_chd = True
+                            tool_fields["has_chd"] = member_has_chd
 
                         entry = FileEntry(
                             name=item,
@@ -240,7 +239,7 @@ async def list_files(
                             size=size,
                             extension=ext,
                             archive_items=archive_items,
-                            archive_has_chd=archive_has_chd,
+                            archive_has_output=archive_has_output,
                             archive_truncated=archive_truncated
                             if is_archive and summarize_archives_flag
                             else None,

--- a/src/lib/components/panels/FileRow.svelte
+++ b/src/lib/components/panels/FileRow.svelte
@@ -94,9 +94,9 @@
 
   function archiveItemSummary(e) {
     const total = e?.archive_items;
-    const hasChd = e?.archive_has_chd;
+    const converted = e?.archive_has_output;
     if (typeof total !== 'number') return null;
-    if (typeof hasChd === 'number' && hasChd > 0) return `${total} items · ${hasChd} converted`;
+    if (typeof converted === 'number' && converted > 0) return `${total} items · ${converted} converted`;
     return `${total} items`;
   }
 </script>

--- a/tests/test_files_outputs_parity.py
+++ b/tests/test_files_outputs_parity.py
@@ -32,6 +32,11 @@ LEGACY_SEARCH_KEYS = {
     "z3ds_path", "nsz_convertible", "has_nsz", "nsz_ready", "nsz_path",
     "in_archive",
 }
+# Archive members carry the same registry-driven flags as on-disk search hits
+# (issue #128) plus the archive-specific locator keys.
+LEGACY_ARCHIVE_KEYS = LEGACY_SEARCH_KEYS | {
+    "archive_path", "internal_path", "output_stem",
+}
 NEW_KEYS = {"convertible_by", "outputs"}
 
 
@@ -202,8 +207,22 @@ async def test_search_files_json_keys_are_additive(parity_env):
         assert LEGACY_SEARCH_KEYS <= keys
         assert keys - LEGACY_SEARCH_KEYS == NEW_KEYS
 
-    # Archive member dicts retain their distinct legacy shape unchanged.
+    # Archive members are now registry-driven too (issue #128): they expose the
+    # same per-tool flags as on-disk hits, plus archive locator keys, and their
+    # legacy booleans must be reconstructable from outputs/convertible_by.
     for item in results["archives"]:
+        keys = set(item.keys())
+        assert LEGACY_ARCHIVE_KEYS <= keys
+        assert keys - LEGACY_ARCHIVE_KEYS == NEW_KEYS
         assert item["in_archive"] is True
-        assert "convertible_by" not in item
-        assert item["has_rvz"] is False
+        _assert_agreement(item, item["outputs"], item["convertible_by"])
+
+    # bundle.zip::inner.iso has a sibling inner.chd, so the member surfaces as
+    # CHDMAN-convertible with a finished output — and as Dolphin-convertible
+    # (.iso is accepted by both) even though no .rvz sibling exists.
+    inner = next(i for i in results["archives"] if i["name"] == "inner.iso")
+    assert inner["convertible"] is True
+    assert inner["has_chd"] is True and inner["chd_ready"] is True
+    assert "chdman" in inner["convertible_by"]
+    assert inner["dolphin_convertible"] is True
+    assert inner["has_rvz"] is False

--- a/tests/test_files_outputs_parity.py
+++ b/tests/test_files_outputs_parity.py
@@ -22,7 +22,7 @@ LEGACY_FILEENTRY_KEYS = {
     "has_rvz", "dolphin_ready", "dolphin_path", "chd_ready",
     "dolphin_convertible", "z3ds_convertible", "has_z3ds", "z3ds_ready",
     "z3ds_path", "nsz_convertible", "has_nsz", "nsz_ready", "nsz_path",
-    "archive_items", "archive_has_chd", "archive_truncated",
+    "archive_items", "archive_has_output", "archive_truncated",
     "media_type",
 }
 LEGACY_SEARCH_KEYS = {
@@ -164,6 +164,10 @@ async def test_list_files_outputs_agree_with_legacy(parity_env):
     assert bundle.has_rvz is False and bundle.z3ds_ready is False
     assert bundle.convertible_by == []
     assert bundle.outputs == []
+    # The summary count is registry-driven: the single member with a sibling
+    # output (inner.iso -> inner.chd) is counted regardless of which tool
+    # produced it.
+    assert bundle.archive_has_output == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #128. Archive-member metadata was **CHDMAN-only**: the `search_files()` archive branch and the `list_archive()` contents path hardcoded a sibling `.chd` existence check and set every other tool's `*_convertible` / `has_*` / `*_ready` / `*_path` flag to `False`. So an archive member like `library.zip::game.iso` (or a `.rvz`, `.3ds`, `.nsp`, …) was **not** badged as Dolphin/3DS/Switch‑convertible in the browse + `Search All` (archive) flows, even though `plan_job` and the job pipeline already accept archive members for every tool whose `ModeSpec.allows_archive_input=True`.

This was a pre-existing, tool-wide limitation (it predates the CSO/maxcso work in #127) — CSO simply would have inherited the same gap.

## What changed (`app/routes/files.py`)

- **`_detect_archive_member_outputs(entry, archive_dir)`** — drives convertibility + sibling-output detection for an archive member off the tool registry. The member doesn't exist on disk yet, so it synthesises the path the extracted member *would* occupy next to its archive (`<archive_dir>/<output_stem><ext>`) and reuses the same `_detect_file_outputs(...)` the regular file scan uses. Each tool's `detect_output()` then resolves its own sibling output (`.chd` / `.rvz` / `.z3ds` / …) — no hardcoded `.chd`. This keeps the listing in lock-step with the pipeline, which extracts the member into the archive's directory before converting.
- **`_legacy_output_fields(convertible_by, by_tool)`** — single source of truth that derives the flat per-tool booleans/paths the frontend still reads from `convertible_by`/`outputs`. Both the on-disk scan (`list_files`, `search_files`) **and** the archive-member paths now go through it, so the legacy flags can't drift and a newly registered archive-aware tool surfaces in archive views automatically.
- Updated `search_files()` archive branch and `list_archive()` to use the two helpers; archive members now also expose `convertible_by` / `outputs`.

The frontend (`FileRow.svelte`) already prefers `convertible_by` (with a legacy-flag fallback), so members now badge correctly with no UI change required.

## Tests

- Updated `tests/test_files_outputs_parity.py`: archive members are now asserted to expose the same registry-driven per-tool flags as on-disk hits (plus archive locator keys), and to satisfy the `outputs`/`convertible_by` ↔ legacy-boolean agreement invariant. Added an explicit check that `bundle.zip::inner.iso` (with a sibling `inner.chd`) surfaces as both CHDMAN- and Dolphin-convertible.
- Full suite: `666 passed, 1 skipped`.

https://claude.ai/code/session_01H25kZ1BqvRFphc6sLBz8bW

---
_Generated by [Claude Code](https://claude.ai/code/session_01H25kZ1BqvRFphc6sLBz8bW)_