### PR TITLE
feat(#98): cso→chd chaining seam (Phase 1) + directory-input scaffolding

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -126,6 +126,14 @@ class Settings(BaseSettings):
         default="/usr/local/bin/maxcso", alias="MAXCSO_PATH",
     )
 
+    # Extra free space (MB) a chained conversion (e.g. cso->iso->chd) keeps
+    # beyond its estimated peak before starting. A chain holds source + full
+    # intermediate + partial final at once, so it preflights disk headroom on
+    # both the work-dir and output-dir volumes; this is the per-volume cushion.
+    chain_disk_margin_mb: int = Field(
+        default=512, alias="COMPRESSATORIUM_CHAIN_DISK_MARGIN_MB",
+    )
+
     # nsz (Nintendo Switch NSP/XCI <-> NSZ/XCZ). Installed via pip into the
     # venv, so the console script lives on PATH (/opt/venv/bin in Docker, .venv
     # locally). A bare name resolves in both; set NSZ_PATH to pin an absolute

--- a/app/models.py
+++ b/app/models.py
@@ -29,6 +29,7 @@ class ConversionMode(str, Enum):
     ZSO_COMPRESS = "zso_compress"
     DAX_COMPRESS = "dax_compress"
     CSO_DECOMPRESS = "cso_decompress"
+    CSO_TO_CHD = "cso_to_chd"
     ROMZ_7Z = "romz_7z"
     ROMZ_ZIP = "romz_zip"
     ROMZ_EXTRACT = "romz_extract"

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -220,6 +220,7 @@ class SkipReason(Enum):
     ROMZ_BAD_EXTENSION = "romz_bad_extension"
     ROMZ_INVALID_ARCHIVE = "romz_invalid_archive"
     DOLPHIN_SAME_PATH = "dolphin_same_path"
+    CHAIN_BAD_EXTENSION = "chain_bad_extension"
 
 
 class SkipFile(Exception):  # noqa: N818 - control-flow signal, not an error
@@ -297,6 +298,10 @@ _SKIP_HTTP: dict[SkipReason, tuple[int, str]] = {
         400,
         "Output path matches input; overwriting would delete the source file",
     ),
+    SkipReason.CHAIN_BAD_EXTENSION: (
+        400,
+        "cso_to_chd requires a .cso/.zso/.dax source",
+    ),
 }
 
 
@@ -325,6 +330,7 @@ async def plan_job(
     is_nsz = spec.tool_id == "nsz"
     is_cso = spec.tool_id == "cso"
     is_romz = spec.tool_id == "romz"
+    is_chain = spec.tool_id == "chain"
 
     archive_source_dir = None  # Directory where the archive is located (for output)
     output_path = None
@@ -407,6 +413,15 @@ async def plan_job(
         ext = _input_extension(file_path)
         if ext not in spec.input_extensions:
             raise SkipFile(SkipReason.CSO_BAD_EXTENSION)
+
+    if is_chain:
+        # Composite modes (tool_id="chain") match none of the legacy per-tool
+        # branches, so without this a direct API/batch submission would accept
+        # any non-.chd file and fail late in the worker. Validate the chain's
+        # declared source extensions (cso_to_chd: .cso/.zso/.dax).
+        ext = _input_extension(file_path)
+        if ext not in spec.input_extensions:
+            raise SkipFile(SkipReason.CHAIN_BAD_EXTENSION)
 
     if is_romz:
         # spec.input_extensions is per-mode: compress (.gb/.gbc/.gba/.nds) vs

--- a/app/services/disc_id.py
+++ b/app/services/disc_id.py
@@ -282,21 +282,24 @@ def _parse_system_cnf(data: bytes) -> dict:
     return {}
 
 
-def _parse_param_sfo(data: bytes) -> dict:
-    """
-    Parse a PSP PARAM.SFO binary blob and return game_id, title, platform.
+def parse_sfo_keys(data: bytes) -> dict[str, str]:
+    """Return every UTF-8 string key of a PSF (PARAM.SFO) blob.
+
+    The shared, format-only PARAM.SFO table reader. Both the PSP/CHD tagging
+    path (``_parse_param_sfo`` below) and PS3 folder detection
+    (``services.ps3``) build on this, so the binary table parsing lives in one
+    place (per the repo's "modularity is key" rule) rather than being
+    copy-pasted per platform.
+
     SFO format (little-endian):
-      0x00  4   magic "\x00PSF"
-      0x04  2   version minor
-      0x06  2   version major
+      0x00  4   magic "\\x00PSF"
       0x08  4   key_table_offset
       0x0C  4   data_table_offset
       0x10  4   num_entries
-    Then num_entries × 16-byte index entries:
+    Then num_entries x 16-byte index entries:
       0x00  2   key_offset (from key_table_offset)
       0x02  2   data_format  (0x0204 = utf8 string)
       0x04  4   data_len
-      0x08  4   data_max_len
       0x0C  4   data_offset (from data_table_offset)
     """
     if len(data) < 20 or data[:4] != _SFO_MAGIC:
@@ -305,41 +308,47 @@ def _parse_param_sfo(data: bytes) -> dict:
         key_table_off = struct.unpack_from("<I", data, 8)[0]
         data_table_off = struct.unpack_from("<I", data, 12)[0]
         num_entries = struct.unpack_from("<I", data, 16)[0]
-
-        result: dict = {}
-        for i in range(num_entries):
-            entry_off = 20 + i * 16
-            if entry_off + 16 > len(data):
-                break
-            key_off = struct.unpack_from("<H", data, entry_off)[0]
-            fmt = struct.unpack_from("<H", data, entry_off + 2)[0]
-            data_len = struct.unpack_from("<I", data, entry_off + 4)[0]
-            val_off = struct.unpack_from("<I", data, entry_off + 12)[0]
-
-            key_start = key_table_off + key_off
-            key_end = data.find(b"\x00", key_start)
-            if key_end < 0:
-                continue
-            key = data[key_start:key_end].decode("ascii", errors="replace")
-
-            if fmt != _SFO_FMT_UTF8:
-                continue
-            val_start = data_table_off + val_off
-            val_end = val_start + data_len
-            if val_end > len(data):
-                continue
-            val = data[val_start:val_end].rstrip(b"\x00").decode("utf-8", errors="replace")
-
-            if key == "DISC_ID":
-                result["game_id"] = val
-            elif key == "TITLE":
-                result["title"] = val
-
-        if result:
-            result["platform"] = "psp"
-        return result
-    except Exception:
+    except struct.error:
         return {}
+
+    out: dict[str, str] = {}
+    for i in range(num_entries):
+        entry_off = 20 + i * 16
+        if entry_off + 16 > len(data):
+            break
+        key_off = struct.unpack_from("<H", data, entry_off)[0]
+        fmt = struct.unpack_from("<H", data, entry_off + 2)[0]
+        data_len = struct.unpack_from("<I", data, entry_off + 4)[0]
+        val_off = struct.unpack_from("<I", data, entry_off + 12)[0]
+
+        key_start = key_table_off + key_off
+        key_end = data.find(b"\x00", key_start)
+        if key_end < 0:
+            continue
+        key = data[key_start:key_end].decode("ascii", errors="replace")
+        if fmt != _SFO_FMT_UTF8:
+            continue
+        val_start = data_table_off + val_off
+        val_end = val_start + data_len
+        if val_end > len(data):
+            continue
+        out[key] = data[val_start:val_end].rstrip(b"\x00").decode(
+            "utf-8", errors="replace",
+        )
+    return out
+
+
+def _parse_param_sfo(data: bytes) -> dict:
+    """Parse a PSP PARAM.SFO blob into game_id, title, platform."""
+    keys = parse_sfo_keys(data)
+    result: dict = {}
+    if "DISC_ID" in keys:
+        result["game_id"] = keys["DISC_ID"]
+    if "TITLE" in keys:
+        result["title"] = keys["TITLE"]
+    if result:
+        result["platform"] = "psp"
+    return result
 
 
 def _parse_ipbin(data: bytes) -> dict:

--- a/app/services/disk.py
+++ b/app/services/disk.py
@@ -1,0 +1,85 @@
+"""Shared free-space (headroom) preflight for multi-step / large conversions.
+
+A single-step convert holds one output at a time, so the codebase never needed
+a disk check. A chain (cso -> iso -> chd) holds the source, the full
+intermediate, and the partial final at once, so it can exhaust a volume mid-run.
+``ensure_headroom`` is the shared seam any such job calls before it starts.
+
+It is **multi-volume aware**: Compressatorium routinely has the per-job work dir
+(intermediates) and the selected output dir (final) on different filesystems, so
+requirements are grouped by mount (``st_dev``) and each mount is checked once.
+The output dir may not exist yet (``SubprocessRunner`` mkdirs it later), so the
+mount is resolved from the nearest existing ancestor of each target.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+
+
+class InsufficientDiskSpace(RuntimeError):
+    """Raised by :func:`ensure_headroom` when a target volume lacks space."""
+
+
+def _nearest_existing(path: str) -> str:
+    """Walk up ``path`` until an existing directory is found.
+
+    A target dir may not exist yet (created later by the subprocess runner);
+    ``shutil.disk_usage`` / ``os.stat`` report the same filesystem for any path
+    on that mount, so the nearest existing ancestor is a safe stand-in.
+    """
+    candidate = os.path.abspath(path)
+    while True:
+        if os.path.exists(candidate):
+            return candidate
+        parent = os.path.dirname(candidate)
+        if parent == candidate:
+            return candidate  # reached the root
+        candidate = parent
+
+
+def ensure_headroom(
+    targets: list[tuple[str, int]],
+    *,
+    margin_bytes: int = 0,
+) -> None:
+    """Verify each distinct mount can hold the bytes targeted at it.
+
+    Parameters
+    ----------
+    targets:
+        ``(path, required_bytes)`` pairs. ``path`` is where bytes will be
+        written (work dir, output dir); it need not exist yet. Requirements
+        for paths on the same mount are summed so a shared filesystem is not
+        double-spent.
+    margin_bytes:
+        Extra free space to keep beyond the summed requirement, per mount.
+
+    Raises
+    ------
+    InsufficientDiskSpace
+        If any mount's free space is below ``required + margin``.
+    """
+    # dev -> [anchor_path, summed_required_bytes]
+    by_dev: dict[int, list] = {}
+    for path, required in targets:
+        anchor = _nearest_existing(path)
+        try:
+            dev = os.stat(anchor).st_dev
+        except OSError:
+            # Can't stat the anchor (race/permission); skip rather than block.
+            continue
+        entry = by_dev.setdefault(dev, [anchor, 0])
+        entry[1] += max(0, int(required))
+
+    for anchor, required in by_dev.values():
+        try:
+            free = shutil.disk_usage(anchor).free
+        except OSError:
+            continue
+        need = required + max(0, int(margin_bytes))
+        if free < need:
+            raise InsufficientDiskSpace(
+                f"Not enough free space on the volume holding {anchor!r}: "
+                f"need ~{need:,} bytes, have {free:,} bytes free"
+            )

--- a/app/services/disk.py
+++ b/app/services/disk.py
@@ -15,10 +15,33 @@ from __future__ import annotations
 
 import os
 import shutil
+import tempfile
+from pathlib import Path
 
 
 class InsufficientDiskSpace(RuntimeError):
     """Raised by :func:`ensure_headroom` when a target volume lacks space."""
+
+
+def create_scratch_dir(prefix: str) -> str:
+    """Create a temp working dir under the operator's configured scratch volume.
+
+    Honors ``settings.temp_dir`` (``CHD_TEMP_DIR``) — the same base the archive
+    extractor uses — so large intermediates land on the scratch volume rather
+    than the container's (often small) ``/tmp`` overlay, which is also the
+    volume the headroom preflight checks. Falls back to the system default if
+    that directory can't be created.
+    """
+    from config import settings  # local import to keep this module stdlib-only
+
+    base_dir = settings.temp_dir or str(Path(settings.data_dir) / "temp")
+    if base_dir:
+        try:
+            Path(base_dir).mkdir(parents=True, exist_ok=True)
+            return tempfile.mkdtemp(prefix=prefix, dir=base_dir)
+        except OSError:
+            pass
+    return tempfile.mkdtemp(prefix=prefix)
 
 
 def _nearest_existing(path: str) -> str:

--- a/app/services/maxcso.py
+++ b/app/services/maxcso.py
@@ -25,6 +25,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import struct
 import threading
 import time
 from collections.abc import AsyncGenerator
@@ -44,6 +45,36 @@ _OWNER = "maxcso"
 # Compress takes a raw .iso; decompress takes any maxcso-produced container.
 MAXCSO_COMPRESS_EXTENSIONS = {".iso"}
 MAXCSO_DECOMPRESS_EXTENSIONS = {".cso", ".zso", ".dax"}
+
+
+def uncompressed_iso_size(path: str) -> int | None:
+    """Read the uncompressed ISO size (bytes) from a CSO/ZSO/DAX header.
+
+    A highly compressed container can be a small fraction of the ISO maxcso
+    will write, so estimating disk headroom from the compressed file size badly
+    under-counts. The uncompressed size lives in the container header:
+
+    - CSO (``CISO``) / ZSO (``ZISO``): ``uint64`` at offset 8.
+    - DAX (``DAX\\0``): ``uint32`` at offset 4.
+
+    Returns ``None`` for an unknown/unreadable header (caller falls back to a
+    ratio-based estimate).
+    """
+    try:
+        with open(path, "rb") as handle:
+            head = handle.read(16)
+    except OSError:
+        return None
+    if len(head) < 16:
+        return None
+    try:
+        if head[:4] in (b"CISO", b"ZISO"):
+            return int(struct.unpack_from("<Q", head, 8)[0]) or None
+        if head[:4] == b"DAX\x00":
+            return int(struct.unpack_from("<I", head, 4)[0]) or None
+    except struct.error:
+        return None
+    return None
 
 # Output extension is decided by the mode, not the input extension (an .iso can
 # become .cso/.zso/.dax), so the map is keyed by mode rather than suffix. CSO v1

--- a/app/services/ps3.py
+++ b/app/services/ps3.py
@@ -1,0 +1,88 @@
+"""PS3 decrypted/JB folder detection for the makeps3iso folder->iso seam.
+
+Phase 2 scaffolding. The codebase keys input off ``Path(filename).suffix``; a
+folder has no suffix, so this module is the directory analogue of an extension
+check — the predicate a future ``MakePs3IsoTool.accepts_directory`` runs.
+
+A folder is a valid makeps3iso source only when it carries the disc/JB layout (a
+``PS3_GAME/`` root, plus ``PS3_DISC.SFB`` for disc rips). A bare TITLEID
+directory that merely holds a ``PARAM.SFO`` — an installed / HDD ``game/``
+game-data layout — is NOT something makeps3iso can package, so it is rejected
+rather than advertised.
+"""
+from __future__ import annotations
+
+import os
+import struct
+
+_SFO_MAGIC = b"\x00PSF"
+_SFO_FMT_UTF8 = 0x0204
+
+
+def is_ps3_iso_source(path: str) -> bool:
+    """Whether ``path`` is a decrypted PS3 disc/JB folder makeps3iso can pack."""
+    if not os.path.isdir(path):
+        return False
+    ps3_game = os.path.join(path, "PS3_GAME")
+    if not os.path.isdir(ps3_game):
+        return False
+    # A disc rip carries PS3_DISC.SFB at the root; a JB game folder at least has
+    # PS3_GAME/PARAM.SFO. Either proves the disc/JB layout — a folder with only
+    # a PARAM.SFO under a TITLEID (and no PS3_GAME root) is intentionally not
+    # matched here.
+    if os.path.isfile(os.path.join(path, "PS3_DISC.SFB")):
+        return True
+    return os.path.isfile(os.path.join(ps3_game, "PARAM.SFO"))
+
+
+def read_sfo_keys(path: str) -> dict[str, str]:
+    """Return the UTF-8 string keys of a PS3/PSP PARAM.SFO (PSF container).
+
+    A small, format-only reader (no platform assumptions), so PS3's
+    ``TITLE_ID`` key is read the same way the PSP path reads ``DISC_ID``.
+    """
+    try:
+        with open(path, "rb") as handle:
+            data = handle.read()
+    except OSError:
+        return {}
+    if len(data) < 20 or data[:4] != _SFO_MAGIC:
+        return {}
+    try:
+        key_table_off = struct.unpack_from("<I", data, 8)[0]
+        data_table_off = struct.unpack_from("<I", data, 12)[0]
+        num_entries = struct.unpack_from("<I", data, 16)[0]
+    except struct.error:
+        return {}
+
+    out: dict[str, str] = {}
+    for i in range(num_entries):
+        entry_off = 20 + i * 16
+        if entry_off + 16 > len(data):
+            break
+        key_off = struct.unpack_from("<H", data, entry_off)[0]
+        fmt = struct.unpack_from("<H", data, entry_off + 2)[0]
+        data_len = struct.unpack_from("<I", data, entry_off + 4)[0]
+        val_off = struct.unpack_from("<I", data, entry_off + 12)[0]
+
+        key_start = key_table_off + key_off
+        key_end = data.find(b"\x00", key_start)
+        if key_end < 0:
+            continue
+        key = data[key_start:key_end].decode("ascii", errors="replace")
+        if fmt != _SFO_FMT_UTF8:
+            continue
+        val_start = data_table_off + val_off
+        val_end = val_start + data_len
+        if val_end > len(data):
+            continue
+        out[key] = data[val_start:val_end].rstrip(b"\x00").decode(
+            "utf-8", errors="replace",
+        )
+    return out
+
+
+def ps3_title_id(path: str) -> str | None:
+    """Best-effort TITLE_ID for a PS3 disc/JB folder (verify/info readback)."""
+    keys = read_sfo_keys(os.path.join(path, "PS3_GAME", "PARAM.SFO"))
+    return keys.get("TITLE_ID") or None

--- a/app/services/ps3.py
+++ b/app/services/ps3.py
@@ -13,10 +13,8 @@ rather than advertised.
 from __future__ import annotations
 
 import os
-import struct
 
-_SFO_MAGIC = b"\x00PSF"
-_SFO_FMT_UTF8 = 0x0204
+from services.disc_id import parse_sfo_keys
 
 
 def is_ps3_iso_source(path: str) -> bool:
@@ -36,50 +34,13 @@ def is_ps3_iso_source(path: str) -> bool:
 
 
 def read_sfo_keys(path: str) -> dict[str, str]:
-    """Return the UTF-8 string keys of a PS3/PSP PARAM.SFO (PSF container).
-
-    A small, format-only reader (no platform assumptions), so PS3's
-    ``TITLE_ID`` key is read the same way the PSP path reads ``DISC_ID``.
-    """
+    """Read a PARAM.SFO file's UTF-8 string keys via the shared SFO parser."""
     try:
         with open(path, "rb") as handle:
             data = handle.read()
     except OSError:
         return {}
-    if len(data) < 20 or data[:4] != _SFO_MAGIC:
-        return {}
-    try:
-        key_table_off = struct.unpack_from("<I", data, 8)[0]
-        data_table_off = struct.unpack_from("<I", data, 12)[0]
-        num_entries = struct.unpack_from("<I", data, 16)[0]
-    except struct.error:
-        return {}
-
-    out: dict[str, str] = {}
-    for i in range(num_entries):
-        entry_off = 20 + i * 16
-        if entry_off + 16 > len(data):
-            break
-        key_off = struct.unpack_from("<H", data, entry_off)[0]
-        fmt = struct.unpack_from("<H", data, entry_off + 2)[0]
-        data_len = struct.unpack_from("<I", data, entry_off + 4)[0]
-        val_off = struct.unpack_from("<I", data, entry_off + 12)[0]
-
-        key_start = key_table_off + key_off
-        key_end = data.find(b"\x00", key_start)
-        if key_end < 0:
-            continue
-        key = data[key_start:key_end].decode("ascii", errors="replace")
-        if fmt != _SFO_FMT_UTF8:
-            continue
-        val_start = data_table_off + val_off
-        val_end = val_start + data_len
-        if val_end > len(data):
-            continue
-        out[key] = data[val_start:val_end].rstrip(b"\x00").decode(
-            "utf-8", errors="replace",
-        )
-    return out
+    return parse_sfo_keys(data)
 
 
 def ps3_title_id(path: str) -> str | None:

--- a/app/services/tools/__init__.py
+++ b/app/services/tools/__init__.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 from config import settings
 
 from .base import BaseTool, ToolPlugin
+from .chain import ChainTool
 from .chdman import ChdmanTool
 from .dolphin import DolphinTool
 from .maxcso import MaxcsoTool
 from .nsz import NszTool
 from .registry import ToolRegistry
 from .romz import RomzTool
-from .spec import ModeKind, ModeSpec
+from .spec import ChainSpec, ChainStep, InputKind, ModeKind, ModeSpec
 from .z3ds import Z3dsTool
 
 registry = ToolRegistry()
@@ -24,9 +25,15 @@ registry.register(Z3dsTool(settings.z3ds_compressor_path))
 registry.register(NszTool(settings.nsz_path))
 registry.register(MaxcsoTool(settings.maxcso_path))
 registry.register(RomzTool(settings.sevenzip_path))
+# Composite/pipeline modes register last: ChainTool drives the component tools
+# above through the registry, so they must already be present.
+registry.register(ChainTool(registry, chdman_path=settings.chdman_path))
 
 __all__ = [
     "BaseTool",
+    "ChainSpec",
+    "ChainStep",
+    "InputKind",
     "ModeKind",
     "ModeSpec",
     "ToolPlugin",

--- a/app/services/tools/base.py
+++ b/app/services/tools/base.py
@@ -71,6 +71,15 @@ class ToolPlugin(Protocol):
         input or no output is present (neither finished nor mid-conversion).
         """
 
+    def accepts_directory(self, path: str) -> bool:
+        """Whether this tool can take ``path`` (a directory) as its input unit.
+
+        The directory analogue of ``ext in input_extensions``. Default
+        ``False``; a tool with an ``InputKind.DIRECTORY`` mode (makeps3iso
+        folder->iso) overrides this to run its source-layout detector. May do
+        disk I/O — call it off the event loop.
+        """
+
     def verifies_path(self, path: str) -> bool:
         """Whether this tool's verify/info applies to a concrete file.
 
@@ -166,6 +175,10 @@ class BaseTool:
 
     def detect_output(self, input_path: str) -> OutputStatus | None:
         return None
+
+    def accepts_directory(self, path: str) -> bool:
+        # Default: file-only tool. Directory-input tools (makeps3iso) override.
+        return False
 
     def verifies_path(self, path: str) -> bool:
         # Default: a plain extension match. Tools that over-claim a container

--- a/app/services/tools/chain.py
+++ b/app/services/tools/chain.py
@@ -1,0 +1,270 @@
+"""ChainTool: a synthetic tool that runs an ordered pipeline of existing modes.
+
+The chaining seam sits **above** the per-tool plugin contract rather than
+rewriting it: ``ChainTool`` owns composite ``ChainSpec`` modes and orchestrates
+them by calling the existing tools' ``convert`` through the registry. Its first
+user is ``cso_to_chd`` (maxcso ``cso_decompress`` -> chdman ``createdvd``), which
+needs no new binary.
+
+Responsibilities unique to a chain:
+
+* the intermediate (``.iso``) lives in a private temp work dir, cleaned up
+  whichever way the job ends;
+* a disk-headroom preflight, because a chain holds source + full intermediate +
+  partial final at once (see ``services.disk``);
+* weighted progress aggregation into one 0-100 bar (chd compression dominates
+  cso decompression, so an even split misreports);
+* the final verify and disc-ID tagging delegate to the last step's tool
+  (chdman), so a ``cso_to_chd`` CHD is verified and tagged exactly like a direct
+  ``createdvd``.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import tempfile
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from fastapi.concurrency import run_in_threadpool
+
+from config import settings
+from logging_setup import get_logger
+from models import OutputStatus
+from services.disc_id import embed_in_chd, extract_from_source
+from services.disk import ensure_headroom
+from services.lock_manager import lock_manager
+
+from .base import BaseTool
+from .spec import ChainSpec, ChainStep, ModeKind
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+    from .registry import ToolRegistry
+
+logger = get_logger()
+
+# cso/zso/dax -> .iso (maxcso, lossless) -> .chd (chdman createdvd).
+# createdvd is pinned: a cso/zso/dax is an ISO/data-only image with no CD audio
+# tracks to preserve, so the createcd (cue/gdi multitrack) path never applies.
+CSO_TO_CHD = ChainSpec(
+    mode="cso_to_chd",
+    tool_id="chain",
+    kind=ModeKind.CREATE,
+    label="CSO/ZSO/DAX → CHD",
+    group="chain",
+    output_ext=".chd",
+    input_extensions=frozenset({".cso", ".zso", ".dax"}),
+    steps=(
+        # weights reflect that chd compression is far slower than cso decompress.
+        ChainStep(tool_id="cso", mode="cso_decompress", weight=0.20, output_ratio=2.0),
+        ChainStep(tool_id="chdman", mode="createdvd", weight=0.80, output_ratio=1.2),
+    ),
+    intermediate_exts=(".iso",),
+    verify_step=1,
+    # No compression knob for now: the CSO tool's UI offers maxcso effort
+    # presets, which are meaningless to the chdman step that compresses the
+    # .chd. The final CHD uses chdman's default codecs. Exposing chdman codecs
+    # for the chain is deferred to the UI-placement decision.
+    supports_compression=False,
+    supports_delete_on_verify=True,
+    allows_archive_input=True,
+)
+
+
+class ChainTool(BaseTool):
+    id = "chain"
+    display_name = "Pipeline"
+    modes = (CSO_TO_CHD,)
+    # The chain's outputs/verify are owned by the final step's tool (chdman
+    # already claims .chd), so the chain claims neither set — it must not
+    # double-register .chd in verify_extensions / output_extensions.
+    output_extensions = frozenset()
+    verify_extensions = frozenset()
+
+    def __init__(self, registry: "ToolRegistry", *, chdman_path: str) -> None:
+        # No binary of its own; it drives the component tools via the registry.
+        self.binary_path = ""
+        self._registry = registry
+        self._chdman_path = chdman_path
+
+    # ------------------------------------------------------------------ paths
+    def output_path(
+        self,
+        mode: str,
+        input_path: str,
+        output_dir: str | None = None,
+        *,
+        treat_as_stem: bool = False,
+    ) -> str:
+        final = self.spec(mode).steps[-1]
+        return self._registry.for_mode(final.mode).output_path(
+            final.mode, input_path, output_dir, treat_as_stem=treat_as_stem,
+        )
+
+    def detect_output(self, input_path: str) -> OutputStatus | None:
+        source = Path(input_path)
+        if source.suffix.lower() not in self.input_extensions:
+            return None
+        candidate = str(source.with_suffix(".chd"))
+        file_exists, is_locked = lock_manager.check_file_status(candidate)
+        if not (file_exists or is_locked):
+            return None
+        return OutputStatus(
+            tool_id=self.id,
+            exists=file_exists,
+            ready=file_exists and not is_locked,
+            path=candidate,
+        )
+
+    # --------------------------------------------------------------- convert
+    def convert(
+        self,
+        input_path: str,
+        output_path: str,
+        mode: str,
+        *,
+        compression: str | None = None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncGenerator[dict, None]:
+        return self._run(
+            input_path, output_path, mode,
+            compression=compression, cancel_event=cancel_event,
+        )
+
+    async def _run(
+        self,
+        input_path: str,
+        output_path: str,
+        mode: str,
+        *,
+        compression: str | None,
+        cancel_event: asyncio.Event | None,
+    ) -> AsyncGenerator[dict, None]:
+        spec = self.spec(mode)
+        work_dir = tempfile.mkdtemp(prefix="cmptr-chain-")
+        try:
+            self._preflight_headroom(input_path, output_path, spec, work_dir)
+
+            total_weight = sum(s.weight for s in spec.steps) or 1.0
+            weights = [s.weight / total_weight for s in spec.steps]
+            n = len(spec.steps)
+            stem = Path(input_path).stem
+            current_in = input_path
+            cumulative = 0.0
+            intermediate_source = input_path  # what feeds the final (for tagging)
+
+            for i, step in enumerate(spec.steps):
+                tool = self._registry.for_mode(step.mode)
+                if i == n - 1:
+                    step_out = output_path
+                else:
+                    ext = (
+                        spec.intermediate_exts[i]
+                        if i < len(spec.intermediate_exts)
+                        else ".tmp"
+                    )
+                    step_out = os.path.join(work_dir, f"{stem}{ext}")
+                    intermediate_source = step_out
+                # Compression only matters to a step that supports it (the
+                # chdman create step); cso_decompress takes none.
+                step_compression = (
+                    compression
+                    if self._registry.spec(step.mode).supports_compression
+                    else None
+                )
+
+                base = cumulative * 100.0
+                span = weights[i] * 100.0
+                last_message = ""
+                async for update in tool.convert(
+                    current_in, step_out, step.mode,
+                    compression=step_compression, cancel_event=cancel_event,
+                ):
+                    last_message = update.get("message") or last_message
+                    raw = update.get("progress") or 0
+                    aggregate = int(round(base + span * (raw / 100.0)))
+                    yield {
+                        "progress": min(max(aggregate, 0), 100),
+                        "message": f"[{i + 1}/{n}] {last_message}",
+                    }
+                cumulative += weights[i]
+                current_in = step_out
+
+            # Carry disc-ID GAME/NAME tags onto the final CHD, the same as a
+            # direct createdvd job (job_manager only tags literal create modes).
+            await self._embed_disc_id(intermediate_source, output_path)
+            yield {"progress": 100, "message": "Conversion complete"}
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    def _preflight_headroom(
+        self, input_path: str, output_path: str, spec: ChainSpec, work_dir: str,
+    ) -> None:
+        try:
+            input_size = os.path.getsize(input_path)
+        except OSError:
+            return  # can't size the input; skip rather than block the job
+        if input_size <= 0:
+            return
+        n = len(spec.steps)
+        intermediate_bytes = int(
+            input_size * sum(s.output_ratio for s in spec.steps[: n - 1])
+        )
+        final_bytes = int(input_size * spec.steps[-1].output_ratio)
+        margin = int(getattr(settings, "chain_disk_margin_mb", 512)) * 1024 * 1024
+        targets: list[tuple[str, int]] = [(output_path, final_bytes)]
+        if intermediate_bytes > 0:
+            targets.append((work_dir, intermediate_bytes))
+        ensure_headroom(targets, margin_bytes=margin)
+
+    async def _embed_disc_id(self, source_path: str, output_path: str) -> None:
+        if Path(output_path).suffix.lower() != ".chd":
+            return
+        try:
+            disc_info = await run_in_threadpool(extract_from_source, source_path)
+            if disc_info and disc_info.get("game_id"):
+                game_id = disc_info["game_id"]
+                title = disc_info.get("title") or game_id
+                embedded = await embed_in_chd(
+                    output_path, game_id, title, self._chdman_path,
+                )
+                if embedded:
+                    logger.info(
+                        "Chain embedded disc ID %r in %s",
+                        game_id, Path(output_path).name,
+                    )
+        except Exception as exc:  # best effort; tagging never fails the job
+            logger.debug("Chain disc ID embed skipped: %s", exc)
+
+    # ------------------------------------------------------ verify / info
+    def _final_tool(self):
+        spec = self.modes[0]
+        step = spec.steps[spec.verify_step]
+        return self._registry.get(step.tool_id)
+
+    async def verify(self, path: str) -> dict:
+        return await self._final_tool().verify(path)
+
+    def verify_stream(self, path: str) -> AsyncGenerator[dict, None]:
+        return self._final_tool().verify_stream(path)
+
+    async def info(self, path: str) -> dict:
+        return await self._final_tool().info(path)
+
+    def info_model(self, raw: dict, path: str) -> "BaseModel":
+        return self._final_tool().info_model(raw, path)
+
+    def active_pids(self) -> list[int]:
+        seen: set[int] = set()
+        pids: list[int] = []
+        tool_ids = {step.tool_id for m in self.modes for step in m.steps}
+        for tool_id in tool_ids:
+            for pid in self._registry.get(tool_id).active_pids():
+                if pid not in seen:
+                    seen.add(pid)
+                    pids.append(pid)
+        return pids

--- a/app/services/tools/chain.py
+++ b/app/services/tools/chain.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import asyncio
 import os
 import shutil
-import tempfile
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -34,8 +33,9 @@ from config import settings
 from logging_setup import get_logger
 from models import OutputStatus
 from services.disc_id import embed_in_chd, extract_from_source
-from services.disk import ensure_headroom
+from services.disk import create_scratch_dir, ensure_headroom
 from services.lock_manager import lock_manager
+from services.maxcso import uncompressed_iso_size
 
 from .base import BaseTool
 from .spec import ChainSpec, ChainStep, ModeKind
@@ -145,7 +145,7 @@ class ChainTool(BaseTool):
         cancel_event: asyncio.Event | None,
     ) -> AsyncGenerator[dict, None]:
         spec = self.spec(mode)
-        work_dir = tempfile.mkdtemp(prefix="cmptr-chain-")
+        work_dir = create_scratch_dir("cmptr-chain-")
         try:
             self._preflight_headroom(input_path, output_path, spec, work_dir)
 
@@ -169,11 +169,15 @@ class ChainTool(BaseTool):
                     )
                     step_out = os.path.join(work_dir, f"{stem}{ext}")
                     intermediate_source = step_out
-                # Compression only matters to a step that supports it (the
-                # chdman create step); cso_decompress takes none.
+                # Only forward compression when the chain itself advertises it
+                # AND the sub-step supports it. cso_to_chd advertises no
+                # compression (the CSO UI's effort presets are meaningless to
+                # chdman), so a stale preset from an API/batch client is dropped
+                # rather than smuggled in as a chdman codec.
                 step_compression = (
                     compression
-                    if self._registry.spec(step.mode).supports_compression
+                    if spec.supports_compression
+                    and self._registry.spec(step.mode).supports_compression
                     else None
                 )
 
@@ -210,11 +214,21 @@ class ChainTool(BaseTool):
             return  # can't size the input; skip rather than block the job
         if input_size <= 0:
             return
-        n = len(spec.steps)
-        intermediate_bytes = int(
-            input_size * sum(s.output_ratio for s in spec.steps[: n - 1])
-        )
-        final_bytes = int(input_size * spec.steps[-1].output_ratio)
+        # Prefer the true uncompressed ISO size from the container header: a
+        # highly compressed .cso/.zso/.dax can be a small fraction of the ISO
+        # maxcso will write, so a ratio on the compressed size badly under-counts
+        # the intermediate. The final .chd is at most the ISO size (chdman
+        # compresses), so the uncompressed size is a safe bound for both.
+        uncompressed = uncompressed_iso_size(input_path)
+        if uncompressed and uncompressed > 0:
+            intermediate_bytes = uncompressed
+            final_bytes = uncompressed
+        else:
+            n = len(spec.steps)
+            intermediate_bytes = int(
+                input_size * sum(s.output_ratio for s in spec.steps[: n - 1])
+            )
+            final_bytes = int(input_size * spec.steps[-1].output_ratio)
         margin = int(getattr(settings, "chain_disk_margin_mb", 512)) * 1024 * 1024
         targets: list[tuple[str, int]] = [(output_path, final_bytes)]
         if intermediate_bytes > 0:

--- a/app/services/tools/chain.py
+++ b/app/services/tools/chain.py
@@ -87,7 +87,7 @@ class ChainTool(BaseTool):
 
     def __init__(self, registry: "ToolRegistry", *, chdman_path: str) -> None:
         # No binary of its own; it drives the component tools via the registry.
-        self.binary_path = ""
+        super().__init__("")
         self._registry = registry
         self._chdman_path = chdman_path
 

--- a/app/services/tools/registry.py
+++ b/app/services/tools/registry.py
@@ -102,6 +102,15 @@ class ToolRegistry:
         ext = Path(filename).suffix.lower()
         return [t for t in self._tools.values() if ext in t.input_extensions]
 
+    def tools_for_directory(self, path: str) -> list[ToolPlugin]:
+        """Tools that accept ``path`` (a directory) as their input unit.
+
+        The directory analogue of :meth:`tools_for_input`. Each tool decides
+        via ``accepts_directory`` (default ``False``), which runs the tool's
+        source-layout detector. May do disk I/O — call off the event loop.
+        """
+        return [t for t in self._tools.values() if t.accepts_directory(path)]
+
     def tool_for_verify(self, path: str) -> ToolPlugin | None:
         ext = Path(path).suffix.lower()
         return next(

--- a/app/services/tools/spec.py
+++ b/app/services/tools/spec.py
@@ -6,7 +6,7 @@ equals a ``ConversionMode`` value (the validated wire type in ``models.py``).
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 
@@ -15,6 +15,20 @@ class ModeKind(str, Enum):
     EXTRACT = "extract"    # compressed container -> source
     COPY = "copy"          # recompress in place
     COMPRESS = "compress"  # generic one-shot compressor (z3ds-style)
+
+
+class InputKind(str, Enum):
+    """The unit of work a mode consumes.
+
+    Everything in the codebase historically keyed input off
+    ``Path(filename).suffix``, which assumes a file. A directory has no
+    suffix, so a mode that packages a folder (makeps3iso folder->iso) declares
+    ``DIRECTORY`` and relies on a detector predicate
+    (``ToolPlugin.accepts_directory``) instead of an extension match.
+    """
+
+    FILE = "file"
+    DIRECTORY = "directory"
 
 
 @dataclass(frozen=True)
@@ -30,3 +44,47 @@ class ModeSpec:
     supports_compression_level: bool = False  # dolphin rvz/wia only
     supports_delete_on_verify: bool = False
     allows_archive_input: bool = False         # chdman create modes only
+    # Default keeps every existing mode FILE-based (zero behavior change). A
+    # directory mode (folder->iso) overrides to {InputKind.DIRECTORY}.
+    input_kinds: frozenset[InputKind] = frozenset({InputKind.FILE})
+
+
+@dataclass(frozen=True)
+class ChainStep:
+    """One step of a :class:`ChainSpec`: a sub-mode run by an existing tool."""
+
+    tool_id: str          # owner of this step's mode ("cso", "chdman")
+    mode: str             # the sub-mode wire value ("cso_decompress", "createdvd")
+    weight: float         # progress weight; normalized across steps at runtime
+    output_ratio: float   # est. (this step's output size) / (chain input size)
+
+
+@dataclass(frozen=True)
+class ChainSpec:
+    """A composite mode that runs an ordered pipeline of existing modes.
+
+    Structurally a superset of :class:`ModeSpec`, so every registry / route /
+    job_manager consumer that reads a spec's fields (``mode``, ``tool_id``,
+    ``kind``, ``output_ext``, ``input_extensions``, ``supports_*``,
+    ``allows_archive_input``, ``input_kinds``) works unchanged. The chain
+    extras (``steps``, ``intermediate_exts``, ``verify_step``) are only read by
+    the synthetic ``ChainTool`` that orchestrates the pipeline.
+    """
+
+    mode: str                       # composite wire value, e.g. "cso_to_chd"
+    tool_id: str                    # synthetic owner ("chain")
+    kind: ModeKind
+    label: str
+    group: str
+    output_ext: str | None          # final output extension (".chd")
+    input_extensions: frozenset[str]  # == step 1's accepted inputs
+    steps: tuple[ChainStep, ...]    # ordered: first owns input, last owns output
+    intermediate_exts: tuple[str, ...] = ()   # one per non-final step (".iso",)
+    verify_step: int = -1           # index of the step whose tool verifies the final output
+    supports_compression: bool = False
+    supports_compression_level: bool = False
+    supports_delete_on_verify: bool = True   # of the ORIGINAL source, gated on final verify
+    allows_archive_input: bool = True        # == step 1's
+    input_kinds: frozenset[InputKind] = field(
+        default_factory=lambda: frozenset({InputKind.FILE})
+    )

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -389,6 +389,54 @@ page/sort/filter changes), and the endpoint additionally caps each batch at
 `MAX_ARCHIVE_SUMMARY_PATHS`. The summary batch and the romz gate share the
 reader's cache, so hydrating a folder opens each archive at most once.
 
+### 3.3.3 Cross-tool chaining (`ChainSpec` / `ChainTool`, `services/disk.py`)
+
+Some conversions are a pipeline of existing single-tool modes (issue #98:
+`cso_to_chd` = maxcso `cso_decompress` → chdman `createdvd`). The chaining seam
+sits **above** the plugin contract rather than rewriting it.
+
+- **`ChainStep` / `ChainSpec` (`services/tools/spec.py`)** — a `ChainSpec` is a
+  structural superset of `ModeSpec` (same `mode`/`tool_id`/`kind`/`output_ext`/
+  `input_extensions`/`supports_*`/`allows_archive_input` fields every registry
+  consumer reads), plus `steps` (ordered `ChainStep(tool_id, mode, weight,
+  output_ratio)`), `intermediate_exts`, and `verify_step`. Because it quacks
+  like a `ModeSpec`, `registry.spec(mode)` / `mode_specs()` / `convertible_extensions()`
+  need no changes.
+- **`ChainTool(BaseTool)` (`services/tools/chain.py`)** — a synthetic tool
+  (`id="chain"`) registered **after** its component tools and handed the
+  `registry`. Its `convert` orchestrates the steps via
+  `registry.for_mode(step.mode).convert(...)`, writing intermediates into a
+  private temp dir (cleaned in `finally`), aggregating each step's 0–100 into a
+  **normalized-weight** slice of one bar, and routing `compression` only to a
+  step whose sub-mode supports it. `verify`/`info`/`output_path` delegate to the
+  `verify_step` (final) tool, so `job_manager`'s existing verify gate and
+  delete-on-verify drive the chain with no special-casing — the original source
+  is deleted only after the **final** output verifies. The chain claims no
+  `verify_extensions`/`output_extensions` of its own (the final tool already
+  owns them). Disc-ID tagging that `job_manager` only runs for literal
+  `createcd`/`createdvd` is re-applied by the chain for its final step.
+- **`services/disk.ensure_headroom`** — the shared free-space preflight a chain
+  runs before step 1 (a chain holds source + full intermediate + partial final
+  at once, which the single-step model never did). It is multi-volume aware:
+  requirements are grouped by mount (`st_dev` of the nearest existing ancestor,
+  since the output dir may not exist yet) and each mount is checked once, summing
+  co-located targets. Cushion is `COMPRESSATORIUM_CHAIN_DISK_MARGIN_MB`.
+
+New chained conversions (xci→nsp, wud→wua, a future folder→iso→chd) are a new
+`ChainSpec` row + its component modes — no new machinery.
+
+### 3.3.4 Directory inputs (`InputKind`, `accepts_directory`)
+
+Every input seam keys off `Path(filename).suffix`; a folder has none. For
+directory-unit conversions (issue #98 Phase 2, makeps3iso folder→iso) the seam
+is an `InputKind` enum + `ModeSpec.input_kinds` (default `{FILE}`, zero behavior
+change), a `ToolPlugin.accepts_directory(path)` predicate (default `False`; the
+directory analogue of `ext in input_extensions`), and
+`registry.tools_for_directory(path)`. The per-source-type detector for PS3 lives
+in `services/ps3.py` (requires the `PS3_GAME/` disc/JB layout). Scaffolding only
+so far — the makeps3iso tool, listing annotation, job-model `input_kind`, and UI
+selection are not wired yet.
+
 ### 3.4 `registry.py`
 
 ```python

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,43 @@
 # Release Notes
 
+## Unreleased
+
+### CSO → CHD in one step (issue #98, Phase 1)
+
+#### New
+
+- **Convert a `.cso`/`.zso`/`.dax` straight to `.chd`.** A new
+  **Convert to CHD** mode on the CSO tool runs the full PSP/PS2 pipeline —
+  maxcso decompresses the compressed image to a temporary `.iso`, then chdman
+  packages that to a `.chd` (PPSSPP / PCSX2 / RetroArch read the result). The
+  intermediate `.iso` lives in a private temp dir and is cleaned up
+  automatically; only the source and the final `.chd` remain. Delete-on-verify
+  works end-to-end: the original `.cso` is removed only after the final `.chd`
+  passes chdman verification. Disc-ID `GAME`/`NAME` tags are embedded into the
+  CHD just like a direct Create DVD. The final CHD uses chdman's default
+  compression (no codec picker yet for the chain).
+
+#### Internal
+
+- A general **cross-tool chaining seam** sits above the existing plugin
+  registry: a `ChainSpec` (ordered `(tool_id, mode)` steps + declared
+  intermediates + which step owns the final verify) and a synthetic `ChainTool`
+  that orchestrates the component tools through the registry. Every existing
+  registry consumer (convert route, job_manager, files route) works unchanged —
+  `registry.for_mode("cso_to_chd")` resolves to the chain, verify/delete-on-verify
+  delegate to the final step's tool. Progress is aggregated into one bar with
+  normalized per-step weights (chd compression dominates cso decompression). A
+  new shared `services.disk.ensure_headroom` preflights free space on the
+  work-dir and output-dir volumes independently (a chain holds source +
+  intermediate + partial final at once). Tests: `tests/test_chain_service.py`,
+  `tests/test_disk_headroom.py`, plus chain coverage in `tests/test_tool_registry.py`.
+- **Directory-input scaffolding** for the upcoming PS3 folder→iso work (issue
+  #98, Phase 2): an `InputKind` enum + `ModeSpec.input_kinds`, a
+  `ToolPlugin.accepts_directory` seam with `registry.tools_for_directory`, and a
+  PS3 disc/JB-folder detector (`services.ps3`) that requires the `PS3_GAME/`
+  layout and rejects bare installed-game folders. No makeps3iso binary, UI, or
+  job plumbing yet. Tests: `tests/test_ps3_detector.py`.
+
 ## 4.1.0 (2026-06-04)
 
 This is the stable 4.1.0 release. It supersedes the `4.1.0-beta-1` through

--- a/docs/issue-98-plan.md
+++ b/docs/issue-98-plan.md
@@ -135,23 +135,35 @@ Q7 on whether to allow a user override.)
      than necessary).
 - **Headroom math.** Peak simultaneous disk = `source(cso) + full(iso) +
   partial(chd)`, which the single-step model never holds. Introduce a shared
-  **`app/services/disk.py`** helper, `ensure_headroom(work_dir, required_bytes,
+  **`app/services/disk.py`** helper, `ensure_headroom(path, required_bytes,
   margin)`, built on `shutil.disk_usage`. Required bytes are derived from the
   `ChainStep.output_ratio` values: `required ≈ input_size * (Σ output_ratio) +
   margin` (for cso→chd: `input * (2.0 + 1.2) + margin`). `ChainTool.convert`
   calls it **before step 1**, raising a clear "insufficient disk space" error
-  that surfaces as a normal job failure. This is a **new shared seam** (no disk
-  check exists today); single-step tools can opt into it later. (Open Q2: hard
-  fail vs warn; margin/setting name.)
+  that surfaces as a normal job failure.
+  - **Multi-volume correctness.** Compressatorium is explicitly multi-volume,
+    so the **work dir (intermediates) and the final output dir can be on
+    different filesystems**. `shutil.disk_usage` is per-mount, so the check must
+    run **independently on each target**: the work-dir mount must hold the
+    intermediate(s) (`input * intermediate_ratio`), and the output-dir mount
+    must hold the final (`input * output_ratio`). When both resolve to the same
+    mount (`os.stat(...).st_dev` match), sum the two requirements instead of
+    checking them separately so the shared filesystem isn't double-spent. The
+    `chain.py` precheck calls `ensure_headroom` once per distinct mount.
+  - This is a **new shared seam** (no disk check exists today); single-step
+    tools can opt into it later. (Open Q2: hard fail vs warn; margin/setting
+    name.)
 
 ### 1.4 Progress aggregation (weighted, single bar)
 
 chd compression dominates cso decompression, so a 50/50 split misreports. The
-weights live on `ChainStep` (cso `0.20`, chd `0.80`). Inside
-`ChainTool.convert`, each sub-step's 0–100 maps into its slice:
+weights live on `ChainStep` (cso `0.20`, chd `0.80`). To stay robust if a future
+chain's weights don't pre-sum to `1.0`, `ChainTool` **normalizes the weights by
+their total** (`w_i = weight_i / Σ weight`) once at construction, then each
+sub-step's 0–100 maps into its normalized slice:
 
 ```
-aggregate = round( (Σ weight_j for j<i)*100 + weight_i * step_progress_i )
+aggregate = round( (Σ w_j for j<i)*100 + w_i * step_progress_i )   # w = normalized weights
 ```
 
 The aggregate is **monotonic non-decreasing** and ends at 100 when the last step
@@ -291,7 +303,10 @@ suffix, so add a small **`InputKind`** seam rather than faking an extension:
   the folder **basename**: `<parent>/<folder_name>.iso`. `MakePs3IsoTool.detect_output`
   reports it (in-progress vs ready via `lock_manager.check_file_status`).
 - **Output-path derivation.** `output_path` = `output_dir/<folder_basename>.iso`
-  (folder name, not a stem swap).
+  (folder name, not a stem swap). **Normalize first** — derive the basename from
+  `Path(path).name` (or `os.path.basename(os.path.normpath(path))`), because a
+  trailing slash makes `os.path.basename("/a/MyGame/")` return `""` and would
+  otherwise yield an invalid `.../MyGame/.iso`.
 - **Verify gate.** makeps3iso has **no native verify**. Recommended: ship
   **no-verify, `supports_delete_on_verify=False`** — deleting a user-curated
   decrypted folder is destructive and there is no cheap trustworthy verify.
@@ -299,10 +314,19 @@ suffix, so add a small **`InputKind`** seam rather than faking an extension:
   the **built iso** and confirm its `TITLE_ID` matches the source folder — a
   light readback, not a full round-trip via `extractps3iso`. (Open Q4.)
 - **Lock manager.** Locks key on `sha256(normpath(path))`, so a **directory
-  path locks fine as-is**. Caveat: a per-file job *inside* the folder hashes to a
-  different key and wouldn't be blocked by the folder lock. For folder→iso this
-  is acceptable (we only read the folder, and we don't offer per-file conversion
-  of PS3 folder contents). Flag as a known limitation (Open Q — acceptable).
+  path locks fine as-is** for exact-path collisions. But the bare hash gives no
+  **containment** protection: a per-file job (or a rename/delete route) acting on
+  a path *inside* an active directory job — e.g. `<folder>/PS3_GAME/PARAM.SFO`
+  while `<folder>` is being packed — hashes to a different key and slips through,
+  which can corrupt the in-flight `.iso`. **Recommendation:** extend the active
+  lookup (`find_active_job_for_path` / `_assert_path_not_in_use` in
+  `job_manager.py`) with a **descendant check** — beyond the existing
+  `cand == target` and "active-dir contains target" cases, also reject when
+  `target` is a descendant of an active **directory** job's path
+  (`target.relative_to(cand_path)` succeeds, guarded by `try/except ValueError`).
+  This makes a directory job protect its whole subtree against concurrent
+  mutation, in both directions. (The containment check is cheap — string/`Path`
+  prefix, no extra disk I/O.)
 - **Job model.** Add `input_kind: str = "file"` to `ConversionJob` (and the
   enqueue path); `file_path` holds the directory path, `output_path` the iso.
   `_process_job` and the verify gate read `input_kind` to skip the file-only

--- a/docs/issue-98-plan.md
+++ b/docs/issue-98-plan.md
@@ -1,0 +1,393 @@
+# Issue #98 — Plan: cso→chd chaining seam, and PS3 folder→iso
+
+**Status:** Research / design proposal · **Scope:** two of the #98 conversions ·
+**Companions:** `docs/DESIGN_tool_plugin_architecture.md`,
+`docs/ADDING_PLATFORMS_AND_TOOLS.md`
+
+This is a plan, not an implementation. It introduces two **independent** seams
+above the existing plugin/registry contract (tools shell out to a CLI and yield
+`{progress, message}`; the seam sits above that and does not rewrite it):
+
+- **Phase 1 — cross-tool chaining** (`ChainSpec` + a synthetic `ChainTool`),
+  with **cso→chd** as its first user. No new binary.
+- **Phase 2 — directory-as-input** (an `InputKind` seam + a PS3-folder
+  detector) with **makeps3iso** as its first user. New binary.
+
+The two phases are orthogonal. A future *folder→iso→chd* would compose Phase 2's
+directory input as step 1 of a Phase 1 chain, but neither phase depends on the
+other today, and **nothing here is architected toward RPCS3 CHD** (issue
+RPCS3 #17997 is an open feature request, opened Jan 2026, not shipped).
+
+## 0. What HEAD already gives us (verified, not assumed)
+
+| Fact | Location |
+|------|----------|
+| `cso_decompress` mode: `.cso/.zso/.dax` → `.iso`, `kind=EXTRACT`, `supports_delete_on_verify=False`, `allows_archive_input=True` | `app/services/tools/maxcso.py` (`MaxcsoTool`, `tool_id="cso"`) |
+| chdman `createcd`/`createdvd` accept `.iso` (`CHDMAN_CONVERTIBLE_EXTENSIONS = {.gdi,.iso,.cue,.bin}`), emit `.chd`, `kind=CREATE`, `supports_delete_on_verify=True`; createdvd injects `-hs 2048` | `app/services/chdman.py`, `app/services/tools/chdman.py` |
+| Mode selection createcd vs createdvd is **user-chosen**, no auto-detect | `app/services/tools/chdman.py` |
+| `ModeSpec` fields: `mode, tool_id, kind, label, group, output_ext, input_extensions, supports_compression, supports_compression_level, supports_delete_on_verify, allows_archive_input` | `app/services/tools/spec.py` |
+| Registry: `for_mode`, `spec`, `mode_specs`, `tools_for_input`, `tool_for_verify`, `*_extensions`, `tools_accepting_archive_member` | `app/services/tools/registry.py` |
+| `convert(input_path, output_path, mode, *, compression=None, cancel_event=None)` is the plugin contract; **no work-dir param** | `app/services/tools/base.py`, `runner.py` |
+| `_process_job`: archive-extract → `registry.for_mode(mode).convert(...)` → progress mapped 1:1 → single verify gate → delete-on-verify only on success | `app/services/job_manager.py` |
+| `ConversionJob`: one `file_path`, `mode`, `output_path`, `temp_dir`; **no input-kind** | `app/models.py` |
+| `plan_job` validates `os.path.isfile(file_path)` (or archive `::` member); a directory is rejected as `FILE_NOT_FOUND` | `app/routes/convert.py` |
+| **No disk-space / headroom check anywhere** (no `shutil.disk_usage`/`statvfs`) | repo-wide |
+| **No multi-step progress weighting** — `job.progress` is one 0–100 stream | `app/services/job_manager.py` |
+| Lock manager keys on `sha256(os.path.normpath(path))` — works for a directory path | `app/services/lock_manager.py` |
+| Directory rows in listings carry only `name/path/type="directory"`; everything else is `Path(suffix)`-driven | `app/routes/files.py` (`scan_directory`, `_detect_file_outputs`) |
+| PSF/SFO container parser already exists (PSP `PARAM.SFO`) — reusable for PS3 `PARAM.SFO` | `app/services/disc_id.py` (`_parse_sfo`, `_SFO_MAGIC`) |
+| `SubprocessRunner.run(cmd, *, input_path, output_path, parse_progress, cancel_event, cwd, ...)` is the shared shell-out seam | `app/services/subprocess_runner.py` |
+
+---
+
+## Phase 1 — the cross-tool chaining seam (cso→chd as first user)
+
+### 1.1 How a composite mode is represented — `ChainSpec`
+
+Add two frozen dataclasses to `app/services/tools/spec.py`, alongside `ModeSpec`:
+
+```python
+@dataclass(frozen=True)
+class ChainStep:
+    tool_id: str          # owner of this step's mode (e.g. "cso", "chdman")
+    mode: str             # the sub-mode wire value ("cso_decompress", "createdvd")
+    weight: float         # progress weight; normalized across steps
+    output_ratio: float   # est. (this step's output size) / (chain input size)
+
+@dataclass(frozen=True)
+class ChainSpec:
+    mode: str                            # composite wire mode, e.g. "cso_to_chd"
+    tool_id: str                         # synthetic owner: "chain"
+    kind: ModeKind                       # CREATE
+    label: str
+    group: str
+    steps: tuple[ChainStep, ...]         # ordered; first owns input, last owns output
+    input_extensions: frozenset[str]     # == step 1's inputs (.cso/.zso/.dax)
+    intermediate_exts: tuple[str, ...]   # (".iso",)
+    output_ext: str                      # ".chd"  (final)
+    verify_step: int = -1                # index whose tool owns the final verify
+    supports_delete_on_verify: bool = True   # of the ORIGINAL source, gated on final verify
+    allows_archive_input: bool = True        # == step 1's
+    supports_compression: bool = False
+    supports_compression_level: bool = False
+```
+
+**Coexistence with `ModeSpec` in the registry.** `ChainSpec` is made
+**structurally compatible** with the fields registry consumers read off a spec
+(`mode`, `tool_id`, `kind`, `output_ext`, `input_extensions`,
+`supports_delete_on_verify`, `supports_compression`, `allows_archive_input`).
+A new **`ChainTool(BaseTool)`** (`app/services/tools/chain.py`) owns the chain
+modes the same way `MaxcsoTool` owns its modes: `ChainTool.modes` is a tuple of
+`ChainSpec`. Registration in `app/services/tools/__init__.py` happens **after**
+the component tools, and `ChainTool` is handed a reference to the `registry` so
+it can resolve and drive sub-tools. Result: `registry.for_mode("cso_to_chd")`
+returns the `ChainTool`, `registry.spec("cso_to_chd")` returns the `ChainSpec`,
+and every existing registry-driven consumer (convert route, job_manager, files
+route) keeps working with **no chain-specific branching**. The seam is the new
+tool; the consumers are untouched.
+
+### 1.2 The concrete `cso_to_chd` ChainSpec
+
+```python
+ChainSpec(
+    mode="cso_to_chd",
+    tool_id="chain",
+    kind=ModeKind.CREATE,
+    label="CSO/ZSO/DAX → CHD",
+    group="chain",                       # or surfaced under the CSO tool — see open Q1
+    steps=(
+        ChainStep("cso", "cso_decompress", weight=0.20, output_ratio=2.0),
+        ChainStep("chdman", "createdvd",   weight=0.80, output_ratio=1.2),
+    ),
+    input_extensions=frozenset({".cso", ".zso", ".dax"}),
+    intermediate_exts=(".iso",),
+    output_ext=".chd",
+    verify_step=1,                       # chdman verifies the final .chd
+    supports_delete_on_verify=True,
+    allows_archive_input=True,
+)
+```
+
+**Why createdvd is pinned (step 2).** A `.cso`/`.zso`/`.dax` is an ISO/data-only
+image — there are **no CD audio tracks to preserve**, so the createcd path
+(cue/gdi multitrack + audio) is never the right target. `createdvd` produces a
+DVD-type CHD with the existing `-hs 2048` sector size (already the PSP-UMD/PS2-DVD
+compatibility default in `chdman.py`), which PPSSPP, PCSX2, and RetroArch read.
+This holds **regardless of CD-vs-DVD-sized payload**: createdvd handles a bare
+single-track data image of any size, so size does not change the mode. (See open
+Q7 on whether to allow a user override.)
+
+### 1.3 Intermediate lifecycle + disk headroom
+
+- **Where the intermediate lives.** `ChainTool.convert` writes the `.iso` into a
+  per-job **work dir**. Today `job.temp_dir` is created **only for archive
+  input**; a chain on a plain `.cso` has no temp dir. Two coordinated changes:
+  1. Add an optional **`work_dir`** kwarg to the `convert(...)` contract
+     (`base.py` / `ToolPlugin` Protocol / `runner` passthrough). Default `None`
+     → tool falls back to its own `tempfile.mkdtemp`. This is additive; existing
+     single-step tools ignore it.
+  2. In `job_manager._process_job`, ensure a work dir exists for chain modes
+     (reuse `job.temp_dir` when archive extraction already made one, else create
+     one) and pass it to `convert(..., work_dir=...)`. The existing
+     `_cleanup_temp_dir(job)` already removes it on success/failure/cancel; the
+     intermediate `.iso` is cleaned with it. `ChainTool.convert` also deletes
+     the intermediate as soon as step 2 finishes (don't hold iso + chd longer
+     than necessary).
+- **Headroom math.** Peak simultaneous disk = `source(cso) + full(iso) +
+  partial(chd)`, which the single-step model never holds. Introduce a shared
+  **`app/services/disk.py`** helper, `ensure_headroom(work_dir, required_bytes,
+  margin)`, built on `shutil.disk_usage`. Required bytes are derived from the
+  `ChainStep.output_ratio` values: `required ≈ input_size * (Σ output_ratio) +
+  margin` (for cso→chd: `input * (2.0 + 1.2) + margin`). `ChainTool.convert`
+  calls it **before step 1**, raising a clear "insufficient disk space" error
+  that surfaces as a normal job failure. This is a **new shared seam** (no disk
+  check exists today); single-step tools can opt into it later. (Open Q2: hard
+  fail vs warn; margin/setting name.)
+
+### 1.4 Progress aggregation (weighted, single bar)
+
+chd compression dominates cso decompression, so a 50/50 split misreports. The
+weights live on `ChainStep` (cso `0.20`, chd `0.80`). Inside
+`ChainTool.convert`, each sub-step's 0–100 maps into its slice:
+
+```
+aggregate = round( (Σ weight_j for j<i)*100 + weight_i * step_progress_i )
+```
+
+The aggregate is **monotonic non-decreasing** and ends at 100 when the last step
+completes. `job_manager` sees an ordinary 0–100 stream — **no job_manager
+change** for progress. The stall-timeout machinery (`_last_progress_at`) keeps
+working because real updates keep flowing. Weights are authored per chain (and
+are the obvious knob to tune from observed timings later).
+
+### 1.5 Staged verify + delete-on-verify
+
+- The intermediate `.iso` **cannot** be verified (maxcso verifies compressed
+  containers, not the extracted iso — exactly why `cso_decompress` has
+  `supports_delete_on_verify=False`). So the chain verifies **only the final
+  `.chd`**, via the `verify_step` tool (chdman).
+- `ChainTool.verify(path)` delegates to `registry.get(steps[verify_step].tool_id).verify(path)`
+  on the final output. The existing verify gate in `_process_job`
+  (`registry.for_mode(mode).verify(output_path)` when
+  `spec.supports_delete_on_verify` and not an extract mode) therefore drives the
+  chain's verify with **no special-casing** — `ChainSpec.supports_delete_on_verify=True`
+  and `ChainTool.verify` resolves to chdman on the `.chd`.
+- **Delete-on-verify of the original `.cso` gates on the final `.chd` verify**:
+  the original is in the existing `delete_snapshot`; it is deleted only after the
+  chd verify returns `{"valid": True}`. The intermediate `.iso` is never in the
+  snapshot and never verified — it's transient work-dir state, removed by
+  cleanup. This reuses the current delete-on-verify safeguards unchanged.
+
+### 1.6 Touched files (described, not coded)
+
+- `app/services/tools/spec.py` — add `ChainStep`, `ChainSpec`.
+- `app/services/tools/chain.py` *(new)* — `ChainTool(BaseTool)`: `modes` = chain
+  specs; `convert` (orchestrate steps via `registry.for_mode(step.mode).convert`,
+  weighted progress, intermediate in `work_dir`, headroom precheck, cleanup);
+  `verify`/`verify_stream` (delegate to `verify_step` tool); `output_path`
+  (final `.chd` from input stem); `info`/`info_model` (delegate to final tool);
+  `detect_output` (sibling `.chd`); `active_pids` (union of in-flight sub-tools).
+- `app/services/tools/__init__.py` — register `ChainTool(registry=registry)`
+  after component tools.
+- `app/services/tools/base.py` + `ToolPlugin` Protocol — add optional `work_dir`
+  kwarg to `convert`.
+- `app/services/tools/registry.py` — ensure `ChainSpec` flows through
+  `mode_specs()`/`spec()` (structural compatibility); optional `chain_specs()`
+  helper.
+- `app/services/job_manager.py` — create/pass `work_dir` for chain modes; no
+  progress or verify changes.
+- `app/routes/convert.py` — `plan_job` already resolves output via
+  `registry.for_mode(mode).output_path` and validates against
+  `spec.input_extensions`; confirm the `ChainSpec` path validates the `.cso`
+  input. No structural change expected.
+- `app/models.py` — add `cso_to_chd` to `ConversionMode`.
+- `app/services/disk.py` *(new)* — `ensure_headroom`.
+- `app/config.py` — optional headroom margin / setting (no new binary path —
+  chain reuses `maxcso_path` + `chdman_path`).
+- `src/lib/tools/registry.js` — surface `cso_to_chd` (new "Pipeline/Chain" card
+  **or** a mode under the CSO tool — open Q1); `productPath` → `.chd`.
+- `docs/DESIGN_tool_plugin_architecture.md` + `docs/RELEASE_NOTES.md` —
+  document the new shared seam and the user-facing mode.
+
+### 1.7 New tests (what would prove it)
+
+- `tests/test_tool_registry.py` — `cso_to_chd` resolves to `ChainTool`;
+  `ChainSpec` fields (kind CREATE, output `.chd`, inputs `.cso/.zso/.dax`,
+  `supports_delete_on_verify=True`).
+- `tests/test_chain_service.py` *(new)* — mock both sub-tools' `convert`
+  generators; assert: intermediate `.iso` created in `work_dir` and removed
+  after step 2; aggregate progress is monotonic and ends at 100 with the
+  documented weighting; final `.chd` produced; `cancel_event` propagates and
+  cleans **both** the intermediate and any partial final.
+- Headroom test — `ensure_headroom` raises before step 1 when free space < need.
+- Verify/delete gate test — original `.cso` deleted only after final `.chd`
+  verify passes; intermediate never verified, never in the delete snapshot.
+
+### 1.8 The seam generalizes
+
+Under the same `ChainSpec` mechanism, other #98 requests become chains with no
+new machinery: **xci→nsp** (Switch, via the existing nsz/Switch tooling),
+**wud/wux→wua** (Wii U, once a wud-extract + wua-pack pair exists), and a
+**future folder→iso→chd** if RPCS3 ever ships CHD (Phase 2 directory input as
+step 1 + this chain). Each is just a new `ChainSpec` row + its component modes.
+
+---
+
+## Phase 2 — directory input + makeps3iso (folder → iso)
+
+### 2.1 makeps3iso (verified against the upstream repo)
+
+- **Source:** `bucanero/ps3iso-utils`. **License GPL-3.0**, primarily C (95.6%),
+  single-source-style, builds with bare gcc, and ships an in-repo Dockerfile.
+- **CLI:** `makeps3iso <input_folder> <output.iso>`; `-s` splits output at 4GB
+  for FAT32 (`makeps3iso -s <folder> <out.iso>`). No keys required — operates on
+  an already-decrypted folder.
+- **Round-trip companion:** `extractps3iso` (iso → folder) exists in the same
+  repo — usable for an optional verify.
+- **arm64:** plain C with a portable Makefile + the repo's own Dockerfile, so it
+  builds the same way `maxcso` already builds from source in our multi-stage
+  `Dockerfile` (build stage → copy binary to runtime). Flag to confirm at
+  implementation: the Makefile has no x86-only asm (a quick read of upstream
+  shows plain C, no SIMD), so an arm64 build is expected to be clean.
+- **License obligation vs how we ship chdman.** chdman ships from MAME
+  (BSD-3-Clause / GPL-2.0+); maxcso is MIT. makeps3iso is **GPL-3.0**, a stricter
+  copyleft. We ship an **unmodified upstream binary** built in the Docker image,
+  so compliance is: keep it a separate binary (no linking into our app), and
+  provide the corresponding source / written offer (pin the upstream ref in the
+  Dockerfile, as we already do for maxcso). **Flag:** GPLv3 is a step up from our
+  current binaries — confirm it's acceptable to add a GPLv3 binary to the image
+  (Open Q3). **Maintenance flag:** upstream's last release is **April 2021**;
+  decide whether to pin upstream or a maintained fork (Open Q3).
+
+### 2.2 A first-class "directory is the unit of work" input kind
+
+The codebase keys every input seam off `Path(filename).suffix`. A folder has no
+suffix, so add a small **`InputKind`** seam rather than faking an extension:
+
+- **`InputKind` enum** `{FILE, DIRECTORY}` in `spec.py`; add
+  `input_kinds: frozenset[InputKind] = frozenset({InputKind.FILE})` to `ModeSpec`
+  (default keeps every existing mode FILE — zero behavior change). A directory
+  mode declares `{InputKind.DIRECTORY}` and, because there's no extension to
+  match, relies on a **detector predicate** instead of `input_extensions`.
+- **Plugin contract:** add `accepts_directory(path) -> bool` to `ToolPlugin`
+  (default `False` in `BaseTool`). `MakePs3IsoTool` overrides it to run the PS3
+  folder detector (§2.4). This is the directory analogue of the
+  `ext in input_extensions` check.
+- **Registry:** add `tools_for_directory(path)` (analogue of `tools_for_input`)
+  that returns tools whose `accepts_directory(path)` is true. Disk I/O lives in
+  the detector, so callers run it in the existing threadpool.
+
+### 2.3 What changes, seam by seam
+
+- **Listing (`files.py:scan_directory`, `_detect_file_outputs`).** Today a
+  directory row is `name/path/type="directory"`. Add: for each directory, ask
+  `registry.tools_for_directory(path)`; if a tool accepts it, annotate the row
+  with `convertible_by` + `outputs` (sibling `<folder>.iso`) just like a file
+  row. Keep the detector cheap (stat for `PS3_DISC.SFB` / `PARAM.SFO`, read only
+  the small SFO header) and inside the threadpool. A directory variant of
+  `tools_for_input` (`tools_for_directory`) drives this. (Open Q6: always-on vs
+  lazy hydration like archive summaries.)
+- **`detect_output` for a folder.** No suffix to swap — derive the sibling from
+  the folder **basename**: `<parent>/<folder_name>.iso`. `MakePs3IsoTool.detect_output`
+  reports it (in-progress vs ready via `lock_manager.check_file_status`).
+- **Output-path derivation.** `output_path` = `output_dir/<folder_basename>.iso`
+  (folder name, not a stem swap).
+- **Verify gate.** makeps3iso has **no native verify**. Recommended: ship
+  **no-verify, `supports_delete_on_verify=False`** — deleting a user-curated
+  decrypted folder is destructive and there is no cheap trustworthy verify.
+  Optional follow-up (reuses `disc_id.py`'s SFO parser): parse `PARAM.SFO` from
+  the **built iso** and confirm its `TITLE_ID` matches the source folder — a
+  light readback, not a full round-trip via `extractps3iso`. (Open Q4.)
+- **Lock manager.** Locks key on `sha256(normpath(path))`, so a **directory
+  path locks fine as-is**. Caveat: a per-file job *inside* the folder hashes to a
+  different key and wouldn't be blocked by the folder lock. For folder→iso this
+  is acceptable (we only read the folder, and we don't offer per-file conversion
+  of PS3 folder contents). Flag as a known limitation (Open Q — acceptable).
+- **Job model.** Add `input_kind: str = "file"` to `ConversionJob` (and the
+  enqueue path); `file_path` holds the directory path, `output_path` the iso.
+  `_process_job` and the verify gate read `input_kind` to skip the file-only
+  assumptions. Reuse `temp_dir` if makeps3iso writes to a temp then moves.
+- **`plan_job` validation (`convert.py`).** Add an `os.path.isdir` branch: for a
+  directory mode, validate `isdir(path)` **and** the PS3 detector instead of
+  `isfile(path)` + extension. Today a directory falls through to `FILE_NOT_FOUND`.
+
+### 2.4 The "valid PS3 iso source" detector
+
+The directory analogue of an extension check, in a new `app/services/ps3.py`
+(or on the tool), threaded through detect → plan → process:
+
+- **Disc folder:** contains `PS3_GAME/` **and** `PS3_DISC.SFB`.
+- **Game folder:** contains a `PARAM.SFO` under a TITLEID directory (or at the
+  expected `PS3_GAME/PARAM.SFO` path).
+
+A folder matching either shape is a valid makeps3iso input; anything else is not
+offered. The SFO read reuses the existing PSF parser in `disc_id.py`.
+
+### 2.5 Reused (Phase 1 / existing) vs new
+
+- **Reused:** plugin/registry/`ModeSpec` pattern, `SubprocessRunner.run`
+  shell-out + `parse_progress`, `BaseTool` delegation, `detect_output`
+  mechanism, `lock_manager`, the job pipeline + verify gate, the frontend
+  registry entry shape. makeps3iso is a **single-step** tool — it does **not**
+  use Phase 1's `ChainSpec`.
+- **New:** `InputKind` + `accepts_directory` + `tools_for_directory`; directory
+  annotation in `scan_directory`; the PS3 folder detector; the makeps3iso binary
+  + Dockerfile build stage + `makeps3iso_path` config field; `input_kind` on the
+  job model; no-verify handling.
+
+### 2.6 makeps3iso integration shape (same pattern as existing tools)
+
+- `app/services/makeps3iso.py` *(new)* — service singleton: `convert()` shells
+  out via `SubprocessRunner.run(["makeps3iso", folder, out_iso], parse_progress=...)`,
+  PID tracking, output-path logic; `info()` (read PARAM.SFO title/id).
+- `app/services/tools/makeps3iso.py` *(new)* — `MakePs3IsoTool(BaseTool)`:
+  `modes` = one DIRECTORY `ModeSpec` (`folder_to_iso`, output `.iso`,
+  `input_kinds={DIRECTORY}`, no delete-on-verify), `accepts_directory`,
+  `detect_output`, delegate the rest to the service.
+- `app/services/tools/__init__.py` — `registry.register(MakePs3IsoTool(settings.makeps3iso_path))`.
+- `app/config.py` — `makeps3iso_path` Field + optional priority/timeout overrides.
+- `Dockerfile` — build stage from `bucanero/ps3iso-utils` at a pinned ref
+  (mirror the maxcso stage), copy `makeps3iso` (+ `extractps3iso` if verify is
+  pursued) into the runtime stage; confirm arm64.
+- `src/lib/tools/registry.js`, `app/models.py` (`folder_to_iso` mode + info
+  model), tests, `docs/`.
+
+### 2.7 New tests
+
+- Directory detector: disc-folder and game-folder fixtures accepted; a plain
+  folder rejected.
+- `tools_for_directory` returns `MakePs3IsoTool` for a valid PS3 folder, nothing
+  for an arbitrary folder.
+- `scan_directory` annotates a PS3 folder row with `convertible_by` + sibling
+  `.iso` output.
+- makeps3iso service convert (mocked subprocess): argv `makeps3iso <folder>
+  <out.iso>`, progress drains to 100, output recorded; cancel cleans partial.
+- `plan_job` accepts a valid PS3 directory, rejects a non-PS3 directory.
+
+---
+
+## Open questions for Talor
+
+1. **cso→chd UI placement** — a new "Pipeline/Chain" tool card, or expose
+   `cso_to_chd` as an extra mode under the existing CSO tool? (Affects
+   `registry.js` + sidebar grouping.)
+2. **Headroom policy** — hard-fail before step 1 when free space is short, or
+   warn-and-proceed? What margin (fixed MB vs % of input), and the setting name
+   (`COMPRESSATORIUM_CHAIN_DISK_MARGIN`?)? Should single-step tools adopt it too?
+3. **makeps3iso provenance** — upstream's last release is April 2021. Pin
+   upstream `bucanero/ps3iso-utils`, or a maintained fork? And is adding a
+   **GPL-3.0** binary to the image acceptable (stricter than our current
+   BSD/GPL-2/MIT binaries)?
+4. **folder→iso verify** — ship no-verify / no-delete-on-verify (recommended),
+   or invest now in the `PARAM.SFO` `TITLE_ID` readback (reusing
+   `disc_id.py`) — or a full `extractps3iso` round-trip?
+5. **`-s` split flag** — expose 4GB FAT32 splitting as a user option, or always
+   emit a single `.iso`? (Depends on whether target volumes are FAT32.)
+6. **Directory-listing cost** — run the PS3 detector on every directory row
+   during `scan_directory`, or hydrate lazily like archive summaries
+   (`/archive-summary`)?
+7. **createdvd pin** — keep step 2 pinned to `createdvd` unconditionally
+   (recommended; cso is audio-free data), or allow a user override to createcd?
+8. **Composite mode naming** — confirm wire value `cso_to_chd`; should the
+   intermediate `.iso` ever be surfaced or optionally kept rather than always
+   discarded?

--- a/docs/issue-98-plan.md
+++ b/docs/issue-98-plan.md
@@ -150,6 +150,13 @@ Q7 on whether to allow a user override.)
     mount (`os.stat(...).st_dev` match), sum the two requirements instead of
     checking them separately so the shared filesystem isn't double-spent. The
     `chain.py` precheck calls `ensure_headroom` once per distinct mount.
+  - **Output dir may not exist yet.** `create_job` accepts an `output_dir` that
+    doesn't exist (it resolves inside a configured volume and is `mkdir`-ed later
+    by `SubprocessRunner.run`). A naive `os.stat`/`shutil.disk_usage` on that
+    parent would fail in preflight before the mkdir runs. `ensure_headroom` (and
+    the `st_dev` mount check) must therefore **walk up to the nearest existing
+    ancestor** of the target — `shutil.disk_usage` reports the same filesystem
+    for any path on that mount — rather than assuming the leaf dir exists.
   - This is a **new shared seam** (no disk check exists today); single-step
     tools can opt into it later. (Open Q2: hard fail vs warn; margin/setting
     name.)
@@ -309,10 +316,18 @@ suffix, so add a small **`InputKind`** seam rather than faking an extension:
   directory row is `name/path/type="directory"`. Add: for each directory, ask
   `registry.tools_for_directory(path)`; if a tool accepts it, annotate the row
   with `convertible_by` + `outputs` (sibling `<folder>.iso`) just like a file
-  row. Keep the detector cheap (stat for `PS3_DISC.SFB` / `PARAM.SFO`, read only
+  row. Keep the detector cheap (stat for `PS3_GAME/` / `PS3_DISC.SFB`, read only
   the small SFO header) and inside the threadpool. A directory variant of
   `tools_for_input` (`tools_for_directory`) drives this. (Open Q6: always-on vs
   lazy hydration like archive summaries.)
+- **Recursive search (`files.py:search_files` / `_scan`).** `scan_directory`
+  alone is not enough: the recursive `_scan` walks **into** directories but only
+  ever appends `os.path.isfile` entries — it never emits the directory itself. If
+  left as-is, a valid PS3 folder shows in normal listings but stays **invisible
+  to search and search-based batch-select**. `_scan` must also emit a
+  *convertible* directory entry (one accepted by `tools_for_directory`) — without
+  recursing past it as a job unit — so folders are discoverable and selectable in
+  large trees, the same way `scan_directory` annotates them.
 - **Frontend selection/action (not just annotation).** Annotating folder rows
   with `convertible_by`/`outputs` is necessary but **not sufficient** to make
   folder→iso usable: the browser treats directories as navigation only —
@@ -363,6 +378,12 @@ suffix, so add a small **`InputKind`** seam rather than faking an extension:
 - **`plan_job` validation (`convert.py`).** Add an `os.path.isdir` branch: for a
   directory mode, validate `isdir(path)` **and** the PS3 detector instead of
   `isfile(path)` + extension. Today a directory falls through to `FILE_NOT_FOUND`.
+- **Queued display filename.** `job_manager._queue_job_locked` derives
+  `ConversionJob.filename` from `os.path.basename(file_path)` when no
+  `filename_override` is given — and a directory path with a **trailing slash**
+  makes that `""`, producing blank job rows/notifications. The directory branch
+  must pass a **normalized display filename** (the same `Path(path).name` used for
+  the output basename) as `filename_override`, not just a normalized output path.
 
 ### 2.4 The "valid PS3 iso source" detector
 
@@ -415,8 +436,11 @@ readback in §2.3's optional verify) reuses the existing PSF parser in
 
 ### 2.7 New tests
 
-- Directory detector: disc-folder and game-folder fixtures accepted; a plain
-  folder rejected.
+- Directory detector: a disc/JB folder fixture (`PS3_GAME/`, + `PS3_DISC.SFB`)
+  is **accepted**; an installed-game / HDD `game/` fixture that has only a
+  `PARAM.SFO` under a TITLEID (no `PS3_GAME` root) is **rejected** (per §2.4); a
+  plain folder is rejected. (The earlier "game-folder accepted" wording would
+  have codified the exact unsafe behavior §2.4 forbids.)
 - `tools_for_directory` returns `MakePs3IsoTool` for a valid PS3 folder, nothing
   for an arbitrary folder.
 - `scan_directory` annotates a PS3 folder row with `convertible_by` + sibling

--- a/docs/issue-98-plan.md
+++ b/docs/issue-98-plan.md
@@ -327,10 +327,13 @@ suffix, so add a small **`InputKind`** seam rather than faking an extension:
   This makes a directory job protect its whole subtree against concurrent
   mutation, in both directions. (The containment check is cheap — string/`Path`
   prefix, no extra disk I/O.)
-- **Job model.** Add `input_kind: str = "file"` to `ConversionJob` (and the
-  enqueue path); `file_path` holds the directory path, `output_path` the iso.
-  `_process_job` and the verify gate read `input_kind` to skip the file-only
-  assumptions. Reuse `temp_dir` if makeps3iso writes to a temp then moves.
+- **Job model.** Add `input_kind: InputKind = InputKind.FILE` to `ConversionJob`
+  (and the enqueue path) — the **same `InputKind` enum** from §2.2, not a bare
+  string, so FILE/DIRECTORY can't drift via typos. Thread the enum end-to-end
+  through `plan_job`, `_process_job`, and the verify gate (which read it to skip
+  the file-only assumptions), and serialize to/from a string only at the
+  API/persistence edge. `file_path` holds the directory path, `output_path` the
+  iso. Reuse `temp_dir` if makeps3iso writes to a temp then moves.
 - **`plan_job` validation (`convert.py`).** Add an `os.path.isdir` branch: for a
   directory mode, validate `isdir(path)` **and** the PS3 detector instead of
   `isfile(path)` + extension. Today a directory falls through to `FILE_NOT_FOUND`.

--- a/docs/issue-98-plan.md
+++ b/docs/issue-98-plan.md
@@ -207,11 +207,25 @@ are the obvious knob to tune from observed timings later).
   `mode_specs()`/`spec()` (structural compatibility); optional `chain_specs()`
   helper.
 - `app/services/job_manager.py` — create/pass `work_dir` for chain modes; no
-  progress or verify changes.
+  progress or verify changes. **One non-obvious change:** `_process_job` embeds
+  the disc-ID `GAME`/`NAME` CHD tags only when `job.mode.value` is *exactly*
+  `createcd`/`createdvd`. `cso_to_chd` hides the final `createdvd` behind the
+  composite mode, so the produced `.chd` would **lose the tags a direct
+  `createdvd` gets**. Fix: have `ChainTool` run that post-convert tag step for its
+  final create step (it knows the final tool/mode), or generalize the embed into
+  the `post_convert` hook (`docs/DESIGN_tool_plugin_architecture.md` §3.2) so the
+  chain inherits it. The chain must call `post_convert` on the final step's tool.
 - `app/routes/convert.py` — `plan_job` already resolves output via
-  `registry.for_mode(mode).output_path` and validates against
-  `spec.input_extensions`; confirm the `ChainSpec` path validates the `.cso`
-  input. No structural change expected.
+  `registry.for_mode(mode).output_path`, but its **input-extension validation is
+  not generic**: it lives in hard-coded per-tool branches
+  (`is_dolphin`/`is_z3ds`/`is_nsz`/`is_cso`/`is_romz`). A `ChainSpec` with
+  `tool_id="chain"` matches none of them, so a direct API/batch submission for
+  `cso_to_chd` would **skip validation and accept any non-`.chd` file**, failing
+  late in the worker. Fix: add a **registry-driven extension check** — validate
+  `_input_extension(path) in spec.input_extensions` for any spec/tool not covered
+  by a legacy branch (ideally fold the legacy branches into the same generic
+  check). This is a small but **required** structural change, not the no-op the
+  earlier draft assumed.
 - `app/models.py` — add `cso_to_chd` to `ConversionMode`.
 - `app/services/disk.py` *(new)* — `ensure_headroom`.
 - `app/config.py` — optional headroom margin / setting (no new binary path —
@@ -299,6 +313,18 @@ suffix, so add a small **`InputKind`** seam rather than faking an extension:
   the small SFO header) and inside the threadpool. A directory variant of
   `tools_for_input` (`tools_for_directory`) drives this. (Open Q6: always-on vs
   lazy hydration like archive summaries.)
+- **Frontend selection/action (not just annotation).** Annotating folder rows
+  with `convertible_by`/`outputs` is necessary but **not sufficient** to make
+  folder→iso usable: the browser treats directories as navigation only —
+  `FileRow` routes a directory click to navigation and `fileBrowser._isSelectable()`
+  returns `false` for every `entry.type === 'directory'`. Without a change, a
+  valid PS3 folder shows metadata but **can't be selected or submitted**. Phase 2
+  must therefore add a frontend path for directory modes: make a
+  *convertible* directory row selectable (e.g. `_isSelectable` returns true when
+  the row has `convertible_by`, distinct from the navigation affordance) and give
+  it a convert action, while a plain directory stays navigation-only. This is a
+  `src/` change (`FileRow`/`fileBrowser`/`RowActionsMenu`), beyond the
+  `registry.js`/model edits listed below.
 - **`detect_output` for a folder.** No suffix to swap — derive the sibling from
   the folder **basename**: `<parent>/<folder_name>.iso`. `MakePs3IsoTool.detect_output`
   reports it (in-progress vs ready via `lock_manager.check_file_status`).
@@ -343,12 +369,20 @@ suffix, so add a small **`InputKind`** seam rather than faking an extension:
 The directory analogue of an extension check, in a new `app/services/ps3.py`
 (or on the tool), threaded through detect → plan → process:
 
-- **Disc folder:** contains `PS3_GAME/` **and** `PS3_DISC.SFB`.
-- **Game folder:** contains a `PARAM.SFO` under a TITLEID directory (or at the
-  expected `PS3_GAME/PARAM.SFO` path).
+- **Disc rip (JB) folder:** contains a **`PS3_GAME/` root**, and for a true disc
+  image also `PS3_DISC.SFB`. This is the layout `makeps3iso` packages.
 
-A folder matching either shape is a valid makeps3iso input; anything else is not
-offered. The SFO read reuses the existing PSF parser in `disc_id.py`.
+**Require the disc/JB layout — a bare `PARAM.SFO` is not enough.** Accepting any
+TITLEID directory that merely contains a `PARAM.SFO` would also match
+installed-game / HDD `game/` / digital game-data layouts that have **no
+`PS3_GAME` root or `PS3_DISC.SFB`**. `makeps3iso` is not meant to package those —
+they'd be advertised in the UI and queued as valid `folder_to_iso` inputs but
+produce an invalid ISO or fail late. So the detector must **prove the folder is a
+genuine makeps3iso source** (require the `PS3_GAME/` disc structure, with
+`PS3_DISC.SFB` for disc rips) before advertising it; a folder that only has a
+`PARAM.SFO` under a TITLEID is **rejected**. The SFO read (for the title/id
+readback in §2.3's optional verify) reuses the existing PSF parser in
+`disc_id.py`.
 
 ### 2.5 Reused (Phase 1 / existing) vs new
 

--- a/src/lib/tools/registry.js
+++ b/src/lib/tools/registry.js
@@ -326,8 +326,8 @@ export const TOOLS = [
     verifyPrefix: 'cso',
     sourceExts: CSO_SOURCE_EXTS,
     verifyExts: CSO_VERIFY_EXTS,
-    modeGroups: ['cso'],
-    groups: { cso: 'CSO / ZSO / DAX' },
+    modeGroups: ['cso', 'chain'],
+    groups: { cso: 'CSO / ZSO / DAX', chain: 'CSO → CHD' },
     defaultMode: 'cso_compress',
     glyph: 'CSO',
     accent: 'var(--badge-cso)',
@@ -363,6 +363,14 @@ export const TOOLS = [
         outputExt: '.iso', inputExtensions: CSO_VERIFY_EXTS,
         supportsCompression: false, supportsCompressionLevel: false,
         supportsDeleteOnVerify: false, allowsArchiveInput: true },
+      // Composite pipeline (maxcso decompress -> chdman createdvd). The .chd is
+      // verified/badged by the chdman tool entry; the final CHD uses chdman's
+      // default compression, so no codec picker is shown here.
+      { mode: 'cso_to_chd', kind: 'create', label: 'Convert to CHD (→ ISO → CHD)',
+        group: 'chain',
+        outputExt: '.chd', inputExtensions: CSO_VERIFY_EXTS,
+        supportsCompression: false, supportsCompressionLevel: false,
+        supportsDeleteOnVerify: true, allowsArchiveInput: true },
     ],
     getInfo: (path) => api.getCsoInfo(path),
     verify: (path, opts) => api.verifyCso(path, opts),
@@ -377,7 +385,11 @@ export const TOOLS = [
           : '.cso';
         return swapExt(path, ext);
       }
-      if (/\.(cso|zso|dax)$/i.test(path)) return swapExt(path, '.iso');
+      if (/\.(cso|zso|dax)$/i.test(path)) {
+        // The chain packages a compressed source straight to .chd; plain
+        // decompress yields the .iso.
+        return swapExt(path, mode === 'cso_to_chd' ? '.chd' : '.iso');
+      }
       return path;
     },
   },

--- a/tests/test_chain_service.py
+++ b/tests/test_chain_service.py
@@ -36,11 +36,11 @@ def chain_env(monkeypatch, tmp_path):
     """Patch the chain's temp dir + disc-ID embed, and install fake steps."""
     work = tmp_path / "chainwork"
 
-    def _mkdtemp(prefix=""):
+    def _scratch(prefix=""):
         work.mkdir(parents=True, exist_ok=True)
         return str(work)
 
-    monkeypatch.setattr(chain_mod.tempfile, "mkdtemp", _mkdtemp)
+    monkeypatch.setattr(chain_mod, "create_scratch_dir", _scratch)
     # No real disc parsing/tagging: keep the embed a no-op.
     monkeypatch.setattr(chain_mod, "extract_from_source", lambda p: None)
 
@@ -97,9 +97,10 @@ def test_chain_orchestration_progress_and_intermediate(chain_env, tmp_path):
     assert os.path.dirname(calls[0]["out"]) == str(work)
     assert calls[1]["in"] == calls[0]["out"]
     assert calls[1]["out"] == str(out)
-    # Compression routes only to the step that supports it (chdman createdvd).
+    # cso_to_chd advertises no compression, so a client-supplied preset is
+    # dropped (not smuggled to chdman as a codec): neither step receives it.
     assert calls[0]["compression"] is None
-    assert calls[1]["compression"] == "zstd"
+    assert calls[1]["compression"] is None
 
     # Aggregate progress is monotonic and ends at 100.
     progs = [u["progress"] for u in updates]
@@ -133,6 +134,31 @@ def test_chain_propagates_cancel_and_cleans_up(chain_env, tmp_path):
     # Temp work dir removed even though the job aborted; no partial final.
     assert not work.exists()
     assert not out.exists()
+
+
+def test_uncompressed_iso_size_reads_container_headers(tmp_path):
+    import struct
+
+    from app.services.maxcso import uncompressed_iso_size
+
+    cso = tmp_path / "g.cso"
+    cso.write_bytes(b"CISO" + struct.pack("<I", 24) + struct.pack("<Q", 5_000_000)
+                    + struct.pack("<I", 2048))
+    assert uncompressed_iso_size(str(cso)) == 5_000_000
+
+    zso = tmp_path / "g.zso"
+    zso.write_bytes(b"ZISO" + struct.pack("<I", 24) + struct.pack("<Q", 7_000_000)
+                    + struct.pack("<I", 2048))
+    assert uncompressed_iso_size(str(zso)) == 7_000_000
+
+    dax = tmp_path / "g.dax"
+    dax.write_bytes(b"DAX\x00" + struct.pack("<I", 3_000_000) + b"\x00" * 8)
+    assert uncompressed_iso_size(str(dax)) == 3_000_000
+
+    # Unknown header -> None (caller falls back to the ratio estimate).
+    other = tmp_path / "g.bin"
+    other.write_bytes(b"\x00" * 16)
+    assert uncompressed_iso_size(str(other)) is None
 
 
 def test_chain_headroom_blocks_before_any_step(chain_env, tmp_path, monkeypatch):

--- a/tests/test_chain_service.py
+++ b/tests/test_chain_service.py
@@ -1,0 +1,158 @@
+"""Orchestration tests for ``ChainTool`` (the cso_to_chd pipeline seam).
+
+The real maxcso/chdman CLIs can't run here, so the component steps are mocked:
+``registry.for_mode("cso_decompress")`` and ``registry.for_mode("createdvd")``
+resolve to the cso/chdman plugins, whose ``convert`` is monkeypatched. These
+tests assert the chain's own behavior — step delegation, weighted progress,
+intermediate placement/cleanup, compression routing, cancel propagation, and the
+disk-headroom preflight — independent of the underlying tools.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+import app.services.tools.chain as chain_mod
+from app.services.disk import InsufficientDiskSpace
+from app.services.tools import registry
+
+
+class _Cancelled(Exception):
+    """Stand-in for a sub-tool's cancellation signal."""
+
+
+def _drain(agen) -> list[dict]:
+    async def _run() -> list[dict]:
+        return [u async for u in agen]
+
+    return asyncio.run(_run())
+
+
+@pytest.fixture
+def chain_env(monkeypatch, tmp_path):
+    """Patch the chain's temp dir + disc-ID embed, and install fake steps."""
+    work = tmp_path / "chainwork"
+
+    def _mkdtemp(prefix=""):
+        work.mkdir(parents=True, exist_ok=True)
+        return str(work)
+
+    monkeypatch.setattr(chain_mod.tempfile, "mkdtemp", _mkdtemp)
+    # No real disc parsing/tagging: keep the embed a no-op.
+    monkeypatch.setattr(chain_mod, "extract_from_source", lambda p: None)
+
+    calls: list[dict] = []
+
+    def install(cso_progress=(0, 100), chd_progress=(0, 100), cso_cancel=False):
+        def make(tool_id, progress, cancel_raises):
+            def _convert(input_path, output_path, mode, *,
+                         compression=None, cancel_event=None):
+                async def _gen():
+                    calls.append({
+                        "tool": tool_id, "mode": mode, "in": input_path,
+                        "out": output_path, "compression": compression,
+                    })
+                    if cancel_raises and cancel_event is not None \
+                            and cancel_event.is_set():
+                        raise _Cancelled()
+                    for p in progress:
+                        yield {"progress": p, "message": f"{mode}:{p}"}
+                    Path(output_path).write_bytes(b"0" * 32)
+
+                return _gen()
+
+            return _convert
+
+        monkeypatch.setattr(
+            registry.get("cso"), "convert", make("cso", cso_progress, cso_cancel),
+        )
+        monkeypatch.setattr(
+            registry.get("chdman"), "convert", make("chdman", chd_progress, False),
+        )
+
+    return calls, work, install
+
+
+def test_chain_orchestration_progress_and_intermediate(chain_env, tmp_path):
+    calls, work, install = chain_env
+    install(cso_progress=(0, 50, 100), chd_progress=(0, 50, 100))
+    src = tmp_path / "Game.cso"
+    src.write_bytes(b"x" * 1000)
+    out = tmp_path / "Game.chd"
+
+    updates = _drain(
+        registry.for_mode("cso_to_chd").convert(
+            str(src), str(out), "cso_to_chd", compression="zstd",
+        )
+    )
+
+    # Step delegation + ordering.
+    assert [c["mode"] for c in calls] == ["cso_decompress", "createdvd"]
+    # Step 1 reads the source; step 2 reads the intermediate .iso in the work dir.
+    assert calls[0]["in"] == str(src)
+    assert calls[0]["out"].endswith(".iso")
+    assert os.path.dirname(calls[0]["out"]) == str(work)
+    assert calls[1]["in"] == calls[0]["out"]
+    assert calls[1]["out"] == str(out)
+    # Compression routes only to the step that supports it (chdman createdvd).
+    assert calls[0]["compression"] is None
+    assert calls[1]["compression"] == "zstd"
+
+    # Aggregate progress is monotonic and ends at 100.
+    progs = [u["progress"] for u in updates]
+    assert progs == sorted(progs)
+    assert progs[-1] == 100
+    # The 0.20-weighted cso step tops out at ~20% of the bar before chd starts.
+    assert max(u["progress"] for u in updates if u["message"].startswith("[1/2]")) == 20
+    assert any(u["message"].startswith("[2/2]") for u in updates)
+
+    # Final output produced; intermediate + work dir cleaned up.
+    assert out.exists()
+    assert not work.exists()
+
+
+def test_chain_propagates_cancel_and_cleans_up(chain_env, tmp_path):
+    calls, work, install = chain_env
+    install(cso_cancel=True)
+    src = tmp_path / "Game.cso"
+    src.write_bytes(b"x" * 1000)
+    out = tmp_path / "Game.chd"
+    event = asyncio.Event()
+    event.set()
+
+    with pytest.raises(_Cancelled):
+        _drain(
+            registry.for_mode("cso_to_chd").convert(
+                str(src), str(out), "cso_to_chd", cancel_event=event,
+            )
+        )
+
+    # Temp work dir removed even though the job aborted; no partial final.
+    assert not work.exists()
+    assert not out.exists()
+
+
+def test_chain_headroom_blocks_before_any_step(chain_env, tmp_path, monkeypatch):
+    calls, work, install = chain_env
+    install()
+
+    def _boom(targets, *, margin_bytes=0):
+        raise InsufficientDiskSpace("not enough space")
+
+    monkeypatch.setattr(chain_mod, "ensure_headroom", _boom)
+
+    src = tmp_path / "Game.cso"
+    src.write_bytes(b"x" * 1000)
+    out = tmp_path / "Game.chd"
+
+    with pytest.raises(InsufficientDiskSpace):
+        _drain(
+            registry.for_mode("cso_to_chd").convert(str(src), str(out), "cso_to_chd")
+        )
+
+    # Preflight runs before step 1: no steps executed, work dir cleaned up.
+    assert calls == []
+    assert not work.exists()

--- a/tests/test_chain_service.py
+++ b/tests/test_chain_service.py
@@ -115,7 +115,7 @@ def test_chain_orchestration_progress_and_intermediate(chain_env, tmp_path):
 
 
 def test_chain_propagates_cancel_and_cleans_up(chain_env, tmp_path):
-    calls, work, install = chain_env
+    _calls, work, install = chain_env
     install(cso_cancel=True)
     src = tmp_path / "Game.cso"
     src.write_bytes(b"x" * 1000)

--- a/tests/test_disk_headroom.py
+++ b/tests/test_disk_headroom.py
@@ -1,0 +1,55 @@
+"""Unit tests for the shared disk-headroom preflight (``services.disk``)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.services import disk
+from app.services.disk import InsufficientDiskSpace, ensure_headroom
+
+
+def _fake_usage(free_by_path):
+    def _usage(path):
+        return os.terminal_size((0, 0)) if False else _Usage(free_by_path(path))
+    return _usage
+
+
+class _Usage:
+    def __init__(self, free):
+        self.total = free
+        self.used = 0
+        self.free = free
+
+
+def test_passes_when_space_available(monkeypatch, tmp_path):
+    monkeypatch.setattr(disk.shutil, "disk_usage", lambda p: _Usage(10_000))
+    # Should not raise: each target needs less than free.
+    ensure_headroom([(str(tmp_path), 1_000)], margin_bytes=100)
+
+
+def test_raises_when_below_required_plus_margin(monkeypatch, tmp_path):
+    monkeypatch.setattr(disk.shutil, "disk_usage", lambda p: _Usage(1_500))
+    with pytest.raises(InsufficientDiskSpace):
+        ensure_headroom([(str(tmp_path), 1_000)], margin_bytes=1_000)
+
+
+def test_same_mount_requirements_are_summed(monkeypatch, tmp_path):
+    # Two targets on the same device must be summed, not checked independently.
+    monkeypatch.setattr(disk.os, "stat", lambda p: os.stat_result(
+        (0, 0, 42, 0, 0, 0, 0, 0, 0, 0)  # st_dev (index 2) == 42 for both
+    ))
+    monkeypatch.setattr(disk.shutil, "disk_usage", lambda p: _Usage(2_500))
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    # 1500 + 1500 = 3000 > 2500 free -> must raise even though each alone fits.
+    with pytest.raises(InsufficientDiskSpace):
+        ensure_headroom([(str(a), 1_500), (str(b), 1_500)])
+
+
+def test_nearest_existing_ancestor_used_for_missing_target(tmp_path):
+    # A not-yet-created output dir resolves to its nearest existing ancestor.
+    missing = tmp_path / "does" / "not" / "exist"
+    assert disk._nearest_existing(str(missing)) == str(tmp_path)

--- a/tests/test_disk_headroom.py
+++ b/tests/test_disk_headroom.py
@@ -9,12 +9,6 @@ from app.services import disk
 from app.services.disk import InsufficientDiskSpace, ensure_headroom
 
 
-def _fake_usage(free_by_path):
-    def _usage(path):
-        return os.terminal_size((0, 0)) if False else _Usage(free_by_path(path))
-    return _usage
-
-
 class _Usage:
     def __init__(self, free):
         self.total = free

--- a/tests/test_dispatch_routing.py
+++ b/tests/test_dispatch_routing.py
@@ -17,7 +17,14 @@ from app.models import ConversionMode
 from app.services.tools import registry
 
 EXTERNAL_MODES = {ConversionMode.METADATA_SCAN, ConversionMode.DAT_MATCH}
-CONVERSION_MODES = [m.value for m in ConversionMode if m not in EXTERNAL_MODES]
+# Composite/chain modes orchestrate several services and have no single
+# ``_service`` to monkeypatch, so the single-tool ladder/parity model below
+# doesn't apply (they get dedicated coverage in test_chain_service.py).
+CONVERSION_MODES = [
+    m.value
+    for m in ConversionMode
+    if m not in EXTERNAL_MODES and registry.for_mode(m.value).id != "chain"
+]
 
 
 def _legacy_dispatch_id(mode: str) -> str:
@@ -98,3 +105,19 @@ def test_external_modes_never_resolve():
     for mode in EXTERNAL_MODES:
         with pytest.raises(KeyError):
             registry.for_mode(mode.value)
+
+
+def test_chain_verify_delegates_to_final_step_tool(monkeypatch):
+    """cso_to_chd verifies the final .chd via the verify_step tool (chdman)."""
+    called: dict[str, str] = {}
+
+    async def _verify(path):
+        called["id"] = "chdman"
+        return {"valid": True, "message": "ok"}
+
+    monkeypatch.setattr(registry.get("chdman")._service, "verify", _verify)
+
+    result = asyncio.run(registry.for_mode("cso_to_chd").verify("/data/out.chd"))
+
+    assert result == {"valid": True, "message": "ok"}
+    assert called["id"] == "chdman"

--- a/tests/test_ps3_detector.py
+++ b/tests/test_ps3_detector.py
@@ -1,0 +1,91 @@
+"""Tests for the PS3 folder->iso source detector (``services.ps3``).
+
+Phase 2 scaffolding: the directory analogue of an extension check. The key
+behavior is that the disc/JB layout (a ``PS3_GAME/`` root) is required, and a
+bare installed/HDD game-data folder (a ``PARAM.SFO`` under a TITLEID with no
+``PS3_GAME``) is rejected — otherwise such folders would be advertised for
+``folder_to_iso`` and fail late.
+"""
+from __future__ import annotations
+
+import struct
+
+from app.services.ps3 import is_ps3_iso_source, ps3_title_id
+from app.services.tools import registry
+
+
+def _make_sfo(pairs: list[tuple[str, str]]) -> bytes:
+    keys_blob = b""
+    key_offsets = []
+    for key, _ in pairs:
+        key_offsets.append(len(keys_blob))
+        keys_blob += key.encode("ascii") + b"\x00"
+    data_blob = b""
+    data_meta = []
+    for _, value in pairs:
+        encoded = value.encode("utf-8") + b"\x00"
+        data_meta.append((len(data_blob), len(encoded)))
+        data_blob += encoded
+    num = len(pairs)
+    index_size = num * 16
+    key_table_off = 20 + index_size
+    data_table_off = key_table_off + len(keys_blob)
+    header = struct.pack("<4sHH", b"\x00PSF", 1, 1)
+    header += struct.pack("<III", key_table_off, data_table_off, num)
+    index = b""
+    for key_off, (data_off, data_len) in zip(key_offsets, data_meta):
+        index += struct.pack("<HHIII", key_off, 0x0204, data_len, data_len, data_off)
+    return header + index + keys_blob + data_blob
+
+
+def test_disc_rip_folder_accepted(tmp_path):
+    root = tmp_path / "MyGame"
+    (root / "PS3_GAME").mkdir(parents=True)
+    (root / "PS3_DISC.SFB").write_bytes(b"\x00")
+    assert is_ps3_iso_source(str(root)) is True
+
+
+def test_jb_game_folder_accepted(tmp_path):
+    root = tmp_path / "MyGame"
+    game = root / "PS3_GAME"
+    game.mkdir(parents=True)
+    (game / "PARAM.SFO").write_bytes(_make_sfo([("TITLE_ID", "BLES00000")]))
+    assert is_ps3_iso_source(str(root)) is True
+
+
+def test_installed_game_data_folder_rejected(tmp_path):
+    # A TITLEID directory with only a PARAM.SFO (no PS3_GAME root) is an
+    # installed/HDD layout makeps3iso can't package — must NOT be advertised.
+    root = tmp_path / "BLES00000"
+    root.mkdir()
+    (root / "PARAM.SFO").write_bytes(_make_sfo([("TITLE_ID", "BLES00000")]))
+    assert is_ps3_iso_source(str(root)) is False
+
+
+def test_plain_folder_and_file_rejected(tmp_path):
+    plain = tmp_path / "random"
+    plain.mkdir()
+    assert is_ps3_iso_source(str(plain)) is False
+
+    a_file = tmp_path / "game.iso"
+    a_file.write_bytes(b"x")
+    assert is_ps3_iso_source(str(a_file)) is False
+
+
+def test_title_id_readback(tmp_path):
+    root = tmp_path / "MyGame"
+    game = root / "PS3_GAME"
+    game.mkdir(parents=True)
+    (game / "PARAM.SFO").write_bytes(
+        _make_sfo([("TITLE_ID", "BLES01807"), ("TITLE", "Some Game")])
+    )
+    assert ps3_title_id(str(root)) == "BLES01807"
+
+
+def test_registry_directory_seam_present(tmp_path):
+    # The seam exists; no directory tool is registered yet (makeps3iso is
+    # deferred), so a valid PS3 folder resolves to no tool for now.
+    root = tmp_path / "MyGame"
+    (root / "PS3_GAME").mkdir(parents=True)
+    (root / "PS3_DISC.SFB").write_bytes(b"\x00")
+    assert registry.tools_for_directory(str(root)) == []

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -50,8 +50,16 @@ EXTERNAL_MODES = {ConversionMode.METADATA_SCAN, ConversionMode.DAT_MATCH}
 CONVERSION_MODES = [m for m in ConversionMode if m not in EXTERNAL_MODES]
 
 
+# Composite/pipeline modes (tool_id="chain") are a newer construct that
+# orchestrates several single-tool modes; they predate neither the legacy ladder
+# below nor its prefix rules, so they're enumerated explicitly.
+COMPOSITE_MODES = {"cso_to_chd"}
+
+
 def _legacy_tool_for_mode(mode: str) -> str:
     """Replicates the dispatch ladder at job_manager.py:1444."""
+    if mode in COMPOSITE_MODES:
+        return "chain"
     if mode.startswith("dolphin_"):
         return "dolphin"
     if mode.startswith("z3ds_"):
@@ -67,7 +75,7 @@ def _legacy_tool_for_mode(mode: str) -> str:
 
 def test_every_conversion_mode_resolves_to_exactly_one_tool():
     resolved = {m.value: registry.for_mode(m.value).id for m in CONVERSION_MODES}
-    assert len(resolved) == 27
+    assert len(resolved) == 28
     # Each registered mode is owned by exactly one tool (no duplicates).
     assert sorted(s.mode for s in registry.mode_specs()) == sorted(resolved)
 
@@ -183,10 +191,11 @@ def test_tools_for_input_representative():
     assert [t.id for t in registry.tools_for_input("game.nsp")] == ["nsz"]
     assert [t.id for t in registry.tools_for_input("game.nsz")] == ["nsz"]
     assert [t.id for t in registry.tools_for_input("disc.gdi")] == ["chdman"]
-    # .cso/.zso/.dax are convertible-from sources for the decompress mode.
-    assert [t.id for t in registry.tools_for_input("game.cso")] == ["cso"]
-    assert [t.id for t in registry.tools_for_input("game.zso")] == ["cso"]
-    assert [t.id for t in registry.tools_for_input("game.dax")] == ["cso"]
+    # .cso/.zso/.dax are convertible-from sources for the maxcso decompress mode
+    # and for the cso_to_chd chain (which packages them straight to .chd).
+    assert sorted(t.id for t in registry.tools_for_input("game.cso")) == ["chain", "cso"]
+    assert sorted(t.id for t in registry.tools_for_input("game.zso")) == ["chain", "cso"]
+    assert sorted(t.id for t in registry.tools_for_input("game.dax")) == ["chain", "cso"]
     # Handheld ROM sources + the archives romz can extract from.
     assert [t.id for t in registry.tools_for_input("Game.gba")] == ["romz"]
     assert [t.id for t in registry.tools_for_input("Game.gb")] == ["romz"]
@@ -388,9 +397,16 @@ def test_delete_on_verify_iff_output_is_verifiable():
     output without also enabling delete-on-verify (or vice versa).
     """
     for tool in registry.all():
-        vexts = tool.verify_extensions
         for mode in tool.modes:
             outs = _mode_output_exts(tool, mode)
+            # A composite/chain mode deliberately claims no verify_extensions of
+            # its own (chdman already owns .chd verify); its output is verified
+            # by the final step's tool, which ChainTool.verify delegates to.
+            if getattr(mode, "steps", None):
+                vtool = registry.get(mode.steps[mode.verify_step].tool_id)
+                vexts = vtool.verify_extensions
+            else:
+                vexts = tool.verify_extensions
             verifiable = bool(outs) and outs <= vexts
             assert mode.supports_delete_on_verify == verifiable, (
                 f"{mode.mode}: supports_delete_on_verify={mode.supports_delete_on_verify} "


### PR DESCRIPTION
Implements issue #98 **Phase 1 in full** (cso→chd) and lands the **Phase 2 scaffolding** (directory-input seam + PS3 detector), following the design doc in `docs/issue-98-plan.md` (also in this PR).

## Phase 1 — cross-tool chaining (cso → iso → chd), no new binary

A general chaining seam that sits **above** the existing plugin registry, with `cso_to_chd` as its first user:

- **`ChainStep`/`ChainSpec`** (`app/services/tools/spec.py`) — a structural superset of `ModeSpec`, so `registry.spec`/`mode_specs`/`convertible_extensions` and every route/job_manager consumer work unchanged.
- **`ChainTool`** (`app/services/tools/chain.py`) — synthetic tool (`id="chain"`) registered after its component tools; orchestrates maxcso `cso_decompress` → chdman `createdvd` through the registry. Intermediate `.iso` in a private temp dir (cleaned in `finally`), weighted progress aggregated into one bar (chd dominates cso), compression routed only to a step that supports it, and `verify`/`info`/`output_path` delegated to the final step's tool — so the existing verify gate + delete-on-verify drive the chain with no special-casing (the source `.cso` is deleted only after the final `.chd` verifies). Disc-ID `GAME`/`NAME` tagging re-applied for the chain's final create step.
- **`services/disk.ensure_headroom`** — shared, multi-volume-aware free-space preflight (work-dir and output-dir checked per mount; output dir may not exist yet → nearest existing ancestor). Cushion: `COMPRESSATORIUM_CHAIN_DISK_MARGIN_MB`.
- **Generic chain input validation** in `routes/convert.py` (the legacy per-tool `is_*` branches don't cover `tool_id="chain"`).
- **UI**: a "Convert to CHD" mode under the CSO tool (`src/lib/tools/registry.js`); the final CHD uses chdman's default compression and is verified/badged by the chdman entry.

## Phase 2 — scaffolding only (no makeps3iso binary/UI/job plumbing)

- `InputKind` enum + `ModeSpec.input_kinds`; `ToolPlugin.accepts_directory` + `registry.tools_for_directory`; PS3 disc/JB-folder detector (`services/ps3.py`) that requires the `PS3_GAME/` layout and rejects bare installed-game folders.

## Review feedback already folded in

The design doc was hardened across earlier commits per Gemini/CodeRabbit/Codex review (multi-volume headroom, normalized weights, path normalization, subtree locking, `InputKind` enum, generic chain validation, CHD tagging for chains, directory UI/search, detector strictness). Phase 1 code implements those decisions.

## Verification

- `PYTHONPATH=app python -m pytest -q` → **978 passed, 1 skipped**
- `ruff check .` → clean
- `npm run build` → succeeds
- New tests: `test_chain_service.py` (orchestration, weighted progress, intermediate cleanup, cancel, headroom), `test_disk_headroom.py`, `test_ps3_detector.py`; chain/composite coverage folded into `test_tool_registry.py` and `test_dispatch_routing.py`.

Deferred to a follow-up (per scope decision): makeps3iso binary + Dockerfile (GPL-3.0, arm64), directory listing annotation, `ConversionJob.input_kind` + folder job plumbing, and the Svelte directory selection UI.

Closes #98 Phase 1.

https://claude.ai/code/session_01BYr1EyCxYQNTpbMT7rxuMA