### PR TITLE
docs: align makeps3iso subtree-lock / wait-requeue / symlink-volume guards with shipped code

### DIFF
--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -458,11 +458,29 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   `convertible_by` + the sibling `.iso` output in **both** `scan_directory` and
   the recursive search `_scan` (the latter emits the folder as a job unit and
   does not recurse past it, so it's discoverable / batch-selectable).
-- **Lock manager.** A directory job protects its whole subtree:
-  `find_active_job_for_path` / `_is_path_in_use_by_other_job` (and the files-route
-  `_assert_path_not_in_use`, which delegates to the former) treat any path that is
-  a **descendant** of an active `InputKind.DIRECTORY` job's source as in-use, so a
-  per-file job / rename / delete inside an in-flight folder can't corrupt the ISO.
+- **Lock manager.** A directory job protects its whole subtree two ways:
+  - *Admission* (rename / delete / new-job validation): `find_active_job_for_path`
+    / `_is_path_in_use_by_other_job` (and the files-route `_assert_path_not_in_use`,
+    which delegates to the former) treat any path that is a **descendant** of an
+    active `InputKind.DIRECTORY` job's source as in-use, so a rename / delete
+    inside an in-flight folder is rejected.
+  - *Runtime* (concurrent conversions): the lock manager exposes directory-lock
+    APIs — `acquire_dir_lock` / `release_dir_lock` (cross-process `fcntl` lock on
+    the resolved subtree) plus the read-only `is_within_locked_dir` /
+    `dir_lock_would_conflict`. A directory job holds its subtree lock for the
+    whole run; per-file jobs hit `acquire_lock`'s subtree guard. When
+    `MAX_CONCURRENT_JOBS > 1`, a job whose input/output falls inside a locked
+    subtree is **deferred, not failed**: `_process_job` releases the concurrency
+    slot (and any output lock taken) and `_schedule_dir_lock_requeue` re-queues
+    it after a fixed short delay, so it runs once the folder job releases the lock —
+    a `Set[asyncio.Task]` holds strong refs so a requeue task can't be GC'd
+    mid-sleep. All containment comparisons (admission and runtime) resolve
+    symlinks via `os.path.realpath`, so a symlinked path into a locked folder
+    can't bypass them; resolution is gated on a dir lock actually being held to
+    keep the hot listing path cheap. `_plan_directory_job` additionally rejects a
+    derived output that resolves inside the source or outside the configured
+    volumes, so a folder-at-volume-root build can't write a sibling `.iso`
+    outside all volumes or ingest its own in-progress ISO.
 - **Plan + UI.** `plan_job` branches on `InputKind.DIRECTORY in spec.input_kinds`
   (validate `isdir` + the detector, normalized basename for output + display
   name). The frontend mode carries `inputKinds: ['directory']`; a *convertible*

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -459,22 +459,32 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   the recursive search `_scan` (the latter emits the folder as a job unit and
   does not recurse past it, so it's discoverable / batch-selectable).
 - **Lock manager.** A directory job protects its whole subtree two ways:
-  - *Admission* (rename / delete / new-job validation): `find_active_job_for_path`
-    / `_is_path_in_use_by_other_job` (and the files-route `_assert_path_not_in_use`,
-    which delegates to the former) treat any path that is a **descendant** of an
-    active `InputKind.DIRECTORY` job's source as in-use, so a rename / delete
-    inside an in-flight folder is rejected.
+  - *Filesystem mutation* (rename / delete / delete-on-verify cleanup): the
+    files-route `_assert_path_not_in_use` (→ `find_active_job_for_path`) rejects
+    a rename or delete of any path that is a **descendant** of an active
+    `InputKind.DIRECTORY` job's source, and delete-on-verify cleanup applies the
+    same descendant check via `_is_path_in_use_by_other_job`. (New-job *output*
+    collisions are handled separately by `check_output_conflicts` in `plan_job`,
+    not these helpers.)
   - *Runtime* (concurrent conversions): the lock manager exposes directory-lock
-    APIs — `acquire_dir_lock` / `release_dir_lock` (cross-process `fcntl` lock on
-    the resolved subtree) plus the read-only `is_within_locked_dir` /
-    `dir_lock_would_conflict`. A directory job holds its subtree lock for the
-    whole run; per-file jobs hit `acquire_lock`'s subtree guard. When
-    `MAX_CONCURRENT_JOBS > 1`, a job whose input/output falls inside a locked
-    subtree is **deferred, not failed**: `_process_job` releases the concurrency
-    slot (and any output lock taken) and `_schedule_dir_lock_requeue` re-queues
-    it after a fixed short delay, so it runs once the folder job releases the lock —
-    a `Set[asyncio.Task]` holds strong refs so a requeue task can't be GC'd
-    mid-sleep. All containment comparisons (admission and runtime) resolve
+    APIs — `acquire_dir_lock` / `release_dir_lock` plus the read-only
+    `is_within_locked_dir` / `dir_lock_would_conflict`. `acquire_dir_lock` takes
+    an `fcntl` lock on the **directory path itself** (so the exact same path is
+    cross-process exclusive) and records the resolved path in an in-memory
+    `_dir_locks` set; **subtree containment is enforced in-process** — a per-file
+    `acquire_lock` checks `_dir_locks` and contends on a child output, and the
+    code notes this is sound because `MAX_CONCURRENT_JOBS` concurrency all lives
+    in one process (it is *not* a cross-process subtree lock — a child output in
+    a second process hashes to a different lock file). A directory job holds the
+    lock for its whole run. When `MAX_CONCURRENT_JOBS > 1`, a job whose
+    input/output falls inside a locked subtree is **deferred, not failed**:
+    `_process_job` releases the concurrency slot (and any output lock taken) and
+    `_schedule_dir_lock_requeue` re-queues it after a fixed short delay, so it
+    runs once the folder job releases the lock — a `Set[asyncio.Task]` holds
+    strong refs so a requeue task can't be GC'd mid-sleep. (A *new* submission
+    whose output is already inside the locked subtree never reaches this path: it
+    is rejected at plan time by `check_output_conflicts`, which reads the dir lock
+    through `check_file_status`.) All containment comparisons resolve
     symlinks via `os.path.realpath`, so a symlinked path into a locked folder
     can't bypass them; resolution is gated on a dir lock actually being held to
     keep the hot listing path cheap. `_plan_directory_job` additionally rejects a

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -41,17 +41,16 @@
   APIs (`acquire_dir_lock` / `release_dir_lock` / `is_within_locked_dir` /
   `dir_lock_would_conflict`): a directory job takes an exclusive `fcntl` lock on
   its whole subtree, so concurrent jobs serialize. A job blocked by that lock is
-  **deferred** — its slot is released and it is re-queued (after a fixed short delay) to run
-  once the folder finishes, instead of failing. A rename / delete inside an
+  **deferred** — its slot is released and it is re-queued after a fixed short
+  delay to run once the folder finishes, instead of failing (a `Set[asyncio.Task]`
+  holds strong refs so the retry task can't be GC'd mid-sleep). A rename / delete inside an
   in-flight folder is still rejected outright (via `find_active_job_for_path`).
   All subtree containment comparisons resolve symlinks (`os.path.realpath`) so a
   symlinked path into a locked folder can't slip past them, and
   `_plan_directory_job` validates the resolved output is not inside the source
   **and** is within a configured volume. `InputKind` moved
   from `services.tools.spec` to `models` (re-exported) so the job model can type
-  the field without an import cycle (the requeue uses a fixed short delay and a
-  `Set[asyncio.Task]` keeps strong refs so the retry task can't be GC'd
-  mid-sleep). The makeps3iso binary (GPL-3.0,
+  the field without an import cycle. The makeps3iso binary (GPL-3.0,
   `bucanero/ps3iso-utils`, pinned commit) is built unmodified in the multi-stage
   `Dockerfile`, mirroring maxcso, and confirmed to build on linux/amd64 and
   linux/arm64 (plain portable C, no x86 asm). Tests: `tests/test_makeps3iso.py`,

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -18,15 +18,17 @@
   in the job message. Decryption and keys are **out of scope** — this only
   repackages folders you already decrypted, and it never deletes the source
   folder (no delete-on-verify).
-- **Concurrent jobs that touch a folder being packed wait their turn.** While a
-  PS3 folder is being built into an ISO its whole subtree is locked, so a
-  per-file conversion whose input or output lands inside that folder (only
-  possible when `MAX_CONCURRENT_JOBS > 1`) is **re-queued and retried** once the
-  folder job finishes rather than failing — it queues like any other job. The
-  default output (`<folder>.iso`) must also land inside a configured volume; if
-  the folder is itself a volume root (so the sibling output would escape all
-  volumes), the plan is rejected with a clear message asking for an in-volume
-  output directory.
+- **Concurrent jobs that touch a folder being packed don't corrupt it.** While a
+  PS3 folder is being built into an ISO its whole subtree is locked. A per-file
+  job that was **already queued** when the folder build starts and whose
+  input/output lands inside that folder (only reachable when
+  `MAX_CONCURRENT_JOBS > 1`) is **deferred — re-queued and retried** once the
+  folder job finishes, instead of failing. A *new* request submitted while the
+  folder is mid-build is treated like any other output collision: it's rejected
+  up front (HTTP 409 for a single job, skipped in a batch). The default output
+  (`<folder>.iso`) must also land inside a configured volume; if the folder is
+  itself a volume root (so the sibling output would escape all volumes), the plan
+  is rejected with a clear message asking for an in-volume output directory.
 
 #### Internal
 
@@ -39,12 +41,20 @@
   **and** recursive search, frontend selection for convertible folders, and
   lock-manager **subtree protection**. The lock manager grows directory-lock
   APIs (`acquire_dir_lock` / `release_dir_lock` / `is_within_locked_dir` /
-  `dir_lock_would_conflict`): a directory job takes an exclusive `fcntl` lock on
-  its whole subtree, so concurrent jobs serialize. A job blocked by that lock is
+  `dir_lock_would_conflict`): a directory job takes an `fcntl` lock on the
+  directory path itself and records the subtree in an in-memory `_dir_locks`
+  set; subtree containment (whether a per-file output lands inside) is enforced
+  **in-process** (the `MAX_CONCURRENT_JOBS` concurrency all lives in one
+  process), so a child path contends just like an output collision. A job
+  already queued when the lock is taken and found to fall inside the subtree is
   **deferred** — its slot is released and it is re-queued after a fixed short
   delay to run once the folder finishes, instead of failing (a `Set[asyncio.Task]`
-  holds strong refs so the retry task can't be GC'd mid-sleep). A rename / delete inside an
-  in-flight folder is still rejected outright (via `find_active_job_for_path`).
+  holds strong refs so the retry task can't be GC'd mid-sleep); a *new*
+  submission whose output is already inside the locked subtree is rejected at
+  plan time via `check_output_conflicts` like any collision. A rename / delete
+  inside an in-flight folder is rejected by the files route's
+  `_assert_path_not_in_use` (→ `find_active_job_for_path`), and delete-on-verify
+  cleanup honors the same descendant check (`_is_path_in_use_by_other_job`).
   All subtree containment comparisons resolve symlinks (`os.path.realpath`) so a
   symlinked path into a locked folder can't slip past them, and
   `_plan_directory_job` validates the resolved output is not inside the source

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -18,6 +18,15 @@
   in the job message. Decryption and keys are **out of scope** — this only
   repackages folders you already decrypted, and it never deletes the source
   folder (no delete-on-verify).
+- **Concurrent jobs that touch a folder being packed wait their turn.** While a
+  PS3 folder is being built into an ISO its whole subtree is locked, so a
+  per-file conversion whose input or output lands inside that folder (only
+  possible when `MAX_CONCURRENT_JOBS > 1`) is **re-queued and retried** once the
+  folder job finishes rather than failing — it queues like any other job. The
+  default output (`<folder>.iso`) must also land inside a configured volume; if
+  the folder is itself a volume root (so the sibling output would escape all
+  volumes), the plan is rejected with a clear message asking for an in-volume
+  output directory.
 
 #### Internal
 
@@ -28,10 +37,21 @@
   threaded through `plan_job` / the job pipeline (a directory source skips the
   archive-extract path), convertible-directory annotation in the file listing
   **and** recursive search, frontend selection for convertible folders, and
-  lock-manager **subtree protection** (a per-file job / rename / delete inside an
-  in-flight folder is rejected so it can't corrupt the ISO). `InputKind` moved
+  lock-manager **subtree protection**. The lock manager grows directory-lock
+  APIs (`acquire_dir_lock` / `release_dir_lock` / `is_within_locked_dir` /
+  `dir_lock_would_conflict`): a directory job takes an exclusive `fcntl` lock on
+  its whole subtree, so concurrent jobs serialize. A job blocked by that lock is
+  **deferred** — its slot is released and it is re-queued (after a fixed short delay) to run
+  once the folder finishes, instead of failing. A rename / delete inside an
+  in-flight folder is still rejected outright (via `find_active_job_for_path`).
+  All subtree containment comparisons resolve symlinks (`os.path.realpath`) so a
+  symlinked path into a locked folder can't slip past them, and
+  `_plan_directory_job` validates the resolved output is not inside the source
+  **and** is within a configured volume. `InputKind` moved
   from `services.tools.spec` to `models` (re-exported) so the job model can type
-  the field without an import cycle. The makeps3iso binary (GPL-3.0,
+  the field without an import cycle (the requeue uses a fixed short delay and a
+  `Set[asyncio.Task]` keeps strong refs so the retry task can't be GC'd
+  mid-sleep). The makeps3iso binary (GPL-3.0,
   `bucanero/ps3iso-utils`, pinned commit) is built unmodified in the multi-stage
   `Dockerfile`, mirroring maxcso, and confirmed to build on linux/amd64 and
   linux/arm64 (plain portable C, no x86 asm). Tests: `tests/test_makeps3iso.py`,


### PR DESCRIPTION
Docs-only follow-up to #158. The PS3 folder→ISO feature's locking behavior changed across the later commits on that PR (`57b7ab7` subtree lock, `07cb690` wait/requeue + symlink/volume guards, `96c44dc` strong task refs), but the docs still described the original `99995f2` behavior. This brings them in line with the merged code.

### `docs/RELEASE_NOTES.md`
- **New** section: added a user-facing note that, under `MAX_CONCURRENT_JOBS > 1`, a per-file job whose input/output lands inside an in-flight folder build is **re-queued and retried** rather than failing, and that the derived `<folder>.iso` output must land inside a configured volume (folder-at-volume-root is rejected with a clear message).
- **Internal** paragraph: corrected the locking description — exclusive `fcntl` subtree lock, the defer/requeue flow (fixed short delay + `Set[asyncio.Task]` strong refs), the new lock-manager APIs, and realpath-resolved containment.

### `docs/DESIGN_tool_plugin_architecture.md`
- Split the §3.3 Lock-manager bullet into **admission** (rename/delete via `find_active_job_for_path`) vs. **runtime** (the `acquire_dir_lock` / `release_dir_lock` / `is_within_locked_dir` / `dir_lock_would_conflict` APIs, the deferred-requeue path, `realpath` containment, and the output not-inside-source / in-volume validation).

No behavior change — documentation only.

https://claude.ai/code/session_018MavEx3D8vzgkj7t2ttsS5

---
_Generated by [Claude Code](https://claude.ai/code/session_018MavEx3D8vzgkj7t2ttsS5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design documentation with expanded details on directory lock management and concurrent job handling.
  * Added release notes documenting concurrent folder-pack job serialization via subtree locking, with blocked jobs requeued and retried after folder builds complete.
  * Documented output placement validation ensuring derived outputs stay within configured volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Documentation-only follow-up to PR #158 that corrects the lock-manager, deferred-requeue, and volume-validation descriptions in two docs files to match the behavior that was actually shipped.

- **`docs/RELEASE_NOTES.md`**: adds a user-facing bullet explaining that queued per-file jobs whose paths fall inside an in-flight folder build are re-queued rather than failed, and that the derived `.iso` output must land inside a configured volume; expands the internal paragraph with the full subtree-lock semantics (`fcntl` dir lock + in-memory `_dir_locks` set, `_schedule_dir_lock_requeue`, `realpath` containment, `_plan_directory_job` volume validation).
- **`docs/DESIGN_tool_plugin_architecture.md`**: splits the former single Lock-manager bullet into two sub-bullets — *Filesystem mutation* (rename/delete via `_assert_path_not_in_use` / `_is_path_in_use_by_other_job`) and *Runtime* (the four directory-lock APIs, the deferred-requeue path, in-process subtree containment caveat, `realpath` resolution, and output-in-volume validation).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no runtime code touched; safe to merge.

Both files are pure prose updates. The new user-facing bullet and the expanded internal paragraph are internally consistent with each other and faithfully reflect the implementation described in the PR #158 commits — the fcntl/in-memory split, the deferred-requeue path, the realpath containment gate, and the volume validation are all described accurately. No code paths, migrations, or configuration files are modified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/RELEASE_NOTES.md | Adds user-facing concurrent-lock bullet and expands internal implementation paragraph; descriptions are consistent with the DESIGN doc and the PR #158 commits cited. |
| docs/DESIGN_tool_plugin_architecture.md | Lock-manager bullet correctly split into filesystem-mutation and runtime sub-sections; the in-process subtree caveat and cross-process fcntl distinction are accurately captured. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Job submitted] --> B{Is input/output\ninside a locked subtree?}
    B -- No --> C[Proceed normally\nacquire_lock / run]
    B -- Yes\n_new_ submission --> D[Rejected at plan time\ncheck_output_conflicts\nHTTP 409 / batch skip]
    B -- Yes\nalready queued --> E[_process_job detects conflict\nvia acquire_dir_lock]
    E --> F[Release concurrency slot\n& any output lock]
    F --> G[_schedule_dir_lock_requeue\nfixed short delay]
    G --> H{Dir lock still\nheld?}
    H -- Yes --> G
    H -- No --> C

    subgraph Subtree Lock Lifecycle
        L1[acquire_dir_lock\nfcntl lock on dir path\n+ record in _dir_locks set] --> L2[Job runs\nsubtree protected]
        L2 --> L3[release_dir_lock\nremove from _dir_locks]
    end

    subgraph Containment Checks
        CC1[os.path.realpath resolution\nonly when _dir_locks non-empty] --> CC2[is_within_locked_dir]
        CC1 --> CC3[dir_lock_would_conflict]
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs: correct lock-manager accuracy (Cod..."](https://github.com/pacnpal/compressatorium/commit/4ac1efb2c29c8ff94c2ec3f0137e08040ddac06e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37396906)</sub>

<!-- /greptile_comment -->