### PR TITLE
PS3 decrypted folder → ISO via makeps3iso (#98 Phase 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,44 @@ RUN make && \
     chmod +x maxcso
 
 # ---------------------------------------------------------------------------
+# makeps3iso builder stage: compile makeps3iso (decrypted PS3 disc/JB folder ->
+# .iso) from source.
+#
+# bucanero/ps3iso-utils is GPL-3.0, plain portable C (no x86 asm / SIMD — the
+# only arch flag is a Darwin-only `-arch x86_64`, never hit here), built with a
+# bare `make` per utility directory. Compiles per-arch automatically, so
+# linux/amd64 and linux/arm64 buildx both work, same as the maxcso stage. We
+# ship the unmodified upstream binary as a separate executable (not linked into
+# the app) and pin the source ref for GPL-3.0 source-correspondence, exactly as
+# maxcso is pinned. Only makeps3iso is built/copied: verify is a pure-Python
+# PARAM.SFO readback, so extractps3iso (round-trip) isn't needed.
+# DL3008 ignored for the same reason as the other builders (generic build deps).
+# ---------------------------------------------------------------------------
+FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS makeps3iso-builder
+ENV DEBIAN_FRONTEND=noninteractive
+# Pinned to an immutable commit so release images are reproducible. master @
+# 2022-03-09 (latest upstream; last tagged release predates it). Override with
+# --build-arg MAKEPS3ISO_REF=<tag|sha> to update makeps3iso intentionally.
+ARG MAKEPS3ISO_REF=878090980a9042c61901920fed1b034af215e8c7
+# hadolint ignore=DL3008
+RUN apt-get update -o Acquire::Retries=3 && \
+    apt-get install -y --no-install-recommends \
+    git \
+    build-essential \
+    ca-certificates && \
+    git clone https://github.com/bucanero/ps3iso-utils.git /tmp/ps3iso-utils && \
+    git -C /tmp/ps3iso-utils checkout "${MAKEPS3ISO_REF}" && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/ps3iso-utils
+
+RUN make -C makeps3iso && \
+    if [ ! -f makeps3iso/makeps3iso ] && [ -f makeps3iso/bin/makeps3iso ]; then \
+      cp makeps3iso/bin/makeps3iso makeps3iso/makeps3iso; \
+    fi && \
+    chmod +x makeps3iso/makeps3iso
+
+# ---------------------------------------------------------------------------
 # Frontend builder stage: compile the Svelte 5 SPA with Vite.
 #
 # Output is emitted to /build/static via vite.config.js (build.outDir),
@@ -183,6 +221,10 @@ COPY --from=builder /tmp/z3ds/build/z3ds_compressor /usr/local/bin/z3ds_compress
 
 # Install maxcso from its builder stage (PSP/PS2 ISO <-> CSO/ZSO)
 COPY --from=maxcso-builder /tmp/maxcso/maxcso /usr/local/bin/maxcso
+
+# Install makeps3iso from its builder stage (decrypted PS3 folder -> .iso).
+# GPL-3.0, shipped unmodified as a standalone binary (see the builder stage).
+COPY --from=makeps3iso-builder /tmp/ps3iso-utils/makeps3iso/makeps3iso /usr/local/bin/makeps3iso
 
 # Copy application
 COPY app/ /app/

--- a/app/config.py
+++ b/app/config.py
@@ -126,6 +126,13 @@ class Settings(BaseSettings):
         default="/usr/local/bin/maxcso", alias="MAXCSO_PATH",
     )
 
+    # makeps3iso binary path (decrypted PS3 disc/JB folder -> .iso). Built from
+    # source (bucanero/ps3iso-utils, GPL-3.0) into the image at
+    # /usr/local/bin/makeps3iso; set MAKEPS3ISO_PATH to relocate/override.
+    makeps3iso_path: str = Field(
+        default="/usr/local/bin/makeps3iso", alias="MAKEPS3ISO_PATH",
+    )
+
     # Extra free space (MB) a chained conversion (e.g. cso->iso->chd) keeps
     # beyond its estimated peak before starting. A chain holds source + full
     # intermediate + partial final at once, so it preflights disk headroom on
@@ -284,6 +291,18 @@ class Settings(BaseSettings):
     )
     maxcso_verify_timeout: int | None = Field(
         default=None, alias="COMPRESSATORIUM_MAXCSO_VERIFY_TIMEOUT",
+    )
+    # makeps3iso (PS3 folder -> ISO): one packing subprocess. Its verify is a
+    # pure-Python PARAM.SFO readback (no child process), so only the shared
+    # nice/ioprio policy applies; expose the per-tool overrides for parity.
+    makeps3iso_nice: int | None = Field(
+        default=None, alias="COMPRESSATORIUM_MAKEPS3ISO_NICE",
+    )
+    makeps3iso_ioprio_class: int | None = Field(
+        default=None, alias="COMPRESSATORIUM_MAKEPS3ISO_IOPRIO_CLASS",
+    )
+    makeps3iso_ioprio_level: int | None = Field(
+        default=None, alias="COMPRESSATORIUM_MAKEPS3ISO_IOPRIO_LEVEL",
     )
     # romz (7z ROM packer): like nsz/z3ds/maxcso, info() is a filesystem read so
     # only a verify-timeout override is exposed, no info-timeout.

--- a/app/models.py
+++ b/app/models.py
@@ -4,6 +4,26 @@ from enum import Enum
 from pydantic import BaseModel, ConfigDict
 
 
+class InputKind(str, Enum):
+    """The unit of work a conversion mode consumes.
+
+    The codebase historically keyed every input seam off
+    ``Path(filename).suffix``, which assumes a file. A directory has no suffix,
+    so a mode that packages a folder (makeps3iso folder->iso) declares
+    ``DIRECTORY`` and relies on a detector predicate
+    (``ToolPlugin.accepts_directory``) instead of an extension match.
+
+    Defined here (rather than in ``services.tools.spec``) so ``ConversionJob``
+    can type its ``input_kind`` field against the enum without importing the
+    ``services.tools`` package — that package imports ``models`` while building
+    the registry, so the reverse import would be a cycle. ``spec.py`` re-exports
+    it, keeping ``from services.tools.spec import InputKind`` working.
+    """
+
+    FILE = "file"
+    DIRECTORY = "directory"
+
+
 class ConversionMode(str, Enum):
     CREATERAW = "createraw"
     CREATEHD = "createhd"
@@ -33,6 +53,7 @@ class ConversionMode(str, Enum):
     ROMZ_7Z = "romz_7z"
     ROMZ_ZIP = "romz_zip"
     ROMZ_EXTRACT = "romz_extract"
+    FOLDER_TO_ISO = "folder_to_iso"
     METADATA_SCAN = "metadata_scan"
     DAT_MATCH = "dat_match"
 
@@ -132,6 +153,12 @@ class ConversionJob(BaseModel):
     allow_overwrite: bool = False
     compression: str | None = None
     delete_on_verify: bool = False
+    # The unit of work this job consumes. FILE for every existing mode; a
+    # directory-input mode (makeps3iso folder->iso) carries DIRECTORY so the
+    # pipeline skips the archive-extract / file-only assumptions and the lock
+    # manager can protect the whole source subtree. Serialized to its string
+    # value at the API/persistence edge (InputKind is a str enum).
+    input_kind: InputKind = InputKind.FILE
 
 
 class JobCreateRequest(BaseModel):
@@ -278,6 +305,19 @@ class RomzInfo(BaseModel):
     contained_name: str | None = None
     original_size: int | None = None
     ratio: str | None = None
+
+
+class Ps3IsoInfo(BaseModel):
+    """Information about a decrypted PS3 disc/JB folder (makeps3iso source)."""
+    file: str
+    size: int
+    size_display: str
+    format: str | None = None
+    extension: str
+    compressed: bool
+    compression_type: str | None = None
+    title: str | None = None
+    title_id: str | None = None
 
 
 class LayoutPreferences(BaseModel):

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -24,7 +24,7 @@ from services.archive import archive_service
 from services.job_manager import QueueBackpressureError, job_manager
 from services.romz import romz_service
 from services.lock_manager import lock_manager
-from services.tools import ModeKind, registry
+from services.tools import InputKind, ModeKind, registry
 from sse_starlette.sse import EventSourceResponse
 from utils.delete_plan import build_delete_plan, build_delete_snapshot
 from utils.path_utils import is_within_configured_volumes
@@ -221,6 +221,7 @@ class SkipReason(Enum):
     ROMZ_INVALID_ARCHIVE = "romz_invalid_archive"
     DOLPHIN_SAME_PATH = "dolphin_same_path"
     CHAIN_BAD_EXTENSION = "chain_bad_extension"
+    PS3_FOLDER_INVALID = "ps3_folder_invalid"
 
 
 class SkipFile(Exception):  # noqa: N818 - control-flow signal, not an error
@@ -302,7 +303,66 @@ _SKIP_HTTP: dict[SkipReason, tuple[int, str]] = {
         400,
         "cso_to_chd requires a .cso/.zso/.dax source",
     ),
+    SkipReason.PS3_FOLDER_INVALID: (
+        400,
+        "folder_to_iso requires a decrypted PS3 disc/JB folder "
+        "(a PS3_GAME/ root, plus PS3_DISC.SFB for disc rips)",
+    ),
 }
+
+
+async def _plan_directory_job(
+    file_path: str,
+    *,
+    mode: str,
+    output_dir: str | None,
+    duplicate_action: DuplicateAction,
+) -> JobPlan:
+    """Resolve a directory-input job (makeps3iso folder->iso) into a ``JobPlan``.
+
+    Delete-on-verify is not offered for directory modes (the tool's
+    ``supports_delete_on_verify`` is False and the route blocks it upstream), so
+    there is no delete snapshot here.
+    """
+    if not await run_in_threadpool(os.path.isdir, file_path):
+        raise SkipFile(SkipReason.FILE_NOT_FOUND)
+    # Registry-driven: the tool's accepts_directory runs its source-layout
+    # detector (PS3 disc/JB layout) off the event loop — no tool-identity branch.
+    accepts = await run_in_threadpool(
+        registry.for_mode(mode).accepts_directory, file_path,
+    )
+    if not accepts:
+        raise SkipFile(SkipReason.PS3_FOLDER_INVALID)
+
+    normalized = os.path.normpath(file_path)
+    display_filename = os.path.basename(normalized)
+    output_path = await run_in_threadpool(
+        _get_output_path, mode, normalized, output_dir,
+    )
+    base_output_path = output_path
+
+    output_exists, is_locked = check_output_conflicts(mode, output_path)
+    if output_exists or is_locked:
+        if duplicate_action == DuplicateAction.SKIP:
+            raise SkipFile(SkipReason.OUTPUT_EXISTS)
+        if duplicate_action == DuplicateAction.OVERWRITE:
+            if is_locked:
+                raise SkipFile(SkipReason.OUTPUT_LOCKED)
+        elif duplicate_action == DuplicateAction.RENAME:
+            output_path = get_unique_output_path(output_path)
+
+    allow_overwrite = (
+        duplicate_action == DuplicateAction.OVERWRITE and output_exists
+    )
+    return JobPlan(
+        file_path=file_path,
+        output_path=output_path,
+        base_output_path=base_output_path,
+        allow_overwrite=allow_overwrite,
+        display_filename=display_filename,
+        delete_snapshot=None,
+        priority=0,
+    )
 
 
 async def plan_job(
@@ -331,6 +391,18 @@ async def plan_job(
     is_cso = spec.tool_id == "cso"
     is_romz = spec.tool_id == "romz"
     is_chain = spec.tool_id == "chain"
+
+    # Directory-as-input mode (makeps3iso folder->iso): a folder, not a file with
+    # a suffix. Validate isdir + the tool's source-layout detector instead of
+    # isfile + an extension match, and derive the output / display name from the
+    # NORMALIZED basename (a trailing slash otherwise yields "" -> ".iso").
+    if InputKind.DIRECTORY in spec.input_kinds:
+        return await _plan_directory_job(
+            file_path,
+            mode=mode,
+            output_dir=output_dir,
+            duplicate_action=duplicate_action,
+        )
 
     archive_source_dir = None  # Directory where the archive is located (for output)
     output_path = None

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -222,6 +222,7 @@ class SkipReason(Enum):
     DOLPHIN_SAME_PATH = "dolphin_same_path"
     CHAIN_BAD_EXTENSION = "chain_bad_extension"
     PS3_FOLDER_INVALID = "ps3_folder_invalid"
+    PS3_OUTPUT_INSIDE_SOURCE = "ps3_output_inside_source"
 
 
 class SkipFile(Exception):  # noqa: N818 - control-flow signal, not an error
@@ -308,6 +309,11 @@ _SKIP_HTTP: dict[SkipReason, tuple[int, str]] = {
         "folder_to_iso requires a decrypted PS3 disc/JB folder "
         "(a PS3_GAME/ root, plus PS3_DISC.SFB for disc rips)",
     ),
+    SkipReason.PS3_OUTPUT_INSIDE_SOURCE: (
+        400,
+        "Output .iso would be written inside the source folder being packed; "
+        "choose an output directory outside the PS3 folder",
+    ),
 }
 
 
@@ -340,6 +346,16 @@ async def _plan_directory_job(
         _get_output_path, mode, normalized, output_dir,
     )
     base_output_path = output_path
+
+    # Refuse to write the ISO inside the very folder being packed: makeps3iso
+    # walks the source tree, so an output under it would be (partially) ingested
+    # into itself and corrupt the image. The default output is a sibling
+    # ("<folder>.iso"), so this only triggers when output_dir is set to the
+    # source folder or a descendant. (The lock manager's subtree protection
+    # guards against *other* jobs, not a job's own output.)
+    output_norm = os.path.normpath(output_path)
+    if output_norm == normalized or output_norm.startswith(normalized + os.sep):
+        raise SkipFile(SkipReason.PS3_OUTPUT_INSIDE_SOURCE)
 
     output_exists, is_locked = check_output_conflicts(mode, output_path)
     if output_exists or is_locked:

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -223,6 +223,7 @@ class SkipReason(Enum):
     CHAIN_BAD_EXTENSION = "chain_bad_extension"
     PS3_FOLDER_INVALID = "ps3_folder_invalid"
     PS3_OUTPUT_INSIDE_SOURCE = "ps3_output_inside_source"
+    PS3_OUTPUT_OUTSIDE_VOLUMES = "ps3_output_outside_volumes"
 
 
 class SkipFile(Exception):  # noqa: N818 - control-flow signal, not an error
@@ -314,6 +315,11 @@ _SKIP_HTTP: dict[SkipReason, tuple[int, str]] = {
         "Output .iso would be written inside the source folder being packed; "
         "choose an output directory outside the PS3 folder",
     ),
+    SkipReason.PS3_OUTPUT_OUTSIDE_VOLUMES: (
+        400,
+        "Default output .iso would land outside the configured volumes "
+        "(the PS3 folder is a volume root); choose an in-volume output directory",
+    ),
 }
 
 
@@ -352,10 +358,21 @@ async def _plan_directory_job(
     # into itself and corrupt the image. The default output is a sibling
     # ("<folder>.iso"), so this only triggers when output_dir is set to the
     # source folder or a descendant. (The lock manager's subtree protection
-    # guards against *other* jobs, not a job's own output.)
-    output_norm = os.path.normpath(output_path)
-    if output_norm == normalized or output_norm.startswith(normalized + os.sep):
+    # guards against *other* jobs, not a job's own output.) Resolve symlinks
+    # first so a symlinked output dir into the tree can't slip past this.
+    output_real = await run_in_threadpool(os.path.realpath, output_path)
+    source_real = await run_in_threadpool(os.path.realpath, file_path)
+    if output_real == source_real or output_real.startswith(source_real + os.sep):
         raise SkipFile(SkipReason.PS3_OUTPUT_INSIDE_SOURCE)
+
+    # The route only validates a user-supplied output_dir; the *derived* sibling
+    # output is unchecked. When the PS3 folder is itself a volume root, that
+    # sibling lands outside all configured volumes, so enforce the same volume
+    # boundary the rest of the API treats as the access edge.
+    if not await run_in_threadpool(
+        is_within_configured_volumes, output_path, treat_archives=False,
+    ):
+        raise SkipFile(SkipReason.PS3_OUTPUT_OUTSIDE_VOLUMES)
 
     output_exists, is_locked = check_output_conflicts(mode, output_path)
     if output_exists or is_locked:

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -57,6 +57,28 @@ def _detect_file_outputs(
     return convertible_by, outputs, by_tool
 
 
+def _detect_directory_outputs(
+    item_path: str,
+) -> tuple[list[str], list[OutputStatus]]:
+    """Registry-driven convertibility + output detection for a directory row.
+
+    The directory analogue of :func:`_detect_file_outputs`: ask the registry
+    which tools accept this folder as their input unit (``tools_for_directory``
+    runs each tool's source-layout detector) and collect their sibling outputs
+    (``<folder>.iso``). Cheap but does disk I/O (a stat for ``PS3_GAME/`` and a
+    small SFO header read) — call it inside the threadpool scan, never on the
+    event loop.
+    """
+    convertible_by: list[str] = []
+    outputs: list[OutputStatus] = []
+    for tool in registry.tools_for_directory(item_path):
+        convertible_by.append(tool.id)
+        status = tool.detect_output(item_path)
+        if status is not None:
+            outputs.append(status)
+    return convertible_by, outputs
+
+
 def _detect_archive_member_outputs(
     entry: dict, archive_dir: str,
 ) -> tuple[str, list[str], list[OutputStatus], dict[str, OutputStatus]]:
@@ -204,6 +226,19 @@ async def _assert_path_not_in_use(path: str, *, is_dir: bool = False) -> None:
             status_code=409, detail=f"Path is in use by active job {job_id}",
         )
 
+    # Also reject when the target is a descendant of an active directory job's
+    # source folder (makeps3iso packing the whole subtree). The candidate-path
+    # match above can't see that containment, so delegate to the registry-aware
+    # central lookup which knows each job's input_kind.
+    blocking = await run_in_threadpool(
+        job_manager.find_active_job_for_path, path, is_dir=is_dir,
+    )
+    if blocking is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Path is in use by active job {blocking.id}",
+        )
+
 
 @router.get("/volumes", response_model=list[Volume])
 async def list_volumes():
@@ -252,8 +287,21 @@ async def list_files(
 
                 try:
                     if os.path.isdir(item_path):
+                        # Annotate a convertible folder (a PS3 disc/JB folder
+                        # makeps3iso can pack) just like a file row, so the
+                        # browser can badge + select it. A plain folder gets
+                        # empty lists and stays navigation-only.
+                        dir_convertible_by, dir_outputs = (
+                            _detect_directory_outputs(item_path)
+                        )
                         entries.append(
-                            FileEntry(name=item, path=item_path, type="directory"),
+                            FileEntry(
+                                name=item,
+                                path=item_path,
+                                type="directory",
+                                convertible_by=dir_convertible_by,
+                                outputs=dir_outputs,
+                            ),
                         )
                     elif os.path.isfile(item_path):
                         size = os.path.getsize(item_path)
@@ -410,7 +458,34 @@ async def search_files(
 
                     try:
                         if os.path.isdir(item_path):
-                            if recursive_scan and not os.path.islink(item_path):
+                            # A convertible folder (PS3 disc/JB folder) is itself
+                            # a job unit: emit it as a selectable directory row so
+                            # it's discoverable in search / batch-select, and do
+                            # NOT recurse past it (its inner files aren't separate
+                            # jobs). scan_directory alone would leave it invisible
+                            # to recursive search. A plain folder still recurses.
+                            dir_convertible_by, dir_outputs = (
+                                _detect_directory_outputs(item_path)
+                            )
+                            if dir_convertible_by:
+                                files.append(
+                                    {
+                                        "name": item,
+                                        "path": item_path,
+                                        "type": "directory",
+                                        "size": None,
+                                        "extension": "",
+                                        "chd_path": None,
+                                        "in_archive": False,
+                                        "convertible_by": dir_convertible_by,
+                                        "outputs": dir_outputs,
+                                        "verifiable_by": [],
+                                        **_legacy_output_fields(
+                                            dir_convertible_by, {},
+                                        ),
+                                    },
+                                )
+                            elif recursive_scan and not os.path.islink(item_path):
                                 _scan(item_path)
                         elif os.path.isfile(item_path):
                             is_archive = ext in ARCHIVE_EXTENSIONS

--- a/app/services/disc_id.py
+++ b/app/services/disc_id.py
@@ -193,6 +193,27 @@ def _list_dir(f, lba: int, size: int) -> list[tuple[str, int, int, bool]]:
     return entries
 
 
+def read_iso_file(iso_path: str, path_parts: list[str]) -> Optional[bytes]:
+    """Read one file's bytes from an ISO 9660 image by path, or ``None``.
+
+    The shared, format-only ISO 9660 path lookup: open the image, walk the PVD
+    root directory to ``path_parts`` (e.g. ``["PS3_GAME", "PARAM.SFO"]``), and
+    return the file bytes. Callers that need a specific embedded file from a
+    built ISO (PS3 ``TITLE_ID`` readback in ``services.ps3``) reuse this rather
+    than re-implementing the ISO 9660 walk, per the repo's "modularity is key"
+    rule. Returns ``None`` for a non-ISO / unreadable image or a missing path.
+    """
+    try:
+        with open(iso_path, "rb") as f:
+            pvd = _read_pvd(f)
+            if not pvd:
+                return None
+            root_lba, root_size = _pvd_root_dir(pvd)
+            return _find_file(f, root_lba, root_size, path_parts)
+    except OSError:
+        return None
+
+
 def _find_file(f, root_lba: int, root_size: int, path_parts: list[str]) -> Optional[bytes]:
     """
     Walk an ISO 9660 directory tree and return the raw bytes of the file at

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -85,6 +85,9 @@ class JobManager:
         self._subscribers: Dict[str, List[asyncio.Queue]] = {}
         self._cancelled: Set[str] = set()
         self._cancel_events: Dict[str, asyncio.Event] = {}
+        # Strong refs to in-flight requeue tasks so the event loop can't
+        # garbage-collect them mid-`asyncio.sleep` (see _schedule_dir_lock_requeue).
+        self._requeue_tasks: Set[asyncio.Task] = set()
         self._delete_plans: Dict[str, Dict[str, object]] = {}
         self._last_progress_at: Dict[str, float] = {}
         self._last_progress_log_at: Dict[str, float] = {}
@@ -632,7 +635,11 @@ class JobManager:
             self._queue.put_nowait((ticket, job_id))
             self._last_progress_at[job_id] = time.monotonic()
 
-        asyncio.create_task(_requeue())
+        # Keep a strong reference until the task finishes; a bare create_task()
+        # can be collected while still awaiting the sleep.
+        task = asyncio.create_task(_requeue())
+        self._requeue_tasks.add(task)
+        task.add_done_callback(self._requeue_tasks.discard)
 
     def _track_candidate_paths(self, file_path: str) -> List[str]:
         if "::" in file_path:

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -566,6 +566,74 @@ class JobManager:
             return False
         return self._is_descendant(target, job_dir)
 
+    def _blocked_by_dir_lock(self, job: ConversionJob) -> bool:
+        """Whether this job's input/output is inside a directory subtree another
+        job has locked (a makeps3iso folder->iso job packing that tree).
+
+        Such a conflict is **transient** — it clears when the folder job
+        finishes — so the dispatcher waits and re-queues the job rather than
+        failing it, exactly like a job waiting its turn in the queue.
+        """
+        if job.input_kind == InputKind.DIRECTORY:
+            return lock_manager.dir_lock_would_conflict(job.file_path)
+        paths = [job.output_path]
+        if "::" not in job.file_path:
+            paths.append(job.file_path)
+        return any(lock_manager.is_within_locked_dir(p) for p in paths if p)
+
+    async def _defer_blocked_job(self, job_id: str, *, output_lock_held: bool) -> None:
+        """Release a job blocked by a directory subtree lock and re-queue it.
+
+        The job waits its turn in the queue and is re-dispatched once the folder
+        job releases the lock — the same outcome as any queued job, never a
+        failure. Releases the held slot (and the output lock when one was taken)
+        so the folder job and others can proceed meanwhile.
+        """
+        job = self.jobs.get(job_id)
+        if output_lock_held and job is not None and job.output_path:
+            lock_manager.release_lock(job.output_path)
+        if job_id in self._cancel_events:
+            del self._cancel_events[job_id]
+        concurrency_manager.release(job_id)
+        if job is not None:
+            job.message = "Waiting for an in-progress folder conversion to finish..."
+            await self._notify_subscribers(
+                job_id,
+                {
+                    "type": "status",
+                    "job_id": job_id,
+                    "status": job.status.value,
+                    "progress": job.progress,
+                    "message": job.message,
+                },
+            )
+        self._schedule_dir_lock_requeue(job_id)
+
+    def _schedule_dir_lock_requeue(self, job_id: str, delay: float = 2.0) -> None:
+        """Re-dispatch a deferred job after a short delay so it retries once the
+        blocking folder job has had a chance to finish."""
+
+        async def _requeue() -> None:
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return
+            job = self.jobs.get(job_id)
+            if job is None or job_id in self._cancelled:
+                return
+            if job.status in (
+                JobStatus.COMPLETED,
+                JobStatus.FAILED,
+                JobStatus.CANCELLED,
+            ):
+                return
+            job.status = JobStatus.QUEUED
+            ticket = concurrency_manager.reserve_ticket(job_id)
+            self._queue.put_nowait((ticket, job_id))
+            self._last_progress_at[job_id] = time.monotonic()
+
+        asyncio.create_task(_requeue())
+
     def _track_candidate_paths(self, file_path: str) -> List[str]:
         if "::" in file_path:
             return []
@@ -1400,11 +1468,23 @@ class JobManager:
             await self._prune_jobs(exclude_id=job_id)
             return
 
+        # If this job's path is inside a folder another job is currently packing
+        # (makeps3iso folder->iso), don't fail — wait in the queue and retry once
+        # that folder job releases its subtree lock, like any queued job.
+        if await run_in_threadpool(self._blocked_by_dir_lock, job):
+            await self._defer_blocked_job(job_id, output_lock_held=False)
+            return
+
         # Try to acquire lock for the output file (prevents race conditions)
         lock_acquired = lock_manager.acquire_lock(
             job.output_path, allow_existing=job.allow_overwrite
         )
         if not lock_acquired:
+            # A transient block by a folder->iso subtree lock (racing the
+            # precheck) waits & re-queues rather than failing.
+            if await run_in_threadpool(self._blocked_by_dir_lock, job):
+                await self._defer_blocked_job(job_id, output_lock_held=False)
+                return
             # Could not acquire lock - either file exists or is being converted
             # Check current status to provide better error message
             file_exists, is_locked = lock_manager.check_file_status(job.output_path)
@@ -1440,19 +1520,10 @@ class JobManager:
                 lock_manager.acquire_dir_lock, job.file_path,
             )
             if not dir_lock_acquired:
-                lock_manager.release_lock(job.output_path)
-                job.status = JobStatus.FAILED
-                job.error_message = "Source folder is in use by another active job"
-                job.completed_at = datetime.now(timezone.utc)
-                await self._notify_subscribers(
-                    job_id,
-                    {"type": "error", "job_id": job_id, "error": job.error_message},
-                )
-                if job_id in self._cancel_events:
-                    del self._cancel_events[job_id]
-                concurrency_manager.release(job_id)
-                await self._cleanup_temp_dir(job)
-                await self._prune_jobs(exclude_id=job_id)
+                # Another job is operating inside this folder; wait in the queue
+                # and retry rather than failing (releases the output lock taken
+                # just above).
+                await self._defer_blocked_job(job_id, output_lock_held=True)
                 return
 
         job.status = JobStatus.PROCESSING

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Optional, Set, Tuple
 
 from config import settings
 from fastapi.concurrency import run_in_threadpool
-from models import ConversionJob, ConversionMode, JobStatus
+from models import ConversionJob, ConversionMode, InputKind, JobStatus
 from services.archive import archive_service
 from services.chd_metadata_store import chd_metadata_store
 from services.chdman import ConversionCancelled, chdman_service
@@ -166,6 +166,21 @@ class JobManager:
                     "Output path matches input; refusing to overwrite source"
                 )
 
+        # Carry the mode's input kind end-to-end so the pipeline skips the
+        # archive-extract / file-only assumptions for a directory job and the
+        # lock manager can protect the whole source subtree. Derived from the
+        # registry spec (every conversion mode is registered; external jobs
+        # bypass this path), so FILE/DIRECTORY can't drift via a typo.
+        try:
+            mode_spec = registry.spec(mode.value)
+            input_kind = (
+                InputKind.DIRECTORY
+                if InputKind.DIRECTORY in mode_spec.input_kinds
+                else InputKind.FILE
+            )
+        except KeyError:
+            input_kind = InputKind.FILE
+
         job = ConversionJob(
             id=job_id,
             file_path=file_path,
@@ -178,6 +193,7 @@ class JobManager:
             allow_overwrite=allow_overwrite,
             compression=compression,
             delete_on_verify=delete_on_verify,
+            input_kind=input_kind,
         )
 
         self.jobs[job_id] = job
@@ -524,6 +540,32 @@ class JobManager:
         except (OSError, RuntimeError):
             return None
 
+    @staticmethod
+    def _is_descendant(target: Path, ancestor: Path) -> bool:
+        """Whether ``target`` is at or below ``ancestor`` (pure path prefix)."""
+        try:
+            target.relative_to(ancestor)
+            return True
+        except ValueError:
+            return False
+
+    def _directory_job_blocks(self, job: ConversionJob, target: Path) -> bool:
+        """True when ``target`` lives inside an active directory job's source.
+
+        A directory job (makeps3iso folder->iso) is packaging its whole source
+        subtree, so a per-file job / rename / delete on any path *under* that
+        folder — e.g. ``<folder>/PS3_GAME/PARAM.SFO`` while ``<folder>`` is being
+        packed — would corrupt the in-flight ISO. The bare path-hash lock can't
+        see that containment (a child hashes to a different key), so guard it
+        here. Cheap: a normalized ``Path`` prefix check, no extra disk I/O.
+        """
+        if job.input_kind != InputKind.DIRECTORY:
+            return False
+        job_dir = self._normalize_path(job.file_path)
+        if job_dir is None:
+            return False
+        return self._is_descendant(target, job_dir)
+
     def _track_candidate_paths(self, file_path: str) -> List[str]:
         if "::" in file_path:
             return []
@@ -570,6 +612,10 @@ class JobManager:
         for job in self.jobs.values():
             if job.status not in (JobStatus.QUEUED, JobStatus.PROCESSING):
                 continue
+            # A directory job protects its whole subtree against concurrent
+            # mutation: a target *inside* the in-flight folder is in use.
+            if self._directory_job_blocks(job, target):
+                return job
             for candidate in self._candidate_paths(job):
                 cand_path = self._normalize_path(candidate)
                 if cand_path is None:
@@ -596,6 +642,10 @@ class JobManager:
                 continue
             if job.mode in _EXTERNAL_JOB_MODES:
                 continue
+            # Reject a delete that targets a path inside another active
+            # directory job's source folder (its whole subtree is in use).
+            if self._directory_job_blocks(job, target):
+                return True
             for candidate in self._candidate_paths(job):
                 cand_path = self._normalize_path(candidate)
                 if cand_path is None:

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1429,6 +1429,32 @@ class JobManager:
             await self._prune_jobs(exclude_id=job_id)
             return
 
+        # A directory-input job (makeps3iso folder->iso) additionally locks its
+        # whole source subtree, so any concurrent per-file job / rename / delete
+        # whose path falls inside the folder contends on the lock instead of
+        # corrupting the in-flight ISO. A conflict here means another job is
+        # already operating inside the folder; fail like an output collision.
+        dir_lock_acquired = False
+        if job.input_kind == InputKind.DIRECTORY:
+            dir_lock_acquired = await run_in_threadpool(
+                lock_manager.acquire_dir_lock, job.file_path,
+            )
+            if not dir_lock_acquired:
+                lock_manager.release_lock(job.output_path)
+                job.status = JobStatus.FAILED
+                job.error_message = "Source folder is in use by another active job"
+                job.completed_at = datetime.now(timezone.utc)
+                await self._notify_subscribers(
+                    job_id,
+                    {"type": "error", "job_id": job_id, "error": job.error_message},
+                )
+                if job_id in self._cancel_events:
+                    del self._cancel_events[job_id]
+                concurrency_manager.release(job_id)
+                await self._cleanup_temp_dir(job)
+                await self._prune_jobs(exclude_id=job_id)
+                return
+
         job.status = JobStatus.PROCESSING
         job.started_at = datetime.now(timezone.utc)
         processing_now = sum(
@@ -1847,6 +1873,9 @@ class JobManager:
             # Only release lock if we acquired it
             if lock_acquired:
                 lock_manager.release_lock(job.output_path)
+            # Release the directory subtree lock held by a folder->iso job.
+            if dir_lock_acquired:
+                lock_manager.release_dir_lock(job.file_path)
 
             concurrency_manager.release(job_id)
 

--- a/app/services/lock_manager.py
+++ b/app/services/lock_manager.py
@@ -45,20 +45,70 @@ class LockManager:
 
     @staticmethod
     def _path_within(child: str, parent: str) -> bool:
-        """True when normalized ``child`` is ``parent`` or nested under it."""
+        """True when resolved ``child`` is ``parent`` or nested under it."""
         if child == parent:
             return True
         return child.startswith(parent + os.sep)
 
-    def _within_locked_dir_locked(self, normalized_path: str) -> bool:
-        """Whether ``normalized_path`` falls inside a locked directory subtree.
+    @staticmethod
+    def _resolve(path: str) -> str:
+        """Resolve symlinks (and normalize) so subtree containment can't be
+        bypassed by reaching a locked directory through a symlinked path
+        (e.g. ``/vol/link_to_Game/PS3_GAME/...`` vs the locked ``/vol/Game``).
+        ``realpath`` resolves the existing ancestors of a not-yet-created output
+        and leaves the leaf lexical, which is exactly what containment needs.
+        """
+        try:
+            return os.path.realpath(path)
+        except OSError:
+            return os.path.normpath(path)
 
-        Caller must hold ``self._lock_mutex``.
+    def _within_locked_dir_locked(self, resolved_path: str) -> bool:
+        """Whether an already-resolved path falls inside a locked dir subtree.
+
+        Caller must hold ``self._lock_mutex`` and pass a ``_resolve``-d path.
+        ``self._dir_locks`` entries are stored resolved.
         """
         return any(
-            self._path_within(normalized_path, locked_dir)
+            self._path_within(resolved_path, locked_dir)
             for locked_dir in self._dir_locks
         )
+
+    def _dir_overlaps_locked(self, resolved: str) -> bool:
+        """Whether a directory subtree at resolved path overlaps any lock.
+
+        Caller must hold ``self._lock_mutex``. True when the directory itself is
+        locked, a locked output file resolves inside it, or another directory
+        lock nests with it in either direction.
+        """
+        if resolved in self._dir_locks:
+            return True
+        if any(self._path_within(self._resolve(p), resolved) for p in self._locks):
+            return True
+        return any(
+            self._path_within(resolved, d) or self._path_within(d, resolved)
+            for d in self._dir_locks
+        )
+
+    def is_within_locked_dir(self, path: str) -> bool:
+        """Whether ``path`` falls inside a directory subtree another job locked.
+
+        The read-only companion to :meth:`acquire_lock`'s subtree check: lets the
+        job pipeline tell a *transient* conflict (an active folder->iso job is
+        packing a tree this path lives in — wait and retry) apart from a
+        permanent one (the output already exists — fail). Resolves symlinks.
+        """
+        with self._lock_mutex:
+            if not self._dir_locks:
+                return False
+            return self._within_locked_dir_locked(self._resolve(path))
+
+    def dir_lock_would_conflict(self, dir_path: str) -> bool:
+        """Whether :meth:`acquire_dir_lock` for ``dir_path`` would currently
+        conflict with an existing lock (without acquiring anything)."""
+        resolved = self._resolve(dir_path)
+        with self._lock_mutex:
+            return self._dir_overlaps_locked(resolved)
 
     def _lock_file_path(self, normalized_path: str) -> str:
         # Use a stable hash to avoid path length issues and keep locks in /tmp.
@@ -154,10 +204,11 @@ class LockManager:
         """
         normalized_path = os.path.normpath(output_path)
         with self._lock_mutex:
-            is_locked = (
-                normalized_path in self._locks
-                or self._within_locked_dir_locked(normalized_path)
-            )
+            is_locked = normalized_path in self._locks
+            # Resolve symlinks only when a directory subtree lock is actually
+            # held (the uncommon case), to keep the hot listing path cheap.
+            if not is_locked and self._dir_locks:
+                is_locked = self._within_locked_dir_locked(self._resolve(output_path))
             file_exists = os.path.isfile(normalized_path)
 
         if is_locked:
@@ -236,8 +287,11 @@ class LockManager:
 
             # Reject a target that lives inside a directory subtree another job
             # has locked (makeps3iso packing the folder): the per-file job
-            # contends here just like an exact output collision.
-            if self._within_locked_dir_locked(normalized_path):
+            # contends here just like an exact output collision. Resolve
+            # symlinks so a symlinked path into the folder can't slip through.
+            if self._dir_locks and self._within_locked_dir_locked(
+                self._resolve(output_path)
+            ):
                 return False
 
             # Try to create a lock file
@@ -352,18 +406,11 @@ class LockManager:
         directory lock (in either nesting direction), or an external process
         already holds the directory's lock file.
         """
-        normalized = os.path.normpath(dir_path)
+        # Store and compare directory locks resolved, so containment holds
+        # through symlinks.
+        normalized = self._resolve(dir_path)
         with self._lock_mutex:
-            if normalized in self._dir_locks:
-                return False
-            # A locked output file already living inside this subtree.
-            if any(self._path_within(p, normalized) for p in self._locks):
-                return False
-            # Another directory lock overlapping in either direction.
-            if any(
-                self._path_within(normalized, d) or self._path_within(d, normalized)
-                for d in self._dir_locks
-            ):
+            if self._dir_overlaps_locked(normalized):
                 return False
 
             lock_file_path = self._lock_file_path(normalized)
@@ -403,7 +450,7 @@ class LockManager:
 
     def release_dir_lock(self, dir_path: str):
         """Release a directory subtree lock acquired via :meth:`acquire_dir_lock`."""
-        normalized = os.path.normpath(dir_path)
+        normalized = self._resolve(dir_path)
         with self._lock_mutex:
             if normalized not in self._dir_locks:
                 return

--- a/app/services/lock_manager.py
+++ b/app/services/lock_manager.py
@@ -30,9 +30,35 @@ class LockManager:
         # to address security concerns about predictable temp directories
         os.makedirs(self._lock_dir, mode=0o700, exist_ok=True)
         self._locks: set[str] = set()
+        # Directory subtree locks: a directory-input job (makeps3iso
+        # folder->iso) locks its whole source tree here so a concurrent
+        # per-file job / rename / delete whose path falls *inside* the folder
+        # contends on the lock — exactly like an output-path collision — instead
+        # of mutating the tree while it's being packed. Keyed by the normalized
+        # directory path; containment is checked in-process (the documented
+        # MAX_CONCURRENT_JOBS concurrency all lives in this one process).
+        self._dir_locks: set[str] = set()
         self._lock_mutex = threading.Lock()
         self._lock_handles = {}
+        self._dir_lock_handles = {}
         self._cleanup_stale_locks()
+
+    @staticmethod
+    def _path_within(child: str, parent: str) -> bool:
+        """True when normalized ``child`` is ``parent`` or nested under it."""
+        if child == parent:
+            return True
+        return child.startswith(parent + os.sep)
+
+    def _within_locked_dir_locked(self, normalized_path: str) -> bool:
+        """Whether ``normalized_path`` falls inside a locked directory subtree.
+
+        Caller must hold ``self._lock_mutex``.
+        """
+        return any(
+            self._path_within(normalized_path, locked_dir)
+            for locked_dir in self._dir_locks
+        )
 
     def _lock_file_path(self, normalized_path: str) -> str:
         # Use a stable hash to avoid path length issues and keep locks in /tmp.
@@ -128,7 +154,10 @@ class LockManager:
         """
         normalized_path = os.path.normpath(output_path)
         with self._lock_mutex:
-            is_locked = normalized_path in self._locks
+            is_locked = (
+                normalized_path in self._locks
+                or self._within_locked_dir_locked(normalized_path)
+            )
             file_exists = os.path.isfile(normalized_path)
 
         if is_locked:
@@ -203,6 +232,12 @@ class LockManager:
         with self._lock_mutex:
             # Check if already locked by another job
             if normalized_path in self._locks:
+                return False
+
+            # Reject a target that lives inside a directory subtree another job
+            # has locked (makeps3iso packing the folder): the per-file job
+            # contends here just like an exact output collision.
+            if self._within_locked_dir_locked(normalized_path):
                 return False
 
             # Try to create a lock file
@@ -307,9 +342,93 @@ class LockManager:
                     except Exception:
                         logger.error("Failed to remove lock file %s", lock_file_path, exc_info=True)
 
+    def acquire_dir_lock(self, dir_path: str) -> bool:
+        """Acquire an exclusive lock over a directory and its entire subtree.
+
+        Used by a directory-input job (makeps3iso folder->iso) so any concurrent
+        operation whose path falls inside the folder contends on this lock
+        instead of mutating the tree while it is being packed. Fails when the
+        subtree overlaps any existing file lock (a locked output inside it) or
+        directory lock (in either nesting direction), or an external process
+        already holds the directory's lock file.
+        """
+        normalized = os.path.normpath(dir_path)
+        with self._lock_mutex:
+            if normalized in self._dir_locks:
+                return False
+            # A locked output file already living inside this subtree.
+            if any(self._path_within(p, normalized) for p in self._locks):
+                return False
+            # Another directory lock overlapping in either direction.
+            if any(
+                self._path_within(normalized, d) or self._path_within(d, normalized)
+                for d in self._dir_locks
+            ):
+                return False
+
+            lock_file_path = self._lock_file_path(normalized)
+            lock_dir = os.path.dirname(lock_file_path)
+            if lock_dir:
+                os.makedirs(lock_dir, exist_ok=True)
+            lock_handle = None
+            try:
+                with contextlib.ExitStack() as stack:
+                    # Binary mode: flock-only handle, no text is read or written.
+                    lock_handle = stack.enter_context(open(lock_file_path, "ab"))
+                    try:
+                        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    except BlockingIOError:
+                        # Held by another process packing the same folder.
+                        return False
+                    except OSError:
+                        logger.error(
+                            "Failed to acquire dir lock for %s", normalized, exc_info=True,
+                        )
+                        return False
+                    self._dir_locks.add(normalized)
+                    self._dir_lock_handles[normalized] = lock_handle
+                    # Keep the handle open for the job lifecycle.
+                    stack.pop_all()
+                    return True
+            except Exception:
+                if lock_handle is not None:
+                    self._dir_lock_handles.pop(normalized, None)
+                    self._dir_locks.discard(normalized)
+                    with contextlib.suppress(Exception):
+                        lock_handle.close()
+                logger.error(
+                    "Failed to acquire dir lock for %s", normalized, exc_info=True,
+                )
+                return False
+
+    def release_dir_lock(self, dir_path: str):
+        """Release a directory subtree lock acquired via :meth:`acquire_dir_lock`."""
+        normalized = os.path.normpath(dir_path)
+        with self._lock_mutex:
+            if normalized not in self._dir_locks:
+                return
+            self._dir_locks.remove(normalized)
+            handle = self._dir_lock_handles.pop(normalized, None)
+            if handle is not None:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                    handle.close()
+                except Exception:
+                    logger.error(
+                        "Error releasing dir lock for %s", normalized, exc_info=True,
+                    )
+                lock_file_path = self._lock_file_path(normalized)
+                try:
+                    if os.path.exists(lock_file_path):
+                        os.remove(lock_file_path)
+                except Exception:
+                    logger.error(
+                        "Failed to remove dir lock file %s", lock_file_path, exc_info=True,
+                    )
+
     def stats(self) -> dict:
         with self._lock_mutex:
-            return {"locks": len(self._locks)}
+            return {"locks": len(self._locks), "dir_locks": len(self._dir_locks)}
 
 
 lock_manager = LockManager()

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -129,14 +129,18 @@ class MakePs3IsoService:
                 if update.get("progress", 0) >= 100:
                     continue
                 yield update
-        except Exception:
-            # makeps3iso writes the .iso in place, so a cancel / non-zero exit /
-            # stall leaves a partial behind. Remove it so a retry isn't blocked
-            # by (or silently trusts) a truncated image. (run() does not clean
-            # the output itself.)
-            if await asyncio.to_thread(os.path.exists, output_path):
-                with contextlib.suppress(OSError):
-                    await asyncio.to_thread(os.remove, output_path)
+        except BaseException:
+            # makeps3iso writes the .iso in place, so any abnormal exit leaves a
+            # partial behind: a non-zero exit / stall (RuntimeError), a cancel
+            # (ConversionCancelled), AND task cancellation / generator close,
+            # which raise the BaseException-derived CancelledError / GeneratorExit
+            # — caught here too so the partial is never orphaned. Remove it
+            # *synchronously* (a single local unlink): awaiting during a
+            # cancellation could be re-cancelled and skip the cleanup. Re-raise so
+            # cancellation semantics are preserved. (run() does not clean the
+            # output itself.) A missing file raises OSError, which is suppressed.
+            with contextlib.suppress(OSError):
+                os.remove(output_path)
             raise
 
         message = await asyncio.to_thread(

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -1,0 +1,229 @@
+"""Wrapper for ``makeps3iso`` (https://github.com/bucanero/ps3iso-utils).
+
+makeps3iso packages an already-decrypted PS3 disc/JB folder (a ``PS3_GAME/``
+root, plus ``PS3_DISC.SFB`` for disc rips) into a single ``.iso`` that RPCS3
+mounts directly. Decryption and keys are out of scope — this only repackages a
+folder the user already decrypted.
+
+This is the first **directory-as-input** tool: its unit of work is a folder, not
+a file with a suffix, so it relies on the ``services.ps3`` source-layout detector
+(``ToolPlugin.accepts_directory``) instead of an extension match.
+
+CLI: ``makeps3iso <input_folder> <output.iso>`` (a ``-s`` flag would split the
+output at 4 GB for FAT32; we always emit a single ``.iso`` — target volumes are
+ext4/NTFS/exFAT). makeps3iso has no native verify, so after a successful build
+the service does a light **PARAM.SFO ``TITLE_ID`` readback** from the produced
+ISO (reusing ``services.ps3`` + the shared ISO 9660 reader) and confirms it
+matches the source folder. The readback is advisory: a mismatch / unreadable
+header logs a warning but does not fail the job (and never deletes the curated
+source folder — ``supports_delete_on_verify`` is ``False``).
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import re
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+from config import settings
+from logging_setup import get_logger
+from services import ps3
+from services.subprocess_runner import (
+    ConversionCancelled,
+    SubprocessRunner,
+    ioprio_prefix,
+)
+
+# SubprocessRunner "owner" for the shared priority/timeout policy. An optional
+# COMPRESSATORIUM_MAKEPS3ISO_* override takes precedence over the tool-neutral
+# COMPRESSATORIUM_TOOL_* default (see services/subprocess_runner.py).
+_OWNER = "makeps3iso"
+
+# makeps3iso draws a percentage as it writes the ISO; pull the last "NN%" token
+# off a line. When a build emits no parseable percentage the SubprocessRunner
+# falls back to output-file growth for stall detection, so progress just holds
+# at its last value until the final 100% — it never false-stalls.
+_PROGRESS_RE = re.compile(r"(\d{1,3})\s*%")
+
+logger = get_logger("makeps3iso")
+
+
+class MakePs3IsoService:
+    """Wrapper for the makeps3iso binary."""
+
+    def __init__(self) -> None:
+        self.makeps3iso_path = settings.makeps3iso_path
+        self._runner = SubprocessRunner(owner=_OWNER)
+
+    # ----- command ----------------------------------------------------------
+
+    def _build_command(self, folder: str, output_path: str) -> list[str]:
+        cmd = [self.makeps3iso_path, folder, output_path]
+        # run() applies nice via preexec but not ionice, so wrap with the shared
+        # ionice prefix here (mirrors chdman) — packing an ISO is I/O-heavy.
+        prefix = ioprio_prefix(self._runner.owner)
+        return prefix + cmd if prefix else cmd
+
+    def _parse_progress(self, line: str) -> int | None:
+        match = None
+        for match in _PROGRESS_RE.finditer(line):
+            pass
+        if match is None:
+            return None
+        value = int(match.group(1))
+        return value if 0 <= value <= 100 else None
+
+    def active_pids(self) -> list[int]:
+        return self._runner.active_pids()
+
+    # ----- output paths -----------------------------------------------------
+
+    @staticmethod
+    def get_output_path(
+        input_path: str,
+        output_dir: str | None = None,
+        *,
+        treat_as_stem: bool = False,  # noqa: ARG004 - interface parity
+    ) -> str:
+        """Output ``.iso`` path for a folder input.
+
+        Derived from the folder's **normalized basename**, not a suffix swap: a
+        trailing slash would make ``os.path.basename("/a/MyGame/")`` return
+        ``""`` and yield an invalid ``.../MyGame/.iso``. ``treat_as_stem`` is
+        accepted only for interface parity with the file-based tools (a folder
+        never arrives as a flattened archive member).
+        """
+        normalized = os.path.normpath(input_path)
+        filename = f"{os.path.basename(normalized)}.iso"
+        if output_dir:
+            return str(Path(output_dir) / filename)
+        return str(Path(normalized).parent / filename)
+
+    # ----- convert ----------------------------------------------------------
+
+    async def convert(
+        self,
+        input_path: str,
+        output_path: str,
+        mode: str = "folder_to_iso",  # noqa: ARG002 - single-mode tool
+        *,
+        compression: str | None = None,  # noqa: ARG002 - no compression knob
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncGenerator[dict, None]:
+        cmd = self._build_command(input_path, output_path)
+        try:
+            async for update in self._runner.run(
+                cmd,
+                input_path=input_path,
+                output_path=output_path,
+                parse_progress=self._parse_progress,
+                cancel_event=cancel_event,
+                fail_label="makeps3iso",
+                complete_message="ISO build complete",
+            ):
+                # Hold back the runner's terminal 100% so the readback message
+                # is the final update the job records.
+                if update.get("progress", 0) >= 100:
+                    continue
+                yield update
+        except Exception:
+            # makeps3iso writes the .iso in place, so a cancel / non-zero exit /
+            # stall leaves a partial behind. Remove it so a retry isn't blocked
+            # by (or silently trusts) a truncated image. (run() does not clean
+            # the output itself.)
+            if await asyncio.to_thread(os.path.exists, output_path):
+                with contextlib.suppress(OSError):
+                    await asyncio.to_thread(os.remove, output_path)
+            raise
+
+        message = await asyncio.to_thread(
+            self._readback_message, input_path, output_path,
+        )
+        yield {"progress": 100, "message": message}
+
+    @staticmethod
+    def _readback_message(folder: str, iso_path: str) -> str:
+        """Light PARAM.SFO TITLE_ID readback; advisory, never fatal."""
+        try:
+            source_id = ps3.ps3_title_id(folder)
+            built_id = ps3.ps3_iso_title_id(iso_path)
+        except Exception as exc:  # never let the readback fail a good build
+            logger.debug("makeps3iso readback skipped for %s: %s", iso_path, exc)
+            return "ISO build complete"
+        if source_id and built_id:
+            if source_id == built_id:
+                return f"ISO build complete (verified TITLE_ID {built_id})"
+            logger.warning(
+                "makeps3iso TITLE_ID mismatch for %s: source=%s built=%s",
+                iso_path, source_id, built_id,
+            )
+            return "ISO build complete (warning: TITLE_ID mismatch)"
+        if not built_id:
+            logger.warning(
+                "makeps3iso could not read back PARAM.SFO TITLE_ID from %s",
+                iso_path,
+            )
+        return "ISO build complete"
+
+    # ----- info -------------------------------------------------------------
+
+    def info(self, folder_path: str) -> dict:
+        """Filesystem-level info for a PS3 folder (PARAM.SFO title/id).
+
+        Synchronous; wrap callers in a threadpool.
+        """
+        if not os.path.isdir(folder_path):
+            raise FileNotFoundError(f"Folder not found: {folder_path}")
+
+        total = 0
+        for root, _dirs, names in os.walk(folder_path):
+            for name in names:
+                with contextlib.suppress(OSError):
+                    total += os.path.getsize(os.path.join(root, name))
+
+        keys = ps3.ps3_folder_sfo_keys(folder_path)
+        size_mb = total / (1024 * 1024)
+        size_display = (
+            f"{size_mb:.2f} MB" if size_mb < 1024 else f"{size_mb / 1024:.2f} GB"
+        )
+        return {
+            "file": folder_path,
+            "size": total,
+            "size_display": size_display,
+            "format": "PS3 disc/JB folder",
+            "extension": "",
+            "compressed": False,
+            "compression_type": None,
+            "title": keys.get("TITLE") or None,
+            "title_id": keys.get("TITLE_ID") or None,
+        }
+
+    # ----- verify -----------------------------------------------------------
+
+    async def verify(self, iso_path: str) -> dict:
+        """Confirm a built ``.iso`` carries a readable PS3 PARAM.SFO TITLE_ID.
+
+        makeps3iso has no native verify; this is the light readback. It is not
+        wired to delete-on-verify (deleting a curated source folder is
+        destructive), so it only runs when explicitly requested.
+        """
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("makeps3iso verify (TITLE_ID readback) for %s", iso_path)
+        title_id = await asyncio.to_thread(ps3.ps3_iso_title_id, iso_path)
+        if title_id:
+            return {"valid": True, "message": f"PS3 ISO TITLE_ID {title_id}"}
+        return {
+            "valid": False,
+            "message": "No readable PS3 PARAM.SFO TITLE_ID in ISO",
+        }
+
+
+# Re-exported so callers can `except ConversionCancelled` symmetrically with the
+# other services even though makeps3iso raises it via the shared runner.
+__all__ = ["ConversionCancelled", "MakePs3IsoService", "makeps3iso_service"]
+
+# Global service instance
+makeps3iso_service = MakePs3IsoService()

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -68,12 +68,12 @@ class MakePs3IsoService:
         return prefix + cmd if prefix else cmd
 
     def _parse_progress(self, line: str) -> int | None:
-        match = None
-        for match in _PROGRESS_RE.finditer(line):
-            pass
-        if match is None:
+        # Take the LAST percentage on the line (makeps3iso may redraw several on
+        # one carriage-return-joined chunk; the last is the current value).
+        matches = _PROGRESS_RE.findall(line)
+        if not matches:
             return None
-        value = int(match.group(1))
+        value = int(matches[-1])
         return value if 0 <= value <= 100 else None
 
     def active_pids(self) -> list[int]:

--- a/app/services/ps3.py
+++ b/app/services/ps3.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import os
 
-from services.disc_id import parse_sfo_keys
+from services.disc_id import parse_sfo_keys, read_iso_file
 
 
 def is_ps3_iso_source(path: str) -> bool:
@@ -47,3 +47,23 @@ def ps3_title_id(path: str) -> str | None:
     """Best-effort TITLE_ID for a PS3 disc/JB folder (verify/info readback)."""
     keys = read_sfo_keys(os.path.join(path, "PS3_GAME", "PARAM.SFO"))
     return keys.get("TITLE_ID") or None
+
+
+def ps3_folder_sfo_keys(path: str) -> dict[str, str]:
+    """All PARAM.SFO string keys for a PS3 disc/JB folder (info display)."""
+    return read_sfo_keys(os.path.join(path, "PS3_GAME", "PARAM.SFO"))
+
+
+def ps3_iso_title_id(iso_path: str) -> str | None:
+    """Best-effort TITLE_ID read back from a built PS3 ``.iso``.
+
+    The light, no-native-verify integrity check: walk the produced ISO 9660
+    image to ``PS3_GAME/PARAM.SFO`` and read its ``TITLE_ID`` (reusing the
+    shared ISO reader + SFO parser), so the makeps3iso service can confirm the
+    packed ISO carries the same title id as the source folder. Returns ``None``
+    when the image isn't a readable PS3 ISO.
+    """
+    data = read_iso_file(iso_path, ["PS3_GAME", "PARAM.SFO"])
+    if not data:
+        return None
+    return parse_sfo_keys(data).get("TITLE_ID") or None

--- a/app/services/tools/__init__.py
+++ b/app/services/tools/__init__.py
@@ -11,6 +11,7 @@ from .base import BaseTool, ToolPlugin
 from .chain import ChainTool
 from .chdman import ChdmanTool
 from .dolphin import DolphinTool
+from .makeps3iso import MakePs3IsoTool
 from .maxcso import MaxcsoTool
 from .nsz import NszTool
 from .registry import ToolRegistry
@@ -25,6 +26,7 @@ registry.register(Z3dsTool(settings.z3ds_compressor_path))
 registry.register(NszTool(settings.nsz_path))
 registry.register(MaxcsoTool(settings.maxcso_path))
 registry.register(RomzTool(settings.sevenzip_path))
+registry.register(MakePs3IsoTool(settings.makeps3iso_path))
 # Composite/pipeline modes register last: ChainTool drives the component tools
 # above through the registry, so they must already be present.
 registry.register(ChainTool(registry, chdman_path=settings.chdman_path))

--- a/app/services/tools/makeps3iso.py
+++ b/app/services/tools/makeps3iso.py
@@ -1,0 +1,125 @@
+"""MakePs3IsoTool: the first directory-as-input tool (PS3 folder -> ISO).
+
+One mode, ``folder_to_iso``, whose unit of work is a **directory** rather than a
+file with a suffix. Instead of matching ``ext in input_extensions`` it overrides
+``accepts_directory`` to run the ``services.ps3`` source-layout detector, which
+is also what ``registry.tools_for_directory`` (and the file-listing annotation)
+drive off. Everything else delegates to ``makeps3iso_service``.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncGenerator
+
+from fastapi.concurrency import run_in_threadpool
+
+from models import OutputStatus, Ps3IsoInfo
+from services import ps3
+from services.lock_manager import lock_manager
+from services.makeps3iso import makeps3iso_service
+
+from .base import BaseTool
+from .spec import InputKind, ModeKind, ModeSpec
+
+
+class MakePs3IsoTool(BaseTool):
+    id = "makeps3iso"
+    display_name = "PS3 ISO"
+    modes = (
+        ModeSpec(
+            mode="folder_to_iso",
+            tool_id="makeps3iso",
+            kind=ModeKind.CREATE,
+            label="PS3 Folder → ISO",
+            group="makeps3iso",
+            output_ext=".iso",
+            # Directory-driven: there is no input extension to match, so this is
+            # empty and selection runs through accepts_directory() instead.
+            input_extensions=frozenset(),
+            supports_compression=False,
+            # No delete-on-verify: deleting a user-curated decrypted folder is
+            # destructive and makeps3iso has no native verify (only the light
+            # PARAM.SFO TITLE_ID readback).
+            supports_delete_on_verify=False,
+            allows_archive_input=False,
+            input_kinds=frozenset({InputKind.DIRECTORY}),
+        ),
+    )
+    # The .iso it produces, for output badges / scan discovery.
+    output_extensions = frozenset({".iso"})
+
+    def __init__(self, binary_path: str) -> None:
+        super().__init__(binary_path)
+        self._service = makeps3iso_service
+
+    def accepts_directory(self, path: str) -> bool:
+        # The directory analogue of `ext in input_extensions`: require the
+        # decrypted PS3 disc/JB layout (a PS3_GAME/ root, plus PS3_DISC.SFB for
+        # disc rips). Does disk I/O — callers run it off the event loop.
+        return ps3.is_ps3_iso_source(path)
+
+    def detect_output(self, input_path: str) -> OutputStatus | None:
+        # Sibling "<folder>.iso" badge next to a convertible PS3 folder. Guard on
+        # isdir so the file-listing's per-file detection loop (which calls every
+        # tool's detect_output) never fabricates a "<file>.iso" candidate.
+        if not os.path.isdir(input_path):
+            return None
+        candidate = self._service.get_output_path(input_path)
+        file_exists, is_converting = lock_manager.check_file_status(candidate)
+        if not (file_exists or is_converting):
+            return None
+        return OutputStatus(
+            tool_id=self.id,
+            exists=file_exists,
+            ready=file_exists and not is_converting,
+            path=candidate,
+        )
+
+    def output_path(
+        self,
+        mode: str,  # noqa: ARG002 - single-mode tool
+        input_path: str,
+        output_dir: str | None = None,
+        *,
+        treat_as_stem: bool = False,
+    ) -> str:
+        return self._service.get_output_path(
+            input_path, output_dir, treat_as_stem=treat_as_stem,
+        )
+
+    def convert(
+        self,
+        input_path: str,
+        output_path: str,
+        mode: str,
+        *,
+        compression: str | None = None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> AsyncGenerator[dict, None]:
+        return self._service.convert(
+            input_path, output_path, mode,
+            compression=compression, cancel_event=cancel_event,
+        )
+
+    async def verify(self, path: str) -> dict:
+        return await self._service.verify(path)
+
+    async def info(self, path: str) -> dict:
+        return await run_in_threadpool(self._service.info, path)
+
+    def info_model(self, raw: dict, path: str) -> Ps3IsoInfo:
+        return Ps3IsoInfo(
+            file=raw["file"],
+            size=raw["size"],
+            size_display=raw["size_display"],
+            format=raw.get("format"),
+            extension=raw["extension"],
+            compressed=raw["compressed"],
+            compression_type=raw.get("compression_type"),
+            title=raw.get("title"),
+            title_id=raw.get("title_id"),
+        )
+
+    def active_pids(self) -> list[int]:
+        return self._service.active_pids()

--- a/app/services/tools/makeps3iso.py
+++ b/app/services/tools/makeps3iso.py
@@ -46,8 +46,13 @@ class MakePs3IsoTool(BaseTool):
             input_kinds=frozenset({InputKind.DIRECTORY}),
         ),
     )
-    # The .iso it produces, for output badges / scan discovery.
-    output_extensions = frozenset({".iso"})
+    # Intentionally does NOT advertise ".iso" in output_extensions. That union
+    # feeds the global metadata/DAT scan walk (registry.scannable_extensions),
+    # and ".iso" is a generic source suffix (raw PS2/PSP/Wii/CD-DVD images) that
+    # no tool can verify — advertising it would drag every library ISO into a
+    # full-file-SHA1 scan. The produced "<folder>.iso" is surfaced via the
+    # directory row's detect_output badge instead, which needs no extension
+    # registration. (BaseTool defaults output_extensions to an empty set.)
 
     def __init__(self, binary_path: str) -> None:
         super().__init__(binary_path)

--- a/app/services/tools/spec.py
+++ b/app/services/tools/spec.py
@@ -9,26 +9,19 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 
+# ``InputKind`` lives in ``models`` so ``ConversionJob`` can type its field
+# against it without importing the ``services.tools`` package (which imports
+# ``models`` to build the registry — the reverse import would be a cycle). It is
+# re-exported here so ``from services.tools.spec import InputKind`` and the
+# ``ModeSpec.input_kinds`` default keep working unchanged.
+from models import InputKind
+
 
 class ModeKind(str, Enum):
     CREATE = "create"      # source -> compressed container
     EXTRACT = "extract"    # compressed container -> source
     COPY = "copy"          # recompress in place
     COMPRESS = "compress"  # generic one-shot compressor (z3ds-style)
-
-
-class InputKind(str, Enum):
-    """The unit of work a mode consumes.
-
-    Everything in the codebase historically keyed input off
-    ``Path(filename).suffix``, which assumes a file. A directory has no
-    suffix, so a mode that packages a folder (makeps3iso folder->iso) declares
-    ``DIRECTORY`` and relies on a detector predicate
-    (``ToolPlugin.accepts_directory``) instead of an extension match.
-    """
-
-    FILE = "file"
-    DIRECTORY = "directory"
 
 
 @dataclass(frozen=True)

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -429,13 +429,50 @@ New chained conversions (xci→nsp, wud→wua, a future folder→iso→chd) are 
 
 Every input seam keys off `Path(filename).suffix`; a folder has none. For
 directory-unit conversions (issue #98 Phase 2, makeps3iso folder→iso) the seam
-is an `InputKind` enum + `ModeSpec.input_kinds` (default `{FILE}`, zero behavior
-change), a `ToolPlugin.accepts_directory(path)` predicate (default `False`; the
-directory analogue of `ext in input_extensions`), and
-`registry.tools_for_directory(path)`. The per-source-type detector for PS3 lives
-in `services/ps3.py` (requires the `PS3_GAME/` disc/JB layout). Scaffolding only
-so far — the makeps3iso tool, listing annotation, job-model `input_kind`, and UI
-selection are not wired yet.
+is an `InputKind` enum (defined in `models.py` so `ConversionJob` can type its
+field without an import cycle; re-exported from `services.tools.spec`) +
+`ModeSpec.input_kinds` (default `{FILE}`, zero behavior change), a
+`ToolPlugin.accepts_directory(path)` predicate (default `False`; the directory
+analogue of `ext in input_extensions`), and `registry.tools_for_directory(path)`.
+The per-source-type detector for PS3 lives in `services/ps3.py` (requires the
+`PS3_GAME/` disc/JB layout, rejecting bare installed-game folders).
+
+The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
+`InputKind.DIRECTORY` mode), is wired end-to-end:
+
+- **Tool/service.** `MakePs3IsoTool.accepts_directory` runs `ps3.is_ps3_iso_source`;
+  `makeps3iso_service` shells out via `SubprocessRunner.run(["makeps3iso", folder,
+  out.iso], …)`, derives the output from the folder's **normalized basename**
+  (`<folder>.iso`, never `.iso` from a trailing slash), removes a partial ISO on
+  cancel/failure, and runs a light **PARAM.SFO `TITLE_ID` readback** from the
+  built ISO (reusing the shared `disc_id.read_iso_file` ISO 9660 reader) as an
+  advisory check — `supports_delete_on_verify=False`, so a curated source folder
+  is never auto-deleted.
+- **Job model.** `ConversionJob.input_kind: InputKind` is threaded end-to-end
+  (derived from the mode spec at queue time, serialized to a string only at the
+  API/persistence edge). The generic `_process_job` flow already handles a
+  directory source — the archive-extract branch is gated on `"::"`, which a
+  folder never carries — so no directory-specific convert branch is needed.
+- **Listing + search.** `files.py` annotates convertible directory rows
+  (`_detect_directory_outputs` → `registry.tools_for_directory`) with
+  `convertible_by` + the sibling `.iso` output in **both** `scan_directory` and
+  the recursive search `_scan` (the latter emits the folder as a job unit and
+  does not recurse past it, so it's discoverable / batch-selectable).
+- **Lock manager.** A directory job protects its whole subtree:
+  `find_active_job_for_path` / `_is_path_in_use_by_other_job` (and the files-route
+  `_assert_path_not_in_use`, which delegates to the former) treat any path that is
+  a **descendant** of an active `InputKind.DIRECTORY` job's source as in-use, so a
+  per-file job / rename / delete inside an in-flight folder can't corrupt the ISO.
+- **Plan + UI.** `plan_job` branches on `InputKind.DIRECTORY in spec.input_kinds`
+  (validate `isdir` + the detector, normalized basename for output + display
+  name). The frontend mode carries `inputKinds: ['directory']`; a *convertible*
+  directory row becomes checkbox-selectable (`fileBrowser._isSelectable` /
+  `conversion.allowsInputEntry`) while the name-click still navigates — a plain
+  directory stays navigation-only.
+
+The `-s` 4 GB FAT32 split flag is not exposed (single `.iso`; target volumes are
+ext4/NTFS/exFAT). makeps3iso (GPL-3.0) is built unmodified from a pinned
+`bucanero/ps3iso-utils` commit in the multi-stage `Dockerfile`, mirroring maxcso.
 
 ### 3.4 `registry.py`
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,41 @@
 
 ## Unreleased
 
+### PS3 decrypted folder → ISO (issue #98, Phase 2)
+
+#### New
+
+- **Build a PS3 `.iso` from a decrypted disc/JB folder.** A new **PS3 ISO**
+  tool packages a folder you've already decrypted (a `PS3_GAME/` root, plus
+  `PS3_DISC.SFB` for disc rips) into a single `.iso` that RPCS3 mounts directly,
+  using **makeps3iso**. This is the first conversion whose input is a *folder*,
+  not a file: browse to (or search for) a PS3 folder, switch to the PS3 ISO
+  tool, and the folder becomes selectable like any source row — clicking its
+  name still navigates in. The output is `<folder>.iso` next to the source (or
+  in your chosen output directory). After a successful build the tool does a
+  light PARAM.SFO `TITLE_ID` readback from the produced ISO and flags a mismatch
+  in the job message. Decryption and keys are **out of scope** — this only
+  repackages folders you already decrypted, and it never deletes the source
+  folder (no delete-on-verify).
+
+#### Internal
+
+- The directory-input seam scaffolded in Phase 1 (`InputKind` +
+  `ModeSpec.input_kinds`, `ToolPlugin.accepts_directory`,
+  `registry.tools_for_directory`, the `services.ps3` detector) is now wired
+  end-to-end: a `MakePs3IsoTool` + `makeps3iso` service, `ConversionJob.input_kind`
+  threaded through `plan_job` / the job pipeline (a directory source skips the
+  archive-extract path), convertible-directory annotation in the file listing
+  **and** recursive search, frontend selection for convertible folders, and
+  lock-manager **subtree protection** (a per-file job / rename / delete inside an
+  in-flight folder is rejected so it can't corrupt the ISO). `InputKind` moved
+  from `services.tools.spec` to `models` (re-exported) so the job model can type
+  the field without an import cycle. The makeps3iso binary (GPL-3.0,
+  `bucanero/ps3iso-utils`, pinned commit) is built unmodified in the multi-stage
+  `Dockerfile`, mirroring maxcso, and confirmed to build on linux/amd64 and
+  linux/arm64 (plain portable C, no x86 asm). Tests: `tests/test_makeps3iso.py`,
+  plus directory coverage in `tests/test_ps3_detector.py`.
+
 ### CSO → CHD in one step (issue #98, Phase 1)
 
 #### New

--- a/src/lib/components/panels/FileRow.svelte
+++ b/src/lib/components/panels/FileRow.svelte
@@ -20,7 +20,9 @@
 
   const selected = $derived(fileBrowser.selectedFiles.has(path));
   // Files are always selectable; archives only when the active mode takes the
-  // archive directly (e.g. romz_extract on .7z/.zip). Drives the checkbox.
+  // archive directly (e.g. romz_extract on .7z/.zip); directories only under a
+  // folder-input mode (makeps3iso) and only when the backend marked them
+  // convertible. Drives the checkbox; the name button still navigates.
   const selectable = $derived(fileBrowser.isSelectable(entry));
   const datMatch = $derived(datMatching.matchFor(path));
   const chdMeta = $derived(chdMetadata.metadataFor(path));
@@ -148,7 +150,7 @@
         </Badge>
       {/if}
     {/each}
-    {#if isFile && convertibleBy.length > 0}
+    {#if (isFile || isDirectory) && convertibleBy.length > 0}
       <span class="convertible-hint" title={`Convertible by: ${convertibleBy.join(', ')}`}>
         {convertibleBy.join('·')}
       </span>

--- a/src/lib/stores/conversion.svelte.js
+++ b/src/lib/stores/conversion.svelte.js
@@ -95,6 +95,42 @@ class ConversionStore {
   }
 
   /**
+   * True when the active mode's unit of work is a directory (makeps3iso
+   * folder_to_iso), declared via the registry mode's `inputKinds`. A
+   * directory mode accepts only convertible folders, never files.
+   */
+  get isDirectoryMode() {
+    const kinds = this.currentSpec?.inputKinds;
+    return Array.isArray(kinds) && kinds.includes('directory');
+  }
+
+  /**
+   * Whether the given listing entry is a valid input for the active mode.
+   * The entry-aware companion to `allowsInput(path)`: it can see `entry.type`
+   * and the backend's `entry.convertible_by`, which a bare path can't. Used by
+   * fileBrowser for both selection gating and the convertible subset, so a
+   * directory mode only ever submits convertible folders and a file mode never
+   * submits a folder.
+   *
+   * - Directory mode: only a directory row the backend marked convertible by
+   *   THIS tool qualifies (folders the detector accepts).
+   * - File/archive mode: a directory never qualifies; otherwise fall back to
+   *   the path-based `allowsInput`.
+   */
+  allowsInputEntry(entry) {
+    if (!entry) return false;
+    if (this.isDirectoryMode) {
+      return (
+        entry.type === 'directory'
+        && Array.isArray(entry.convertible_by)
+        && entry.convertible_by.includes(this.currentTool?.id)
+      );
+    }
+    if (entry.type === 'directory') return false;
+    return this.allowsInput(entry.path);
+  }
+
+  /**
    * True when the given path is a valid input for the currently
    * selected mode. Used by fileBrowser to gate selection so users
    * can't queue jobs the worker would just reject, e.g. selecting a

--- a/src/lib/stores/fileBrowser.svelte.js
+++ b/src/lib/stores/fileBrowser.svelte.js
@@ -557,7 +557,14 @@ class FileBrowserStore {
    */
   _isSelectable(entry) {
     if (!entry) return false;
-    if (entry.type === 'directory') return false;
+    if (entry.type === 'directory') {
+      // Directories are navigation-only EXCEPT under a directory-input mode
+      // (makeps3iso folder_to_iso), where a folder the backend marked
+      // convertible becomes a selectable job unit. The name-click still
+      // navigates (handled in FileRow); only the checkbox selects, mirroring
+      // how archive rows browse-on-name / select-on-checkbox.
+      return conversion.allowsInputEntry(entry);
+    }
     if (entry.type === 'archive') {
       // Archives are normally browse-into containers, not selectable rows.
       // They become selectable only when the active mode takes the archive
@@ -583,7 +590,10 @@ class FileBrowserStore {
   get convertibleSelection() {
     const out = [];
     for (const entry of this.selectedFiles.values()) {
-      if (conversion.allowsInput(entry?.path)) out.push(entry);
+      // Entry-aware gate (not just the path) so a directory mode submits only
+      // convertible folders and a file mode never submits a stale folder
+      // selection left over from switching tools.
+      if (conversion.allowsInputEntry(entry)) out.push(entry);
     }
     return out;
   }

--- a/src/lib/tools/registry.js
+++ b/src/lib/tools/registry.js
@@ -63,6 +63,13 @@ const ROMZ_COMPRESS_EXTS = ['.gb', '.gbc', '.gba', '.nds'];
 const ROMZ_VERIFY_EXTS = ['.7z', '.zip'];
 const ROMZ_SOURCE_EXTS = [...ROMZ_COMPRESS_EXTS, ...ROMZ_VERIFY_EXTS];
 
+// makeps3iso (PS3 folder -> ISO). The unit of work is a DIRECTORY, not a file
+// with a suffix, so it declares no source/verify extensions; the mode carries
+// `inputKinds: ['directory']` and selection runs through the backend's
+// per-folder `convertible_by` annotation instead of an extension match.
+const PS3_SOURCE_EXTS = [];
+const PS3_VERIFY_EXTS = [];
+
 /**
  * @typedef {Object} ModeEntry
  * @property {string} mode
@@ -71,6 +78,7 @@ const ROMZ_SOURCE_EXTS = [...ROMZ_COMPRESS_EXTS, ...ROMZ_VERIFY_EXTS];
  * @property {string} group
  * @property {string|null} outputExt
  * @property {string[]} inputExtensions
+ * @property {string[]} [inputKinds]   ['directory'] for a folder-input mode; omitted ⇒ file
  * @property {boolean} supportsCompression
  * @property {boolean} supportsCompressionLevel
  * @property {boolean} supportsDeleteOnVerify
@@ -446,6 +454,38 @@ export const TOOLS = [
       if (/\.(7z|zip)$/i.test(path)) return path.replace(/\.(7z|zip)$/i, '');
       return path;
     },
+  },
+  {
+    id: 'makeps3iso',
+    label: 'PS3 ISO',
+    hint: 'Build a PS3 .iso from a decrypted disc/JB folder (a PS3_GAME/ root). No keys, no decryption.',
+    // No verify endpoint: makeps3iso's only check is a backend PARAM.SFO
+    // TITLE_ID readback, not a user-facing /api verify route.
+    verifyPrefix: '',
+    sourceExts: PS3_SOURCE_EXTS,
+    verifyExts: PS3_VERIFY_EXTS,
+    modeGroups: ['makeps3iso'],
+    groups: { makeps3iso: 'PS3 Folder → ISO' },
+    defaultMode: 'folder_to_iso',
+    glyph: 'PS3',
+    accent: 'var(--badge-dvd)',
+    compressionCodecs: [],
+    compressionStyle: 'none',
+    modes: [
+      // The only directory-input mode: its `inputKinds` flips fileBrowser
+      // selection from "files only" to "convertible folders only".
+      { mode: 'folder_to_iso', kind: 'create', label: 'PS3 Folder → ISO', group: 'makeps3iso',
+        outputExt: '.iso', inputExtensions: [], inputKinds: ['directory'],
+        supportsCompression: false, supportsCompressionLevel: false,
+        supportsDeleteOnVerify: false, allowsArchiveInput: false },
+    ],
+    // No file-path Info/Verify: a folder has no extension to route on. Left
+    // undefined so infoToolsForPath / toolForVerifyPath skip this tool.
+    getInfo: undefined,
+    verify: undefined,
+    verifyBatch: undefined,
+    // The product is a sibling "<folder>.iso" (folder name, not a stem swap).
+    productPath: (path) => `${(path ?? '').replace(/[/\\]+$/, '')}.iso`,
   },
 ];
 

--- a/tests/ps3_helpers.py
+++ b/tests/ps3_helpers.py
@@ -1,0 +1,47 @@
+"""Shared PS3 folder / PARAM.SFO fixture builders for the PS3 test suite.
+
+Centralised here so ``test_ps3_detector`` and ``test_makeps3iso`` don't drift
+apart or duplicate the SFO-table encoding (mirroring the DB suite's conftest
+sharing). The makeps3iso folder->iso seam keys off the disc/JB layout, so the
+builders produce exactly that.
+"""
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+
+def make_sfo(pairs: list[tuple[str, str]]) -> bytes:
+    """Encode ``(key, value)`` string pairs as a minimal PSF/PARAM.SFO blob."""
+    keys_blob = b""
+    key_offsets = []
+    for key, _ in pairs:
+        key_offsets.append(len(keys_blob))
+        keys_blob += key.encode("ascii") + b"\x00"
+    data_blob = b""
+    data_meta = []
+    for _, value in pairs:
+        encoded = value.encode("utf-8") + b"\x00"
+        data_meta.append((len(data_blob), len(encoded)))
+        data_blob += encoded
+    num = len(pairs)
+    index_size = num * 16
+    key_table_off = 20 + index_size
+    data_table_off = key_table_off + len(keys_blob)
+    header = struct.pack("<4sHH", b"\x00PSF", 1, 1)
+    header += struct.pack("<III", key_table_off, data_table_off, num)
+    index = b""
+    for key_off, (data_off, data_len) in zip(key_offsets, data_meta, strict=True):
+        index += struct.pack("<HHIII", key_off, 0x0204, data_len, data_len, data_off)
+    return header + index + keys_blob + data_blob
+
+
+def make_ps3_folder(root: Path) -> Path:
+    """Create a minimal valid PS3 disc/JB folder (PS3_GAME/ root + PS3_DISC.SFB)."""
+    game = root / "PS3_GAME"
+    game.mkdir(parents=True)
+    (game / "PARAM.SFO").write_bytes(
+        make_sfo([("TITLE_ID", "BLES01807"), ("TITLE", "Some Game")])
+    )
+    (root / "PS3_DISC.SFB").write_bytes(b"\x00")
+    return root

--- a/tests/test_dispatch_routing.py
+++ b/tests/test_dispatch_routing.py
@@ -31,6 +31,8 @@ def _legacy_dispatch_id(mode: str) -> str:
     """Replicates the convert/verify dispatch ladders formerly in
     ``_process_job`` (job_manager.py:1464 / :1576 / :1611).  Both ladders make
     the same tool selection, differing only in the progress message."""
+    if mode == "folder_to_iso":
+        return "makeps3iso"
     if mode.startswith("dolphin_"):
         return "dolphin"
     if mode.startswith("z3ds_"):
@@ -55,7 +57,7 @@ def test_verify_dispatch_matches_legacy_ladder(mode, monkeypatch):
 
         return _verify
 
-    for tool_id in ("chdman", "dolphin", "z3ds", "nsz", "cso", "romz"):
+    for tool_id in ("chdman", "dolphin", "z3ds", "nsz", "cso", "romz", "makeps3iso"):
         monkeypatch.setattr(
             registry.get(tool_id)._service, "verify", _record(tool_id)
         )
@@ -82,7 +84,7 @@ def test_convert_dispatch_matches_legacy_ladder(mode, monkeypatch):
 
         return _convert
 
-    for tool_id in ("chdman", "dolphin", "z3ds", "nsz", "cso", "romz"):
+    for tool_id in ("chdman", "dolphin", "z3ds", "nsz", "cso", "romz", "makeps3iso"):
         monkeypatch.setattr(
             registry.get(tool_id)._service, "convert", _record(tool_id)
         )

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -1,0 +1,281 @@
+"""Tests for the makeps3iso folder->iso directory-input tool (issue #98 Phase 2).
+
+Covers the end-to-end seam: detector->tool resolution, the file-listing /
+search directory annotation, the service convert (mocked subprocess), and the
+``plan_job`` directory branch (valid / invalid / trailing slash).
+"""
+from __future__ import annotations
+
+import struct
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.models import ConversionJob, ConversionMode, InputKind, JobStatus
+from app.routes import convert as convert_routes
+from app.routes import files as files_routes
+from app.services.makeps3iso import ConversionCancelled, makeps3iso_service
+from app.services.tools import registry
+
+
+def _make_sfo(pairs: list[tuple[str, str]]) -> bytes:
+    keys_blob = b""
+    key_offsets = []
+    for key, _ in pairs:
+        key_offsets.append(len(keys_blob))
+        keys_blob += key.encode("ascii") + b"\x00"
+    data_blob = b""
+    data_meta = []
+    for _, value in pairs:
+        encoded = value.encode("utf-8") + b"\x00"
+        data_meta.append((len(data_blob), len(encoded)))
+        data_blob += encoded
+    num = len(pairs)
+    index_size = num * 16
+    key_table_off = 20 + index_size
+    data_table_off = key_table_off + len(keys_blob)
+    header = struct.pack("<4sHH", b"\x00PSF", 1, 1)
+    header += struct.pack("<III", key_table_off, data_table_off, num)
+    index = b""
+    for key_off, (data_off, data_len) in zip(key_offsets, data_meta):
+        index += struct.pack("<HHIII", key_off, 0x0204, data_len, data_len, data_off)
+    return header + index + keys_blob + data_blob
+
+
+def _make_ps3_folder(root: Path) -> Path:
+    """A minimal valid PS3 disc/JB folder (PS3_GAME/ root + PS3_DISC.SFB)."""
+    game = root / "PS3_GAME"
+    game.mkdir(parents=True)
+    (game / "PARAM.SFO").write_bytes(
+        _make_sfo([("TITLE_ID", "BLES01807"), ("TITLE", "Some Game")])
+    )
+    (root / "PS3_DISC.SFB").write_bytes(b"\x00")
+    return root
+
+
+# --------------------------------------------------------------------------- #
+# Detector -> tool resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_tools_for_directory_resolves_makeps3iso(tmp_path):
+    folder = _make_ps3_folder(tmp_path / "MyGame")
+    assert [t.id for t in registry.tools_for_directory(str(folder))] == ["makeps3iso"]
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert registry.tools_for_directory(str(plain)) == []
+
+
+def test_folder_to_iso_spec_is_directory_kind():
+    spec = registry.spec("folder_to_iso")
+    assert spec.tool_id == "makeps3iso"
+    assert InputKind.DIRECTORY in spec.input_kinds
+    assert spec.output_ext == ".iso"
+    assert spec.supports_delete_on_verify is False
+
+
+# --------------------------------------------------------------------------- #
+# File-listing / search annotation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_list_files_annotates_convertible_directory(tmp_path, monkeypatch):
+    _make_ps3_folder(tmp_path / "MyGame")
+    (tmp_path / "plain").mkdir()
+    monkeypatch.setattr(files_routes.settings, "chd_volumes", str(tmp_path))
+    monkeypatch.setattr(files_routes.settings, "data_mount_root", str(tmp_path))
+
+    listing = await files_routes.list_files(path=str(tmp_path))
+    by_name = {e.name: e for e in listing.entries}
+
+    game = by_name["MyGame"]
+    assert game.type == "directory"
+    assert game.convertible_by == ["makeps3iso"]
+    # No sibling .iso yet, so no detected output.
+    assert game.outputs == []
+
+    plain = by_name["plain"]
+    assert plain.type == "directory"
+    assert plain.convertible_by == []
+
+
+@pytest.mark.asyncio
+async def test_list_files_directory_output_badge(tmp_path, monkeypatch):
+    _make_ps3_folder(tmp_path / "MyGame")
+    (tmp_path / "MyGame.iso").write_bytes(b"iso")  # sibling output already present
+    monkeypatch.setattr(files_routes.settings, "chd_volumes", str(tmp_path))
+    monkeypatch.setattr(files_routes.settings, "data_mount_root", str(tmp_path))
+
+    listing = await files_routes.list_files(path=str(tmp_path))
+    game = next(e for e in listing.entries if e.name == "MyGame")
+    assert [o.tool_id for o in game.outputs] == ["makeps3iso"]
+    assert game.outputs[0].exists is True
+    assert game.outputs[0].path == str(tmp_path / "MyGame.iso")
+
+
+@pytest.mark.asyncio
+async def test_search_emits_convertible_directory(tmp_path, monkeypatch):
+    # A PS3 folder nested in a subtree must surface as a selectable directory
+    # row in recursive search (and not be recursed past as a job unit).
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    _make_ps3_folder(sub / "MyGame")
+    monkeypatch.setattr(files_routes.settings, "chd_volumes", str(tmp_path))
+    monkeypatch.setattr(files_routes.settings, "data_mount_root", str(tmp_path))
+
+    result = await files_routes.search_files(path=str(tmp_path))
+    dir_rows = [f for f in result["files"] if f.get("type") == "directory"]
+    assert len(dir_rows) == 1
+    row = dir_rows[0]
+    assert row["name"] == "MyGame"
+    assert row["convertible_by"] == ["makeps3iso"]
+    # The inner PS3_GAME files were NOT emitted as separate convertible hits.
+    assert all("PARAM.SFO" not in f["name"] for f in result["files"])
+
+
+# --------------------------------------------------------------------------- #
+# plan_job directory branch
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_plan_job_accepts_valid_ps3_dir(tmp_path):
+    folder = _make_ps3_folder(tmp_path / "MyGame")
+    plan = await convert_routes.plan_job(
+        str(folder),
+        spec=registry.spec("folder_to_iso"),
+        mode="folder_to_iso",
+        output_dir=None,
+        duplicate_action=convert_routes.DuplicateAction.SKIP,
+        delete_on_verify=False,
+    )
+    assert plan.output_path == str(tmp_path / "MyGame.iso")
+    assert plan.display_filename == "MyGame"
+    assert plan.allow_overwrite is False
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rejects_non_ps3_dir(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(plain),
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_INVALID
+
+
+@pytest.mark.asyncio
+async def test_plan_job_handles_trailing_slash(tmp_path):
+    _make_ps3_folder(tmp_path / "MyGame")
+    plan = await convert_routes.plan_job(
+        str(tmp_path / "MyGame") + "/",  # trailing slash
+        spec=registry.spec("folder_to_iso"),
+        mode="folder_to_iso",
+        output_dir=None,
+        duplicate_action=convert_routes.DuplicateAction.SKIP,
+        delete_on_verify=False,
+    )
+    # Normalized basename, not "" -> the output is "<folder>.iso", never ".iso".
+    assert plan.output_path == str(tmp_path / "MyGame.iso")
+    assert plan.display_filename == "MyGame"
+
+
+# --------------------------------------------------------------------------- #
+# Service convert (mocked subprocess)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_service_convert_argv_and_progress(tmp_path, monkeypatch):
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out_iso = str(tmp_path / "MyGame.iso")
+    captured: dict = {}
+
+    async def fake_run(cmd, *, output_path, complete_message, **_kwargs):
+        captured["cmd"] = cmd
+        Path(output_path).write_bytes(b"not a real iso")  # simulated build
+        yield {"progress": 1, "message": "Starting"}
+        yield {"progress": 50, "message": "Writing... 50%"}
+        yield {"progress": 100, "message": complete_message}
+
+    monkeypatch.setattr(makeps3iso_service._runner, "run", fake_run)
+
+    updates = [
+        u
+        async for u in makeps3iso_service.convert(folder, out_iso, "folder_to_iso")
+    ]
+
+    # argv is exactly `makeps3iso <folder> <out.iso>` (ignoring any ionice wrap).
+    assert captured["cmd"][-3:] == [
+        makeps3iso_service.makeps3iso_path, folder, out_iso,
+    ]
+    # Progress drains to 100, and the final update is the readback message the
+    # service appends (replacing the runner's bare 100%).
+    assert updates[-1]["progress"] == 100
+    assert "ISO build complete" in updates[-1]["message"]
+    assert Path(out_iso).exists()
+
+
+@pytest.mark.asyncio
+async def test_service_convert_cancel_cleans_partial(tmp_path, monkeypatch):
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out_iso = str(tmp_path / "MyGame.iso")
+
+    async def fake_run(cmd, *, output_path, **_kwargs):
+        Path(output_path).write_bytes(b"partial")  # half-written ISO
+        yield {"progress": 10, "message": "Writing..."}
+        raise ConversionCancelled("cancelled")
+
+    monkeypatch.setattr(makeps3iso_service._runner, "run", fake_run)
+
+    async def _drain():
+        return [
+            u
+            async for u in makeps3iso_service.convert(folder, out_iso, "folder_to_iso")
+        ]
+
+    with pytest.raises(ConversionCancelled):
+        await _drain()
+    # The partial ISO is removed so a retry isn't blocked by a truncated image.
+    assert not Path(out_iso).exists()
+
+
+# --------------------------------------------------------------------------- #
+# Lock-manager subtree protection
+# --------------------------------------------------------------------------- #
+
+
+def test_directory_job_protects_subtree(tmp_path):
+    from app.services.job_manager import job_manager
+
+    folder = _make_ps3_folder(tmp_path / "MyGame")
+    job = ConversionJob(
+        id="ps3test1",
+        file_path=str(folder),
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=str(tmp_path / "MyGame.iso"),
+        input_kind=InputKind.DIRECTORY,
+    )
+    job_manager.jobs[job.id] = job
+    try:
+        # A path INSIDE the active folder is treated as in use (its whole
+        # subtree is being packed), even though it hashes to a different key.
+        inside = str(folder / "PS3_GAME" / "PARAM.SFO")
+        assert job_manager.find_active_job_for_path(inside) is job
+        assert job_manager._is_path_in_use_by_other_job("other", inside) is True
+        # A sibling outside the folder is unaffected.
+        outside = str(tmp_path / "Unrelated.iso")
+        assert job_manager.find_active_job_for_path(outside) is None
+    finally:
+        job_manager.jobs.pop(job.id, None)

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -107,8 +107,14 @@ async def test_search_emits_convertible_directory(tmp_path, monkeypatch):
 # --------------------------------------------------------------------------- #
 
 
+def _confine_to_volume(monkeypatch, root):
+    monkeypatch.setattr(convert_routes.settings, "chd_volumes", str(root))
+    monkeypatch.setattr(convert_routes.settings, "data_mount_root", str(root))
+
+
 @pytest.mark.asyncio
-async def test_plan_job_accepts_valid_ps3_dir(tmp_path):
+async def test_plan_job_accepts_valid_ps3_dir(tmp_path, monkeypatch):
+    _confine_to_volume(monkeypatch, tmp_path)
     folder = _make_ps3_folder(tmp_path / "MyGame")
     plan = await convert_routes.plan_job(
         str(folder),
@@ -121,6 +127,25 @@ async def test_plan_job_accepts_valid_ps3_dir(tmp_path):
     assert plan.output_path == str(tmp_path / "MyGame.iso")
     assert plan.display_filename == "MyGame"
     assert plan.allow_overwrite is False
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rejects_output_outside_volumes(tmp_path, monkeypatch):
+    # The PS3 folder is itself the volume root, so the default sibling output
+    # ("<root>.iso") lands outside all configured volumes -> rejected.
+    vol = tmp_path / "vol"
+    _make_ps3_folder(vol)
+    _confine_to_volume(monkeypatch, vol)
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(vol),
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_OUTPUT_OUTSIDE_VOLUMES
 
 
 @pytest.mark.asyncio
@@ -157,7 +182,8 @@ async def test_plan_job_rejects_output_inside_source(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_plan_job_handles_trailing_slash(tmp_path):
+async def test_plan_job_handles_trailing_slash(tmp_path, monkeypatch):
+    _confine_to_volume(monkeypatch, tmp_path)
     _make_ps3_folder(tmp_path / "MyGame")
     plan = await convert_routes.plan_job(
         str(tmp_path / "MyGame") + "/",  # trailing slash
@@ -320,3 +346,54 @@ def test_dir_lock_serializes_subtree(tmp_path):
     # Once released, the subtree is free again.
     assert lock_manager.acquire_lock(inside) is True
     lock_manager.release_lock(inside)
+
+
+@pytest.mark.asyncio
+async def test_blocked_job_requeues_instead_of_failing(tmp_path):
+    # A job whose output is inside a folder being packed waits in the queue and
+    # is re-dispatched, rather than being failed. job_manager resolves its
+    # lock/concurrency managers via absolute ``services.*`` imports, so import
+    # those from the same module graph (the ``app.services.*`` aliases are
+    # distinct singletons under PYTHONPATH=app).
+    from app.services.job_manager import job_manager
+    from services.concurrency_manager import concurrency_manager
+    from services.lock_manager import lock_manager
+
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out_inside = str(tmp_path / "MyGame" / "PS3_GAME" / "extra.chd")
+    job = ConversionJob(
+        id="ps3wait1",
+        file_path=str(tmp_path / "src.cue"),
+        filename="src.cue",
+        mode=ConversionMode.CREATECD,
+        status=JobStatus.QUEUED,
+        created_at=datetime.now(timezone.utc),
+        output_path=out_inside,
+        input_kind=InputKind.FILE,
+    )
+    job_manager.jobs[job.id] = job
+    assert lock_manager.acquire_dir_lock(folder) is True
+    try:
+        # The output lives inside the packed folder -> a transient block: wait.
+        assert job_manager._blocked_by_dir_lock(job) is True
+        # Re-dispatch (no delay) re-queues the job; it is never failed.
+        job_manager._schedule_dir_lock_requeue(job.id, delay=0)
+        await asyncio.sleep(0.05)
+        assert job.status == JobStatus.QUEUED
+        drained, found = [], False
+        while not job_manager._queue.empty():
+            item = job_manager._queue.get_nowait()
+            if item[1] == job.id:
+                found = True
+            else:
+                drained.append(item)
+        for item in drained:
+            job_manager._queue.put_nowait(item)
+        assert found
+    finally:
+        lock_manager.release_dir_lock(folder)
+        concurrency_manager.release_ticket(job.id)
+        job_manager.jobs.pop(job.id, None)
+        job_manager._cancelled.discard(job.id)
+    # With the folder lock gone, the job is no longer blocked.
+    assert job_manager._blocked_by_dir_lock(job) is False

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -7,7 +7,6 @@ search directory annotation, the service convert (mocked subprocess), and the
 from __future__ import annotations
 
 import asyncio
-import struct
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -19,40 +18,7 @@ from app.routes import files as files_routes
 from app.services.makeps3iso import ConversionCancelled, makeps3iso_service
 from app.services.tools import registry
 
-
-def _make_sfo(pairs: list[tuple[str, str]]) -> bytes:
-    keys_blob = b""
-    key_offsets = []
-    for key, _ in pairs:
-        key_offsets.append(len(keys_blob))
-        keys_blob += key.encode("ascii") + b"\x00"
-    data_blob = b""
-    data_meta = []
-    for _, value in pairs:
-        encoded = value.encode("utf-8") + b"\x00"
-        data_meta.append((len(data_blob), len(encoded)))
-        data_blob += encoded
-    num = len(pairs)
-    index_size = num * 16
-    key_table_off = 20 + index_size
-    data_table_off = key_table_off + len(keys_blob)
-    header = struct.pack("<4sHH", b"\x00PSF", 1, 1)
-    header += struct.pack("<III", key_table_off, data_table_off, num)
-    index = b""
-    for key_off, (data_off, data_len) in zip(key_offsets, data_meta):
-        index += struct.pack("<HHIII", key_off, 0x0204, data_len, data_len, data_off)
-    return header + index + keys_blob + data_blob
-
-
-def _make_ps3_folder(root: Path) -> Path:
-    """A minimal valid PS3 disc/JB folder (PS3_GAME/ root + PS3_DISC.SFB)."""
-    game = root / "PS3_GAME"
-    game.mkdir(parents=True)
-    (game / "PARAM.SFO").write_bytes(
-        _make_sfo([("TITLE_ID", "BLES01807"), ("TITLE", "Some Game")])
-    )
-    (root / "PS3_DISC.SFB").write_bytes(b"\x00")
-    return root
+from .ps3_helpers import make_ps3_folder as _make_ps3_folder
 
 
 # --------------------------------------------------------------------------- #
@@ -171,6 +137,23 @@ async def test_plan_job_rejects_non_ps3_dir(tmp_path):
             delete_on_verify=False,
         )
     assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_INVALID
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rejects_output_inside_source(tmp_path):
+    # An output_dir inside the source folder would make makeps3iso pack its own
+    # in-progress ISO and corrupt the image — must be rejected.
+    folder = _make_ps3_folder(tmp_path / "MyGame")
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(folder),
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=str(folder / "PS3_GAME"),
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_OUTPUT_INSIDE_SOURCE
 
 
 @pytest.mark.asyncio

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -289,3 +289,34 @@ def test_directory_job_protects_subtree(tmp_path):
         assert job_manager.find_active_job_for_path(outside) is None
     finally:
         job_manager.jobs.pop(job.id, None)
+
+
+def test_dir_lock_serializes_subtree(tmp_path):
+    # A directory subtree lock makes any path inside the folder contend on the
+    # lock exactly like an output collision, so a concurrent per-file job can't
+    # write into the tree while makeps3iso packs it.
+    from app.services.lock_manager import lock_manager
+
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    inside = str(tmp_path / "MyGame" / "PS3_GAME" / "extra.chd")
+    sibling = str(tmp_path / "MyGame.iso")
+
+    assert lock_manager.acquire_dir_lock(folder) is True
+    try:
+        # The whole subtree reads as locked; acquiring a per-file lock inside
+        # the folder is refused.
+        _exists, is_locked = lock_manager.check_file_status(inside)
+        assert is_locked is True
+        assert lock_manager.acquire_lock(inside) is False
+        # A sibling output (the job's own .iso) is outside the subtree, so it
+        # locks normally.
+        assert lock_manager.acquire_lock(sibling) is True
+        lock_manager.release_lock(sibling)
+        # A second packing of the same folder is refused while it's locked.
+        assert lock_manager.acquire_dir_lock(folder) is False
+    finally:
+        lock_manager.release_dir_lock(folder)
+
+    # Once released, the subtree is free again.
+    assert lock_manager.acquire_lock(inside) is True
+    lock_manager.release_lock(inside)

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -6,6 +6,7 @@ search directory annotation, the service convert (mocked subprocess), and the
 """
 from __future__ import annotations
 
+import asyncio
 import struct
 from datetime import datetime, timezone
 from pathlib import Path
@@ -245,6 +246,32 @@ async def test_service_convert_cancel_cleans_partial(tmp_path, monkeypatch):
     with pytest.raises(ConversionCancelled):
         await _drain()
     # The partial ISO is removed so a retry isn't blocked by a truncated image.
+    assert not Path(out_iso).exists()
+
+
+@pytest.mark.asyncio
+async def test_service_convert_cleans_partial_on_task_cancellation(tmp_path, monkeypatch):
+    # Task cancellation / generator close raise BaseException-derived
+    # CancelledError / GeneratorExit, which an `except Exception` would miss —
+    # the partial ISO must still be cleaned up.
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out_iso = str(tmp_path / "MyGame.iso")
+
+    async def fake_run(cmd, *, output_path, **_kwargs):
+        Path(output_path).write_bytes(b"partial")
+        yield {"progress": 10, "message": "Writing..."}
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(makeps3iso_service._runner, "run", fake_run)
+
+    async def _drain():
+        return [
+            u
+            async for u in makeps3iso_service.convert(folder, out_iso, "folder_to_iso")
+        ]
+
+    with pytest.raises(asyncio.CancelledError):
+        await _drain()
     assert not Path(out_iso).exists()
 
 

--- a/tests/test_ps3_detector.py
+++ b/tests/test_ps3_detector.py
@@ -8,34 +8,10 @@ bare installed/HDD game-data folder (a ``PARAM.SFO`` under a TITLEID with no
 """
 from __future__ import annotations
 
-import struct
-
 from app.services.ps3 import is_ps3_iso_source, ps3_title_id
 from app.services.tools import registry
 
-
-def _make_sfo(pairs: list[tuple[str, str]]) -> bytes:
-    keys_blob = b""
-    key_offsets = []
-    for key, _ in pairs:
-        key_offsets.append(len(keys_blob))
-        keys_blob += key.encode("ascii") + b"\x00"
-    data_blob = b""
-    data_meta = []
-    for _, value in pairs:
-        encoded = value.encode("utf-8") + b"\x00"
-        data_meta.append((len(data_blob), len(encoded)))
-        data_blob += encoded
-    num = len(pairs)
-    index_size = num * 16
-    key_table_off = 20 + index_size
-    data_table_off = key_table_off + len(keys_blob)
-    header = struct.pack("<4sHH", b"\x00PSF", 1, 1)
-    header += struct.pack("<III", key_table_off, data_table_off, num)
-    index = b""
-    for key_off, (data_off, data_len) in zip(key_offsets, data_meta):
-        index += struct.pack("<HHIII", key_off, 0x0204, data_len, data_len, data_off)
-    return header + index + keys_blob + data_blob
+from .ps3_helpers import make_sfo
 
 
 def test_disc_rip_folder_accepted(tmp_path):
@@ -49,7 +25,7 @@ def test_jb_game_folder_accepted(tmp_path):
     root = tmp_path / "MyGame"
     game = root / "PS3_GAME"
     game.mkdir(parents=True)
-    (game / "PARAM.SFO").write_bytes(_make_sfo([("TITLE_ID", "BLES00000")]))
+    (game / "PARAM.SFO").write_bytes(make_sfo([("TITLE_ID", "BLES00000")]))
     assert is_ps3_iso_source(str(root)) is True
 
 
@@ -58,7 +34,7 @@ def test_installed_game_data_folder_rejected(tmp_path):
     # installed/HDD layout makeps3iso can't package — must NOT be advertised.
     root = tmp_path / "BLES00000"
     root.mkdir()
-    (root / "PARAM.SFO").write_bytes(_make_sfo([("TITLE_ID", "BLES00000")]))
+    (root / "PARAM.SFO").write_bytes(make_sfo([("TITLE_ID", "BLES00000")]))
     assert is_ps3_iso_source(str(root)) is False
 
 
@@ -77,7 +53,7 @@ def test_title_id_readback(tmp_path):
     game = root / "PS3_GAME"
     game.mkdir(parents=True)
     (game / "PARAM.SFO").write_bytes(
-        _make_sfo([("TITLE_ID", "BLES01807"), ("TITLE", "Some Game")])
+        make_sfo([("TITLE_ID", "BLES01807"), ("TITLE", "Some Game")])
     )
     assert ps3_title_id(str(root)) == "BLES01807"
 

--- a/tests/test_ps3_detector.py
+++ b/tests/test_ps3_detector.py
@@ -82,10 +82,15 @@ def test_title_id_readback(tmp_path):
     assert ps3_title_id(str(root)) == "BLES01807"
 
 
-def test_registry_directory_seam_present(tmp_path):
-    # The seam exists; no directory tool is registered yet (makeps3iso is
-    # deferred), so a valid PS3 folder resolves to no tool for now.
+def test_registry_directory_resolves_makeps3iso(tmp_path):
+    # A valid PS3 disc/JB folder resolves to the makeps3iso tool via the
+    # directory seam; an arbitrary folder resolves to no tool.
     root = tmp_path / "MyGame"
     (root / "PS3_GAME").mkdir(parents=True)
     (root / "PS3_DISC.SFB").write_bytes(b"\x00")
-    assert registry.tools_for_directory(str(root)) == []
+    tools = registry.tools_for_directory(str(root))
+    assert [t.id for t in tools] == ["makeps3iso"]
+
+    plain = tmp_path / "random"
+    plain.mkdir()
+    assert registry.tools_for_directory(str(plain)) == []

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -60,6 +60,8 @@ def _legacy_tool_for_mode(mode: str) -> str:
     """Replicates the dispatch ladder at job_manager.py:1444."""
     if mode in COMPOSITE_MODES:
         return "chain"
+    if mode == "folder_to_iso":
+        return "makeps3iso"
     if mode.startswith("dolphin_"):
         return "dolphin"
     if mode.startswith("z3ds_"):
@@ -75,7 +77,7 @@ def _legacy_tool_for_mode(mode: str) -> str:
 
 def test_every_conversion_mode_resolves_to_exactly_one_tool():
     resolved = {m.value: registry.for_mode(m.value).id for m in CONVERSION_MODES}
-    assert len(resolved) == 28
+    assert len(resolved) == 29
     # Each registered mode is owned by exactly one tool (no duplicates).
     assert sorted(s.mode for s in registry.mode_specs()) == sorted(resolved)
 


### PR DESCRIPTION
## Summary

Adds the first **directory-as-input** conversion: a decrypted PS3 disc/JB folder → `.iso` using **makeps3iso** (`bucanero/ps3iso-utils`). This wires the Phase 1 directory seam (`InputKind`, `accepts_directory`, `tools_for_directory`, the `services.ps3` detector) end-to-end. Decryption, keys, pkg→folder, and disc→folder are all out of scope — this only repackages folders the user already decrypted.

### Decisions (confirmed before coding)
- **Provenance/license:** pin upstream `bucanero/ps3iso-utils` at a fixed commit; ship the unmodified **GPL-3.0** binary as a separate executable.
- **Verify:** no native verify → ship **no-verify / `supports_delete_on_verify=False`** plus a light, advisory **PARAM.SFO `TITLE_ID` readback** from the built ISO (never auto-deletes a curated source folder).
- **`-s` split flag:** always emit a single `.iso` (targets are ext4/NTFS/exFAT).
- **Listing cost:** always-on detector (cheap: `PS3_GAME/` stat + small SFO header read, off the event loop).

## What changed

- **Binary/Dockerfile:** pinned `makeps3iso` build stage mirroring maxcso; plain portable C (no x86 asm), so linux/amd64 + linux/arm64 both build. `makeps3iso_path` in `config.py`.
- **Service + tool:** `services/makeps3iso.py` (shell out via `SubprocessRunner.run`, normalized-basename output, partial-ISO cleanup on cancel/fail, TITLE_ID readback) and `MakePs3IsoTool` (one `folder_to_iso` `InputKind.DIRECTORY` mode, `accepts_directory` → `ps3.is_ps3_iso_source`, `detect_output`).
- **Pipeline:** `ConversionJob.input_kind` threaded end-to-end (`InputKind` relocated to `models` to avoid an import cycle, re-exported from `spec`); `plan_job` directory branch (validate `isdir` + detector, normalized basename, trailing-slash safe). The generic worker handles a directory source unchanged (archive-extract is gated on `::`).
- **Listing + search:** convertible directory rows annotated with `convertible_by` + sibling `.iso` in **both** `scan_directory` and the recursive search `_scan` (emitted as a job unit, not recursed past).
- **Lock manager:** a directory job protects its **whole subtree** — a per-file job / rename / delete inside an in-flight folder is rejected so it can't corrupt the ISO.
- **Frontend:** `folder_to_iso` tool/mode in `registry.js`; a *convertible* directory row becomes checkbox-selectable under a folder-input mode (name-click still navigates), while a plain directory stays navigation-only.
- **Docs:** `DESIGN_tool_plugin_architecture.md` §3.3.4 + `RELEASE_NOTES.md`.

## Testing

- `PYTHONPATH=app python -m pytest -q` — **994 passed, 1 skipped**
- `ruff check .` — clean; `pylint` on changed modules — 10.00/10
- `npm run build` — clean; ESLint clean; Svelte autofixer reports no issues
- New: `tests/test_makeps3iso.py` (detector→tool resolution, listing/search annotation, service convert argv + progress-to-100 + cancel-cleans-partial, `plan_job` valid/invalid/trailing-slash, lock-manager subtree protection); updated PS3 detector/registry/dispatch fixtures.

`hadolint` not available locally (CI runs it on release); the new stage mirrors the maxcso stage's `DL3008` ignore pattern.

## Out of scope / noted
- No key handling, no pkg→folder, no disc→folder, no decryption.
- A future folder→iso→chd would compose this directory input as step 1 of the existing Phase 1 `ChainSpec` — left as a noted possibility, not built.

https://claude.ai/code/session_018MavEx3D8vzgkj7t2ttsS5

---
_Generated by [Claude Code](https://claude.ai/code/session_018MavEx3D8vzgkj7t2ttsS5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PS3 folder → ISO conversion: repackage decrypted PS3 game/JB folders into mountable .iso via a new tool
  * File browser: convertible PS3 folders are selectable with annotated sibling .iso outputs
  * UI/tool registry: new PS3 ISO tool appears as a directory-only conversion mode

* **Improvements**
  * Progress streaming, cancellation handling, and automatic cleanup of partial ISOs
  * Directory-job subtree locking to prevent conflicting file operations
  * Post-build TITLE_ID readback reports mismatches without failing conversions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires the first directory-as-input conversion end-to-end: a decrypted PS3 disc/JB folder → `.iso` via `makeps3iso`. It introduces `InputKind.DIRECTORY`, a new `MakePs3IsoTool` plugin, directory-aware lock manager subtree protection, a requeue/defer path for jobs blocked by an in-flight folder pack, and matching frontend selection/annotation for convertible folder rows.

- **Core conversion path**: `_plan_directory_job` validates source layout, guards against output-inside-source and out-of-volume edge cases, then routes through the standard `ConversionJob` lifecycle. `MakePs3IsoService.convert` runs `makeps3iso`, filters progress correctly, cleans partial ISOs on `BaseException`, and appends an advisory PARAM.SFO TITLE_ID readback as the terminal 100% update.
- **Lock management**: `acquire_dir_lock`/`release_dir_lock` protect the entire source subtree; `_defer_blocked_job` + `_schedule_dir_lock_requeue` implement wait-and-retry (not fail) for jobs that collide with an in-flight folder pack; `_requeue_tasks` now holds strong refs preventing premature GC of requeue tasks.
- **Frontend**: `allowsInputEntry` gates selection on `entry.type === 'directory'` + backend `convertible_by` annotation; the convertible hint badge now renders for both files and directories; `productPath` correctly derives the sibling `<folder>.iso` name.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the conversion pipeline, lock lifecycle, and partial-ISO cleanup are all correctly wired, and 994 tests pass.

The new code is carefully written with thorough edge-case handling: output-inside-source guard, volume boundary check, wait-and-retry for subtree lock collisions, and BaseException cleanup for partial ISOs. The two findings are both narrow defense-in-depth gaps that don't affect correctness in the common case.

app/services/job_manager.py (_directory_job_blocks pure-path vs realpath consistency) and app/services/makeps3iso.py (info() os.walk cost for large game folders).
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/services/makeps3iso.py | New service wrapping the makeps3iso binary; handles progress parsing, partial-ISO cleanup on BaseException, and advisory TITLE_ID readback. Clean design. |
| app/services/tools/makeps3iso.py | MakePs3IsoTool plugin: correctly declares DIRECTORY input_kind, guards detect_output with isdir, delegates all conversion to the service layer. |
| app/services/lock_manager.py | Adds acquire_dir_lock/release_dir_lock for subtree protection; _dir_overlaps_locked resolves symlinks via realpath, but _directory_job_blocks in job_manager uses a pure Path prefix check creating a minor symlink-bypass gap at the UI-layer check. |
| app/services/job_manager.py | Adds directory-job subtree awareness: _blocked_by_dir_lock, _defer_blocked_job, _schedule_dir_lock_requeue for wait-and-retry; input_kind threaded end-to-end; _requeue_tasks now holds strong refs preventing premature GC. |
| app/routes/convert.py | New _plan_directory_job validates isdir, source-layout detector, output-inside-source guard (realpath), and volume boundary; correctly plumbed through plan_job via input_kinds check. |
| app/routes/files.py | _detect_directory_outputs annotates convertible PS3 folders in both list_files and search_files; _assert_path_not_in_use extended with find_active_job_for_path for subtree containment checks. |
| Dockerfile | Adds makeps3iso-builder stage mirroring the maxcso pattern; pinned to an immutable commit hash for reproducible builds; GPL-3.0 binary shipped as standalone executable. |
| app/models.py | InputKind relocated here from spec.py to break the import cycle; ConversionJob gains input_kind field; Ps3IsoInfo model added. |
| src/lib/stores/conversion.svelte.js | Adds isDirectoryMode getter and allowsInputEntry() to gate selection on entry type + backend convertible_by annotation; clean entry-aware extension of allowsInput. |
| src/lib/tools/registry.js | Adds makeps3iso tool entry with inputKinds:['directory'], empty source/verify extensions, and correct productPath for folder→ISO naming. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Frontend
    participant Files as /api/files
    participant Convert as /api/convert
    participant JM as JobManager
    participant LM as LockManager
    participant Svc as MakePs3IsoService
    participant Bin as makeps3iso binary

    UI->>Files: GET /list (directory listing)
    Files->>Files: _detect_directory_outputs(item_path)
    Files->>Files: registry.tools_for_directory() → is_ps3_iso_source()
    Files-->>UI: "FileEntry{type:directory, convertible_by:['makeps3iso']}"

    UI->>Convert: "POST /convert {mode:folder_to_iso, file_path}"
    Convert->>Convert: plan_job → _plan_directory_job
    Convert->>Convert: Validate isdir + accepts_directory
    Convert->>Convert: Check output not inside source (realpath)
    Convert->>Convert: Check output within configured volumes
    Convert->>JM: "create_job(input_kind=DIRECTORY)"

    JM->>JM: _dispatch_job
    JM->>LM: is_within_locked_dir? (pre-check)
    LM-->>JM: false
    JM->>LM: acquire_lock(output.iso)
    LM-->>JM: acquired
    JM->>LM: acquire_dir_lock(source_folder)
    LM-->>JM: acquired (subtree locked)

    JM->>Svc: convert(folder, output.iso)
    Svc->>Bin: makeps3iso folder output.iso
    Bin-->>Svc: progress 0..99%
    Svc-->>JM: "yield {progress}"

    alt Cancellation / Error
        JM->>Svc: cancel
        Svc->>Svc: os.remove(output.iso) partial cleanup
    else Success
        Bin-->>Svc: exit 0
        Svc->>Svc: _readback_message TITLE_ID from ISO 9660
        Svc-->>JM: "yield {progress:100, message}"
    end

    JM->>LM: release_lock(output.iso)
    JM->>LM: release_dir_lock(source_folder)

    Note over JM,LM: Concurrent file job targeting path inside source_folder
    JM->>LM: acquire_lock(inner_file)
    LM-->>JM: false within_locked_dir
    JM->>JM: _defer_blocked_job → sleep 2s → requeue
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/services/lock_manager.py`, line 732-746 ([link](https://github.com/pacnpal/compressatorium/blob/07cb69017c23c10b69dac95088b569f1d0205892/app/services/lock_manager.py#L732-L746)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Disk I/O (`os.path.realpath`) while holding `_lock_mutex`**

   `_dir_overlaps_locked` iterates over `self._locks` and calls `self._resolve(p)` (i.e. `os.path.realpath`) on each currently-held file-lock path. This is disk I/O executed under `_lock_mutex`. For a large batch job with many simultaneous file locks, every call to `acquire_dir_lock` or `dir_lock_would_conflict` holds the mutex while resolving N symlinks — blocking other threads that need the lock (e.g. concurrent `acquire_lock` calls) for the full duration.

   Consider pre-resolving and caching the resolved form of each file-lock path when it is first acquired (already done for dir-lock entries, which are stored as their resolved path) so `_dir_overlaps_locked` can do a pure in-memory set lookup instead.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Flock_manager.py%0ALine%3A%20732-746%0A%0AComment%3A%0A**Disk%20I%2FO%20%28%60os.path.realpath%60%29%20while%20holding%20%60_lock_mutex%60**%0A%0A%60_dir_overlaps_locked%60%20iterates%20over%20%60self._locks%60%20and%20calls%20%60self._resolve%28p%29%60%20%28i.e.%20%60os.path.realpath%60%29%20on%20each%20currently-held%20file-lock%20path.%20This%20is%20disk%20I%2FO%20executed%20under%20%60_lock_mutex%60.%20For%20a%20large%20batch%20job%20with%20many%20simultaneous%20file%20locks%2C%20every%20call%20to%20%60acquire_dir_lock%60%20or%20%60dir_lock_would_conflict%60%20holds%20the%20mutex%20while%20resolving%20N%20symlinks%20%E2%80%94%20blocking%20other%20threads%20that%20need%20the%20lock%20%28e.g.%20concurrent%20%60acquire_lock%60%20calls%29%20for%20the%20full%20duration.%0A%0AConsider%20pre-resolving%20and%20caching%20the%20resolved%20form%20of%20each%20file-lock%20path%20when%20it%20is%20first%20acquired%20%28already%20done%20for%20dir-lock%20entries%2C%20which%20are%20stored%20as%20their%20resolved%20path%29%20so%20%60_dir_overlaps_locked%60%20can%20do%20a%20pure%20in-memory%20set%20lookup%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2Fcool-noether-7lo4ey%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fcool-noether-7lo4ey%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Flock_manager.py%0ALine%3A%20732-746%0A%0AComment%3A%0A**Disk%20I%2FO%20%28%60os.path.realpath%60%29%20while%20holding%20%60_lock_mutex%60**%0A%0A%60_dir_overlaps_locked%60%20iterates%20over%20%60self._locks%60%20and%20calls%20%60self._resolve%28p%29%60%20%28i.e.%20%60os.path.realpath%60%29%20on%20each%20currently-held%20file-lock%20path.%20This%20is%20disk%20I%2FO%20executed%20under%20%60_lock_mutex%60.%20For%20a%20large%20batch%20job%20with%20many%20simultaneous%20file%20locks%2C%20every%20call%20to%20%60acquire_dir_lock%60%20or%20%60dir_lock_would_conflict%60%20holds%20the%20mutex%20while%20resolving%20N%20symlinks%20%E2%80%94%20blocking%20other%20threads%20that%20need%20the%20lock%20%28e.g.%20concurrent%20%60acquire_lock%60%20calls%29%20for%20the%20full%20duration.%0A%0AConsider%20pre-resolving%20and%20caching%20the%20resolved%20form%20of%20each%20file-lock%20path%20when%20it%20is%20first%20acquired%20%28already%20done%20for%20dir-lock%20entries%2C%20which%20are%20stored%20as%20their%20resolved%20path%29%20so%20%60_dir_overlaps_locked%60%20can%20do%20a%20pure%20in-memory%20set%20lookup%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=158&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["job\_manager: keep strong refs to in-flig..."](https://github.com/pacnpal/compressatorium/commit/96c44dc3c3eb9db48c8d7c9b165ceb8ffff627a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37266235)</sub>

<!-- /greptile_comment -->