### PR TITLE
docs: finalize 4.1.0 stable notes; document archive browse visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ a source.
 Browsing into an archive does **not** list everything it contains. It lists the
 file types the app *knows* — every extension that some tool recognizes as a
 convertible source (`.iso`, `.cue`/`.bin`, `.gdi`, `.gcz`/`.wia`/`.rvz`/`.wbfs`,
-`.cci`/`.cia`/`.3ds`/`.cxi`/`.3dsx`, `.nsp`/`.xci`, the handheld ROMs
+`.cci`/`.cia`/`.3ds`/`.cxi`/`.3dsx`, `.nsp`/`.xci`, `.cso`/`.zso`/`.dax`, the handheld ROMs
 `.gb`/`.gbc`/`.gba`/`.nds`, …) plus a `.chd` you can decompress in place. Anything
 else is hidden, on purpose:
 
@@ -418,7 +418,7 @@ On small screens the file list switches to a card layout. Controls use 44 to 48p
 - Archives extract temporarily during conversion, then clean up automatically
 - When a `.cue`/`.gdi` is present in the same archive folder, `.bin` entries are suppressed and batch jobs are deduplicated by output path to avoid stalled conversions.
 - Archive listings include safety limits (max entries/size) and expose truncation metadata when limits are hit.
-- **Browsing is global, scoped to known extensions.** When you look inside an archive, the listing shows every member whose extension is one the app understands — every tool's convertible source plus a `.chd` you can decompress — regardless of which tool is currently selected. That covers CHDMAN (`.gdi`/`.iso`/`.cue`/`.bin`), Dolphin (`.iso`/`.gcz`/`.wia`/`.rvz`/`.wbfs`), 3DS (`.cci`/`.cia`/`.3ds`/`.cxi`/`.3dsx`), Switch (`.nsp`/`.xci`), CSO (`.iso`), and Handheld ROM (`.gb`/`.gbc`/`.gba`/`.nds`). Archive members appear for whichever tool accepts them, exactly like on-disk files.
+- **Browsing is global, scoped to known extensions.** When you look inside an archive, the listing shows every member whose extension is one the app understands — every tool's convertible source plus a `.chd` you can decompress — regardless of which tool is currently selected. That covers CHDMAN (`.gdi`/`.iso`/`.cue`/`.bin`), Dolphin (`.iso`/`.gcz`/`.wia`/`.rvz`/`.wbfs`), 3DS (`.cci`/`.cia`/`.3ds`/`.cxi`/`.3dsx`), Switch (`.nsp`/`.xci`), CSO (`.iso`/`.cso`/`.zso`/`.dax`), and Handheld ROM (`.gb`/`.gbc`/`.gba`/`.nds`). Archive members appear for whichever tool accepts them, exactly like on-disk files.
 - **Why everything else is hidden.** Unknown files (text, `.nfo`/`.sfv`, cover art, manuals), nested archives (a `.zip` inside a `.zip`), and OS/NAS clutter (`__MACOSX/…`, `.DS_Store`, `Thumbs.db`) are filtered out — they aren't convertible or verifiable, so listing them would only be noise. See [Archives → Why only certain files show inside an archive](#why-only-certain-files-show-inside-an-archive).
 - **Some shown members are view-only.** A handheld ROM this app packed (`Game.gba` inside `Game.gba.7z`) is listed for visibility/verification but not offered for re-conversion (recompressing an archived ROM would be recursive); unpack it by selecting the archive and running `romz_extract`. A `.chd` inside an archive can be decompressed in place but not recompressed (copy/recompress acts on a finished output). Such members are badged non-convertible.
 - The only inputs that can't come from an archive are CHDMAN extract/copy modes, which operate on a finished `.chd` (an output, not a convertible source), and Handheld ROM compression, whose `.7z`/`.zip` are the packed product.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Each tool's full mode list (e.g. CHDMAN's `createcd`/`extractcd`, CSO's
 `cso2_compress`, the ROM packer's `romz_7z`/`romz_zip`/`romz_extract`) is in
 [Supported Operations](#supported-operations).
 
-> **Archive inputs:** most input formats above can be converted straight from inside a ZIP, 7z, or RAR archive, including 3DS ROMs, Dolphin disc images, and Switch dumps. Browse into the archive, pick a member, and convert. Two exceptions: CHDMAN extract and copy modes act on a finished `.chd` (an output, not a convertible source); and **Handheld ROM** does not accept loose ROMs from inside an archive — its `.7z`/`.zip` are the packed product, so to unpack one select the archive file itself and run `romz_extract`, rather than browsing into it for a member.
+> **Archive inputs:** most input formats above can be converted straight from inside a ZIP, 7z, or RAR archive, including 3DS ROMs, Dolphin disc images, and Switch dumps. Browse into the archive, pick a member, and convert. This even covers CHDMAN's extract modes pulling a `.chd` out of an archive and decompressing it back to a disc image. Two exceptions: CHDMAN's **copy/recompress** mode is not offered from an archive (recompressing an already-finished `.chd` would be a pointless round trip); and **Handheld ROM** does not accept loose ROMs from inside an archive — its `.7z`/`.zip` are the packed product, so to unpack one select the archive file itself and run `romz_extract`, rather than browsing into it for a member.
 
 ### MAME Redump DAT Integration
 
@@ -236,9 +236,11 @@ the file is bad.
 Browse straight into a ZIP, 7z, or RAR and convert a file from inside it — no need
 to extract first. The member is unpacked to a temp dir for the conversion and
 cleaned up afterwards. Any convertible **source** works this way (CHD create,
-Dolphin, 3DS, Switch, and CSO — Switch still needs your own `prod.keys`). The
-exception is CHDMAN extract/copy, which act on a finished `.chd` output rather than
-a source.
+Dolphin, 3DS, Switch, and CSO — Switch still needs your own `prod.keys`), and
+CHDMAN's extract modes can even pull a `.chd` out of an archive and decompress it
+back to a disc image. The exception is CHDMAN's copy/recompress mode: it acts on a
+finished `.chd`, and recompressing one straight out of an archive is a pointless
+round trip, so it's not offered there.
 
 #### Why only certain files show inside an archive
 
@@ -421,7 +423,7 @@ On small screens the file list switches to a card layout. Controls use 44 to 48p
 - **Browsing is global, scoped to known extensions.** When you look inside an archive, the listing shows every member whose extension is one the app understands — every tool's convertible source plus a `.chd` you can decompress — regardless of which tool is currently selected. That covers CHDMAN (`.gdi`/`.iso`/`.cue`/`.bin`), Dolphin (`.iso`/`.gcz`/`.wia`/`.rvz`/`.wbfs`), 3DS (`.cci`/`.cia`/`.3ds`/`.cxi`/`.3dsx`), Switch (`.nsp`/`.xci`), CSO (`.iso`/`.cso`/`.zso`/`.dax`), and Handheld ROM (`.gb`/`.gbc`/`.gba`/`.nds`). Archive members appear for whichever tool accepts them, exactly like on-disk files.
 - **Why everything else is hidden.** Unknown files (text, `.nfo`/`.sfv`, cover art, manuals), nested archives (a `.zip` inside a `.zip`), and OS/NAS clutter (`__MACOSX/…`, `.DS_Store`, `Thumbs.db`) are filtered out — they aren't convertible or verifiable, so listing them would only be noise. See [Archives → Why only certain files show inside an archive](#why-only-certain-files-show-inside-an-archive).
 - **Some shown members are view-only.** A handheld ROM this app packed (`Game.gba` inside `Game.gba.7z`) is listed for visibility/verification but not offered for re-conversion (recompressing an archived ROM would be recursive); unpack it by selecting the archive and running `romz_extract`. A `.chd` inside an archive can be decompressed in place but not recompressed (copy/recompress acts on a finished output). Such members are badged non-convertible.
-- The only inputs that can't come from an archive are CHDMAN extract/copy modes, which operate on a finished `.chd` (an output, not a convertible source), and Handheld ROM compression, whose `.7z`/`.zip` are the packed product.
+- The only inputs that can't come from an archive are CHDMAN's copy/recompress mode (recompressing an already-finished `.chd` would be a pointless round trip — though the extract modes *can* decompress a `.chd` straight out of an archive) and Handheld ROM compression, whose `.7z`/`.zip` are the packed product.
 
 **ISO Handling & Dolphin Tools (GameCube/Wii)**
 - Toggle ISO handling between CHDMAN and Dolphin (controls ISO info/verify and conversions)
@@ -844,7 +846,7 @@ Notes:
 - `extractcd` produces both `.cue` and `.bin` outputs.
 - Dolphin GCZ/ISO outputs ignore compression selection.
 - 3DS compression uses fixed settings (no user configuration needed).
-- Archive inputs are supported for every convertible source (CHD create, Dolphin, 3DS, Switch, and CSO), except CHDMAN extract/copy modes, which act on a finished `.chd` output.
+- Archive inputs are supported for every convertible source (CHD create, Dolphin, 3DS, Switch, and CSO), plus CHDMAN's extract modes decompressing a `.chd` pulled out of an archive. The exception is CHDMAN's copy/recompress mode, which would just re-compress an already-finished `.chd`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,42 @@ Dolphin, 3DS, Switch, and CSO — Switch still needs your own `prod.keys`). The
 exception is CHDMAN extract/copy, which act on a finished `.chd` output rather than
 a source.
 
+#### Why only certain files show inside an archive
+
+Browsing into an archive does **not** list everything it contains. It lists the
+file types the app *knows* — every extension that some tool recognizes as a
+convertible source (`.iso`, `.cue`/`.bin`, `.gdi`, `.gcz`/`.wia`/`.rvz`/`.wbfs`,
+`.cci`/`.cia`/`.3ds`/`.cxi`/`.3dsx`, `.nsp`/`.xci`, the handheld ROMs
+`.gb`/`.gbc`/`.gba`/`.nds`, …) plus a `.chd` you can decompress in place. Anything
+else is hidden, on purpose:
+
+- **Unknown files are filtered out.** Read-me text, `.nfo`/`.sfv` files, box art,
+  manuals, save states — none of it is something the app can convert or verify, so
+  it would only be clutter in the browser. The listing is *global, scoped to known
+  extensions*: a member shows up if and only if its extension is one the app
+  understands, regardless of which tool you currently have selected.
+- **Nested archives are hidden.** A `.zip` inside a `.zip` (or `.7z`/`.rar`) is not
+  listed — there's no point browsing an archive within an archive.
+- **OS/NAS clutter is ignored.** macOS `__MACOSX/…` resource forks, `.DS_Store`,
+  `Thumbs.db` and the like never appear, so a ROM zipped on a Mac or Windows box
+  still reads as a clean single-file archive.
+
+Some members that *are* shown still can't be converted from inside the archive,
+and the UI badges them non-convertible:
+
+- **A handheld ROM packed by this app** (`Game.gba` inside `Game.gba.7z`) is shown
+  so you can see and verify it, but it isn't offered for re-conversion —
+  recompressing an already-archived ROM would just be packing a `.7z` into another
+  `.7z`. To unpack it, select the archive file itself and run `romz_extract`.
+- **A `.chd` inside an archive** can be *decompressed* in place (chdman's extract
+  modes), but it can't be recompressed — it's already a finished CHD, so chdman's
+  copy/recompress mode is deliberately not offered from an archive.
+
+In short: if a file you expect isn't in the list, it's almost always because its
+extension isn't one of the convertible/verifiable types the app handles. Loose
+files on disk follow the same rule — the file list filters to the types the
+selected tool understands.
+
 ### Troubleshooting
 
 * **An emulator won't read the CHD** — almost always the codec; recompress with
@@ -382,8 +418,10 @@ On small screens the file list switches to a card layout. Controls use 44 to 48p
 - Archives extract temporarily during conversion, then clean up automatically
 - When a `.cue`/`.gdi` is present in the same archive folder, `.bin` entries are suppressed and batch jobs are deduplicated by output path to avoid stalled conversions.
 - Archive listings include safety limits (max entries/size) and expose truncation metadata when limits are hit.
-- **Any convertible source inside an archive can be converted.** That covers CHDMAN (`.gdi`/`.iso`/`.cue`/`.bin`), Dolphin (`.iso`/`.gcz`/`.wia`/`.rvz`/`.wbfs`), and 3DS (`.cci`/`.cia`/`.3ds`). Archive members show up for whichever tool accepts them, exactly like on-disk files.
-- The only inputs that can't come from an archive are CHDMAN extract/copy modes, which operate on a finished `.chd` (an output, not a convertible source).
+- **Browsing is global, scoped to known extensions.** When you look inside an archive, the listing shows every member whose extension is one the app understands — every tool's convertible source plus a `.chd` you can decompress — regardless of which tool is currently selected. That covers CHDMAN (`.gdi`/`.iso`/`.cue`/`.bin`), Dolphin (`.iso`/`.gcz`/`.wia`/`.rvz`/`.wbfs`), 3DS (`.cci`/`.cia`/`.3ds`/`.cxi`/`.3dsx`), Switch (`.nsp`/`.xci`), CSO (`.iso`), and Handheld ROM (`.gb`/`.gbc`/`.gba`/`.nds`). Archive members appear for whichever tool accepts them, exactly like on-disk files.
+- **Why everything else is hidden.** Unknown files (text, `.nfo`/`.sfv`, cover art, manuals), nested archives (a `.zip` inside a `.zip`), and OS/NAS clutter (`__MACOSX/…`, `.DS_Store`, `Thumbs.db`) are filtered out — they aren't convertible or verifiable, so listing them would only be noise. See [Archives → Why only certain files show inside an archive](#why-only-certain-files-show-inside-an-archive).
+- **Some shown members are view-only.** A handheld ROM this app packed (`Game.gba` inside `Game.gba.7z`) is listed for visibility/verification but not offered for re-conversion (recompressing an archived ROM would be recursive); unpack it by selecting the archive and running `romz_extract`. A `.chd` inside an archive can be decompressed in place but not recompressed (copy/recompress acts on a finished output). Such members are badged non-convertible.
+- The only inputs that can't come from an archive are CHDMAN extract/copy modes, which operate on a finished `.chd` (an output, not a convertible source), and Handheld ROM compression, whose `.7z`/`.zip` are the packed product.
 
 **ISO Handling & Dolphin Tools (GameCube/Wii)**
 - Toggle ISO handling between CHDMAN and Dolphin (controls ISO info/verify and conversions)

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,13 +1,20 @@
 # Release Notes
 
-## 4.1.0 (2026-06-03)
+## 4.1.0 (2026-06-04)
 
-This release rolls up everything since 4.0 into one version: PSP / PS2
-CSO·ZSO·DAX support (maxcso), Handheld ROM archiving (GB / GBC / GBA / NDS ↔
-`.7z`/`.zip`), full Nintendo 3DS reversibility on a new upstream fork
-(decompression + `.cxi`/`.3dsx`), registry-driven library-scan / DAT-match
-across every format, tool-neutral process-priority and timeout settings, and the
-related fixes below. Sections are newest-first.
+This is the stable 4.1.0 release. It supersedes the `4.1.0-beta-1` through
+`4.1.0-beta-4` pre-releases; everything in those betas is rolled up here and no
+further changes were made between `4.1.0-beta-4` and stable. The release rolls
+up everything since 4.0 into one version: PSP / PS2 CSO·ZSO·DAX support
+(maxcso), Handheld ROM archiving (GB / GBC / GBA / NDS ↔ `.7z`/`.zip`), full
+Nintendo 3DS reversibility on a new upstream fork (decompression +
+`.cxi`/`.3dsx`), faster archive-heavy directory listings, archive browsing made
+global (so a packed ROM and an archived `.chd` are now visible inside their
+container), CHD decompression straight out of an archive, registry-driven
+library-scan / DAT-match across every format, tool-neutral process-priority and
+timeout settings, dependency refreshes, and the related fixes below. Sections
+are newest-first; a per-beta breakdown is in [Beta history](#beta-history-410-beta-1--beta-4)
+at the end of this release.
 
 ### CHD: decompress a .chd straight out of an archive
 
@@ -137,6 +144,43 @@ related fixes below. Sections are newest-first.
 #### Internal
 
 - `tests/test_mode_parity_fixes.py` gained a regression test deleting a `.rvz` source on verify (asserting the tool-wide store is cleared but `chd_metadata_store` is not), and the existing z3ds test now asserts a non-verify-class `.3ds` source leaves both stores untouched.
+
+### Dependency updates
+
+#### Changed
+
+- **Routine dependency refresh (Dependabot).** Shipped in `4.1.0-beta-3`, no
+  behavior change:
+  - **npm / frontend:** `vite` 6.4.2 → 8.0.16 (#142), `svelte` 5.55.10 → 5.56.1
+    (#143), `svelte-eslint-parser` 1.6.1 → 1.7.1 (#144), `eslint` 10.4.0 →
+    10.4.1 (#139), `eslint-plugin-svelte` 3.18.0 → 3.19.0 (#138).
+  - **pip / backend:** `pytest-asyncio` `>=1.3.0` → `>=1.4.0` (#141),
+    `python-multipart` `>=0.0.29` → `>=0.0.30` (#140).
+  - **GitHub Actions:** `docker/setup-qemu-action` 4.0.0 → 4.1.0 (#145).
+
+### Beta history (4.1.0-beta-1 → beta-4)
+
+The stable 4.1.0 was cut from four betas. Each entry below points at the
+thematic section above where the change is described in full; this is the
+chronological map of what landed in which pre-release.
+
+- **`4.1.0-beta-1` (2026-06-03).** Handheld ROM tool — GB / GBC / GBA / NDS ↔
+  `.7z`/`.zip` (#137); romz Verify/Info gated to single-ROM archives (#147);
+  Nintendo 3DS decompression + the new `pacnpal/z3ds_compress` upstream adding
+  `.cxi`/`.3dsx` (#148). (The maxcso CSO/ZSO/DAX tool, the registry-driven
+  library-scan / DAT-match generalization, tool-neutral priority/timeout
+  settings, and the delete-on-verify fix were authored against 4.0.1 and are
+  rolled into this release per the note at the top.)
+- **`4.1.0-beta-2` (2026-06-04).** Faster directory listings in archive-heavy
+  folders via the shared, mtime-keyed archive-member cache and the
+  `POST /api/archive-summary` batch (#149).
+- **`4.1.0-beta-3` (2026-06-04).** Dependency updates (#138–#145) — see
+  [Dependency updates](#dependency-updates) above.
+- **`4.1.0-beta-4` (2026-06-04).** Archive browsing made global, scoped to
+  known extensions, so a packed handheld ROM is now visible when you browse
+  into its archive instead of showing "Empty folder"; list-only members kept
+  out of Search and the convertible flag; and chdman extract enabled from
+  inside an archive so a `.chd` decompresses in place (#150, #151).
 
 ## 4.0.0-beta-10 (2026-06-01)
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -13,7 +13,7 @@ global (so a packed ROM and an archived `.chd` are now visible inside their
 container), CHD decompression straight out of an archive, registry-driven
 library-scan / DAT-match across every format, tool-neutral process-priority and
 timeout settings, dependency refreshes, and the related fixes below. Sections
-are newest-first; a per-beta breakdown is in [Beta history](#beta-history-410-beta-1--beta-4)
+are newest-first; a per-beta breakdown is in [Beta history](#beta-history-410-beta-1-to-beta-4)
 at the end of this release.
 
 ### CHD: decompress a .chd straight out of an archive
@@ -158,7 +158,7 @@ at the end of this release.
     `python-multipart` `>=0.0.29` → `>=0.0.30` (#140).
   - **GitHub Actions:** `docker/setup-qemu-action` 4.0.0 → 4.1.0 (#145).
 
-### Beta history (4.1.0-beta-1 → beta-4)
+### Beta history (4.1.0-beta-1 to beta-4)
 
 The stable 4.1.0 was cut from four betas. Each entry below points at the
 thematic section above where the change is described in full; this is the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compressatorium",
-  "version": "4.1.0-beta-4",
+  "version": "4.1.0",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/lib/components/views/HelpView.svelte
+++ b/src/lib/components/views/HelpView.svelte
@@ -384,8 +384,10 @@
       Any convertible source works this way — 3DS ROMs, Dolphin discs, Switch dumps
       (<code>.nsp</code>/<code>.xci</code>, your own <code>prod.keys</code> still required), and PSP/PS2
       images (both the <code>.iso</code> you compress and the <code>.cso</code>/<code>.zso</code>/<code>.dax</code>
-      you decompress). The one exception is CHDMAN extract and copy, which act on a finished
-      <code>.chd</code> (an output, not a source).
+      you decompress). CHDMAN's extract modes can even pull a <code>.chd</code> out of an
+      archive and decompress it back to a disc image. The one exception is CHDMAN's
+      copy/recompress mode: recompressing an already-finished <code>.chd</code> straight out of
+      an archive is a pointless round trip, so it isn't offered there.
     </p>
     <p>
       When a <code>.cue</code> or <code>.gdi</code> sits next to its <code>.bin</code>

--- a/src/lib/components/views/HelpView.svelte
+++ b/src/lib/components/views/HelpView.svelte
@@ -399,7 +399,8 @@
       a member appears if and only if its extension is one some tool recognizes as a
       convertible source (<code>.iso</code>, <code>.cue</code>/<code>.bin</code>,
       <code>.gdi</code>, the Dolphin and 3DS formats, <code>.nsp</code>/<code>.xci</code>,
-      the handheld ROMs <code>.gb</code>/<code>.gbc</code>/<code>.gba</code>/<code>.nds</code>,
+      <code>.cso</code>/<code>.zso</code>/<code>.dax</code>, the handheld ROMs
+      <code>.gb</code>/<code>.gbc</code>/<code>.gba</code>/<code>.nds</code>,
       …), plus a <code>.chd</code> you can decompress in place — no matter which tool you
       currently have selected.
     </p>

--- a/src/lib/components/views/HelpView.svelte
+++ b/src/lib/components/views/HelpView.svelte
@@ -392,6 +392,34 @@
       inside an archive, the loose <code>.bin</code> entries are hidden and batch jobs are
       deduplicated by output, so you don't end up with two jobs fighting over the same file.
     </p>
+    <h3 class="sub-title">Why only certain files show inside an archive</h3>
+    <p>
+      Browsing into an archive doesn't list everything in it — it lists the file types the
+      app <em>knows</em>. The listing is <strong>global, scoped to known extensions</strong>:
+      a member appears if and only if its extension is one some tool recognizes as a
+      convertible source (<code>.iso</code>, <code>.cue</code>/<code>.bin</code>,
+      <code>.gdi</code>, the Dolphin and 3DS formats, <code>.nsp</code>/<code>.xci</code>,
+      the handheld ROMs <code>.gb</code>/<code>.gbc</code>/<code>.gba</code>/<code>.nds</code>,
+      …), plus a <code>.chd</code> you can decompress in place — no matter which tool you
+      currently have selected.
+    </p>
+    <p>
+      Everything else is hidden on purpose: <strong>unknown files</strong> (read-me text,
+      <code>.nfo</code>/<code>.sfv</code>, box art, manuals, save states) that the app can't
+      convert or verify, <strong>nested archives</strong> (a <code>.zip</code> inside a
+      <code>.zip</code>), and <strong>OS/NAS clutter</strong> (<code>__MACOSX/…</code>,
+      <code>.DS_Store</code>, <code>Thumbs.db</code>). So if a file you expected isn't in the
+      list, it's almost always because its extension isn't one of the convertible/verifiable
+      types — the same rule the on-disk file list follows.
+    </p>
+    <p>
+      A few members that <em>do</em> show are view-only and badged non-convertible. A handheld
+      ROM this app packed (<code>Game.gba</code> inside <code>Game.gba.7z</code>) is shown so
+      you can see and verify it, but it isn't offered for re-conversion — recompressing an
+      already-archived ROM would be recursive; to unpack it, select the archive itself and run
+      <code>romz_extract</code>. A <code>.chd</code> inside an archive can be decompressed in
+      place but not recompressed (copy/recompress acts on a finished output).
+    </p>
   </article>
 
   <article class="panel">
@@ -514,6 +542,7 @@
 
   .panel { background: var(--surface-1); border: 1px solid var(--border-subtle); border-radius: var(--radius-lg); padding: var(--space-4); box-shadow: var(--elev-1); }
   .panel-title { margin: 0 0 var(--space-3); font-size: var(--text-base); font-weight: var(--weight-semibold); color: var(--text-1); text-transform: uppercase; letter-spacing: 0.05em; }
+  .sub-title { margin: var(--space-4) 0 var(--space-2); font-size: var(--text-sm); font-weight: var(--weight-semibold); color: var(--text-1); }
 
   .panel p { color: var(--text-2); margin: 0 0 var(--space-2); line-height: 1.6; max-width: 72ch; }
   .panel p:last-child { margin-bottom: 0; }


### PR DESCRIPTION
## Summary

Finalizes the 4.1.0 release notes as **stable** and adds detailed, user-facing documentation for **why only certain files show inside an archive** — in both the README and the in-app Help view. Also bumps `package.json` to the stable `4.1.0`.

## Release notes (`docs/RELEASE_NOTES.md`)

- **Presented as stable.** The `## 4.1.0` heading is dated `2026-06-04` and the intro now states it supersedes the `4.1.0-beta-1` … `4.1.0-beta-4` pre-releases, with no changes between `beta-4` and stable.
- **Dependency refresh section added.** The Dependabot bumps that shipped in `beta-3` were missing from the notes; added them grouped by ecosystem: npm (`vite`, `svelte`, `svelte-eslint-parser`, `eslint`, `eslint-plugin-svelte`), pip (`pytest-asyncio`, `python-multipart`), and GitHub Actions (`docker/setup-qemu-action`) — #138–#145.
- **Beta history section added.** A chronological map of which work landed in each beta tag (beta-1 → beta-4), cross-linked to the thematic sections above.

## Archive browse visibility (the "why only certain files show" docs)

The 4.1 work made archive browsing *global, scoped to known extensions* (`ArchiveService._listable_extensions` = `convertible_extensions() | archive_input_extensions()` minus the containers). This PR explains that behavior to users:

- **README** — rewrote the *Archives* usage section (new `#### Why only certain files show inside an archive` subsection) and the *Archive Support* feature list to cover:
  - the global-known-extensions listing (every tool's source + a decompressable `.chd`, regardless of selected tool);
  - what's hidden and why (unknown files like text/`.nfo`/cover art, nested archives, OS/NAS clutter such as `__MACOSX/…`/`.DS_Store`/`Thumbs.db`);
  - view-only/non-convertible members (a packed handheld ROM, an archived `.chd`) and how to act on them.
- **In-app Help (`HelpView.svelte`)** — added a matching *Why only certain files show inside an archive* subsection to the Archives panel, plus a `.sub-title` style. Validated with the Svelte autofixer (no issues).

## Version

- `package.json`: `4.1.0-beta-4` → `4.1.0` to match the stable notes.

## Notes

The developer-facing docs (`docs/DESIGN_tool_plugin_architecture.md`, `docs/ADDING_PLATFORMS_AND_TOOLS.md`) already document the listable-vs-convert-gate split, so no changes were needed there.

https://claude.ai/code/session_01PYYh6NdJhrBJcAiBdHmQ3e

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYYh6NdJhrBJcAiBdHmQ3e)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced help documentation with detailed explanations of archive file filtering, visibility rules, and view-only content constraints
  * Clarified which file types are hidden from archive listings and operations unavailable from archives
  * Updated README and release notes with comprehensive archive browsing specifications

* **Release**
  * Version 4.1.0 now available as stable release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->