### PR TITLE
Fix verification_store leak on delete-on-verify for non-CHD verify-class sources

### DIFF
--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1751,8 +1751,10 @@ class JobManager:
 
                         source_deleted = True
 
-                        if job.file_path.lower().endswith(".chd"):
+                        ext = os.path.splitext(job.file_path)[1].lower()
+                        if ext in registry.verify_extensions():
                             await verification_store.clear(job.file_path)
+                        if ext == ".chd":
                             await chd_metadata_store.clear(job.file_path)
 
                 job.status = JobStatus.COMPLETED

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 4.0.0-beta-11 (2026-06-02)
+
+### Delete-on-verify no longer leaks verification records (#130)
+
+#### Fixed
+
+- **Non-CHD verify-class sources are cleared from the verification store on delete-on-verify.** When a conversion deleted its source after verifying, `job_manager` only cleared the persistent verification record if the source ended in `.chd`. But `verification_store` is tool-wide — it tracks verify-class outputs for every registered tool — so deleting a non-CHD verify-class source (`.rvz`/`.wia`/`.gcz`/`.z3ds`/`.zcci`/`.zcia`/`.nsz`/`.xcz`) left a stale record pointing at a file that no longer exists. The clear is now gated on `ext in registry.verify_extensions()` (tool-wide), mirroring the already-generalized file-browser delete/rename paths, while the CHD-specific `chd_metadata_store` clear stays gated on `.chd`.
+
+#### Internal
+
+- `tests/test_mode_parity_fixes.py` gained a regression test deleting a `.rvz` source on verify (asserting the tool-wide store is cleared but `chd_metadata_store` is not), and the existing z3ds test now asserts a non-verify-class `.3ds` source leaves both stores untouched.
+
 ## 4.0.0-beta-10 (2026-06-01)
 
 ### Switch key discovery + logging cleanup

--- a/tests/test_mode_parity_fixes.py
+++ b/tests/test_mode_parity_fixes.py
@@ -571,6 +571,79 @@ async def test_z3ds_delete_on_verify_marks_output_verified(tmp_path: Path, monke
     )
     assert not source_path.exists()
     assert output_path.exists()
+    # A non-verify-class source (.3ds) leaves the tool-wide verification_store
+    # untouched on delete.
+    clear_verified.assert_not_called()
+    clear_metadata.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_on_verify_clears_verification_store_for_non_chd_source(
+    tmp_path: Path, monkeypatch,
+):
+    """A non-CHD verify-class source (.rvz) must clear its tool-wide
+    verification_store record on delete-on-verify, while chd_metadata_store
+    (CHDMAN-specific) is left untouched."""
+    source_path = tmp_path / "game.rvz"
+    output_path = tmp_path / "game.wia"
+    source_path.write_bytes(b"source")
+
+    monkeypatch.setattr(job_manager_module.settings, "chd_volumes", str(tmp_path))
+    monkeypatch.setattr(job_manager_module.settings, "data_mount_root", str(tmp_path))
+
+    async def fake_convert(
+        input_path: str,
+        destination_path: str,
+        mode: str = "dolphin_wia",
+        compression: str | None = None,
+        cancel_event=None,
+    ):
+        Path(destination_path).write_bytes(b"converted")
+        yield {"progress": 100, "message": "Done"}
+
+    async def fake_verify(path: str):
+        return {"valid": True, "message": "File verified successfully"}
+
+    mark_verified = AsyncMock()
+    clear_verified = AsyncMock()
+    clear_metadata = AsyncMock()
+
+    _dolphin_service = job_manager_module.registry.for_mode("dolphin_wia")._service
+    monkeypatch.setattr(_dolphin_service, "convert", fake_convert)
+    monkeypatch.setattr(_dolphin_service, "verify", fake_verify)
+    monkeypatch.setattr(job_manager_module.verification_store, "mark_verified", mark_verified)
+    monkeypatch.setattr(job_manager_module.verification_store, "clear", clear_verified)
+    monkeypatch.setattr(job_manager_module.chd_metadata_store, "clear", clear_metadata)
+    monkeypatch.setattr(
+        job_manager_module,
+        "build_delete_plan",
+        lambda path: {
+            "delete_paths": [os.path.realpath(str(source_path))],
+            "missing_paths": [],
+            "unsafe_paths": [],
+            "errors": [],
+        },
+    )
+
+    manager = JobManager(max_concurrent=1, max_job_history=5)
+    snapshot = build_delete_snapshot(str(source_path))
+    job = await manager.create_job(
+        str(source_path),
+        ConversionMode.DOLPHIN_WIA,
+        output_path=str(output_path),
+        delete_on_verify=True,
+        delete_snapshot=snapshot,
+    )
+
+    await manager._process_job(job.id)
+
+    assert job.status == JobStatus.COMPLETED
+    assert not source_path.exists()
+    assert output_path.exists()
+    # The .rvz source is verify-class, so its tool-wide record is cleared...
+    clear_verified.assert_called_once_with(str(source_path))
+    # ...but chd_metadata_store stays CHDMAN-only and is not touched.
+    clear_metadata.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #130.

The source-delete-after-verify branch in `app/services/job_manager.py` (~line 1754) cleared the persistent `verification_store` record only when the deleted source ended in `.chd`:

```python
if job.file_path.lower().endswith(".chd"):
    await verification_store.clear(job.file_path)
    await chd_metadata_store.clear(job.file_path)
```

`verification_store` is **tool-wide** — it holds verify-class outputs for every registered tool (`registry.verify_extensions()`). So non-CHD verify-class sources (`.rvz`/`.wia`/`.gcz`/`.z3ds`/`.zcci`/`.zcia`/`.nsz`/`.xcz`) leaked their records when deleted on verify.

## Change

Mirror the already-generalized pattern in `app/routes/files.py` `delete_file()`/`rename_file()`:

```python
ext = os.path.splitext(job.file_path)[1].lower()
if ext in registry.verify_extensions():
    await verification_store.clear(job.file_path)
if ext == ".chd":
    await chd_metadata_store.clear(job.file_path)
```

- `verification_store.clear()` is now gated on `ext in registry.verify_extensions()` (tool-wide).
- `chd_metadata_store.clear()` stays gated on `.chd` (CHDMAN-specific by design).

## Tests

- Added `test_delete_on_verify_clears_verification_store_for_non_chd_source`, which deletes a `.rvz` source (non-CHD verify-class, via `dolphin_wia`) on verify and asserts `verification_store.clear()` is called for it while `chd_metadata_store.clear()` is not.
- Extended `test_z3ds_delete_on_verify_marks_output_verified` to assert the non-verify-class `.3ds` source leaves both stores untouched.

## Validation

- `PYTHONPATH=app python -m pytest -q` → 667 passed, 1 skipped
- `ruff check .` → clean

https://claude.ai/code/session_01UAqKALD8Fgkg5JY81KyNae

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAqKALD8Fgkg5JY81KyNae)_