### PR TITLE
makeps3iso: optional 4 GB FAT32 split (-s), with split-set folding in the browser

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -122,6 +122,11 @@ class FileEntry(BaseModel):
     # archive's members so only single-ROM .7z/.zip surface its row-actions —
     # not every archive. Empty when no tool can verify/info the path.
     verifiable_by: list[str] = []
+    # For a folded split-ISO set (makeps3iso -s output: Game.iso.0, .1, ...): the
+    # number of part files this single logical entry represents. None for an
+    # ordinary single-file entry. The entry's ``path`` points at the ``.0`` part
+    # (what RPCS3 mounts / verify reads) and ``size`` is the summed part size.
+    split_parts: int | None = None
 
 
 class DirectoryListing(BaseModel):
@@ -153,6 +158,9 @@ class ConversionJob(BaseModel):
     allow_overwrite: bool = False
     compression: str | None = None
     delete_on_verify: bool = False
+    # Split the output into ~4 GB parts for FAT32 targets (makeps3iso -s).
+    # Only meaningful for the folder->iso directory mode; ignored elsewhere.
+    split: bool = False
     # The unit of work this job consumes. FILE for every existing mode; a
     # directory-input mode (makeps3iso folder->iso) carries DIRECTORY so the
     # pipeline skips the archive-extract / file-only assumptions and the lock
@@ -170,6 +178,7 @@ class JobCreateRequest(BaseModel):
     )  # What to do if output exists
     compression: str | None = None  # Comma-separated list (e.g. "zlib,lzma")
     delete_on_verify: bool = False
+    split: bool = False  # makeps3iso folder->iso: split output into 4 GB parts
 
 
 class BatchJobCreateRequest(BaseModel):
@@ -181,6 +190,7 @@ class BatchJobCreateRequest(BaseModel):
     )  # What to do if output exists
     compression: str | None = None  # Comma-separated list (e.g. "zlib,lzma")
     delete_on_verify: bool = False
+    split: bool = False  # makeps3iso folder->iso: split output into 4 GB parts
 
 
 class CheckDuplicatesRequest(BaseModel):

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -137,6 +137,32 @@ def get_unique_output_path(base_path: str) -> str:
         counter += 1
 
 
+def _ps3_iso_output_taken(output_path: str) -> bool:
+    """Whether a PS3 ISO output path is occupied by a single file, a held lock,
+    *or* a prior split set (``<output>.iso.0``).
+
+    A ``-s`` build only writes ``<output>.iso.0``/``.1``/… (no plain
+    ``<output>.iso``) once it crosses 4 GB, so the bare-path check the other
+    tools use would miss it and silently clobber the set.
+    """
+    file_exists, is_locked = lock_manager.check_file_status(output_path)
+    return file_exists or is_locked or os.path.exists(output_path + ".0")
+
+
+def get_unique_ps3_iso_output_path(base_path: str) -> str:
+    """:func:`get_unique_output_path` that also steps past an existing split set."""
+    if not _ps3_iso_output_taken(base_path):
+        return base_path
+    path = Path(base_path)
+    stem, suffix, parent = path.stem, path.suffix, path.parent
+    counter = 1
+    while True:
+        candidate = str(parent / f"{stem}_{counter}{suffix}")
+        if not _ps3_iso_output_taken(candidate):
+            return candidate
+        counter += 1
+
+
 def check_output_conflicts(mode: str, output_path: str) -> tuple:
     file_exists, is_locked = lock_manager.check_file_status(output_path)
     exists = file_exists or is_locked
@@ -374,7 +400,11 @@ async def _plan_directory_job(
     ):
         raise SkipFile(SkipReason.PS3_OUTPUT_OUTSIDE_VOLUMES)
 
-    output_exists, is_locked = check_output_conflicts(mode, output_path)
+    # Split-set aware: a prior ``-s`` build leaves ``<output>.iso.0``/… with no
+    # plain ``<output>.iso``, so probe the ``.0`` part too (the in-flight case is
+    # already covered — a running job holds the lock on the base output path).
+    _, is_locked = check_output_conflicts(mode, output_path)
+    output_exists = await run_in_threadpool(_ps3_iso_output_taken, output_path)
     if output_exists or is_locked:
         if duplicate_action == DuplicateAction.SKIP:
             raise SkipFile(SkipReason.OUTPUT_EXISTS)
@@ -382,7 +412,9 @@ async def _plan_directory_job(
             if is_locked:
                 raise SkipFile(SkipReason.OUTPUT_LOCKED)
         elif duplicate_action == DuplicateAction.RENAME:
-            output_path = get_unique_output_path(output_path)
+            output_path = await run_in_threadpool(
+                get_unique_ps3_iso_output_path, output_path,
+            )
 
     allow_overwrite = (
         duplicate_action == DuplicateAction.OVERWRITE and output_exists
@@ -818,6 +850,7 @@ async def create_job(request: JobCreateRequest):
             filename_override=plan.display_filename,
             compression=compression,
             delete_on_verify=request.delete_on_verify,
+            split=request.split,
             delete_snapshot=plan.delete_snapshot,
         )
     except QueueBackpressureError as exc:
@@ -969,6 +1002,7 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
             request.mode,
             compression=compression,
             delete_on_verify=request.delete_on_verify,
+            split=request.split,
         )
     except QueueBackpressureError as exc:
         raise HTTPException(status_code=429, detail=exc.detail) from exc

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -173,6 +173,14 @@ def check_output_conflicts(mode: str, output_path: str) -> tuple:
         bin_exists, bin_locked = lock_manager.check_file_status(bin_path)
         exists = exists or bin_exists or bin_locked
         locked = locked or bin_locked
+    elif mode == "folder_to_iso":
+        # A prior makeps3iso ``-s`` build over 4 GB leaves ``<output>.iso.0``
+        # (and ``.1``/…) with no plain ``<output>.iso``, so the bare-path check
+        # above would miss it. Probe the ``.0`` part so the duplicate preflight
+        # (/jobs/check-duplicates) and plan agree a split set already occupies
+        # the target.
+        if os.path.exists(output_path + ".0"):
+            exists = True
 
     return exists, locked
 
@@ -400,11 +408,10 @@ async def _plan_directory_job(
     ):
         raise SkipFile(SkipReason.PS3_OUTPUT_OUTSIDE_VOLUMES)
 
-    # Split-set aware: a prior ``-s`` build leaves ``<output>.iso.0``/… with no
-    # plain ``<output>.iso``, so probe the ``.0`` part too (the in-flight case is
-    # already covered — a running job holds the lock on the base output path).
-    _, is_locked = check_output_conflicts(mode, output_path)
-    output_exists = await run_in_threadpool(_ps3_iso_output_taken, output_path)
+    # check_output_conflicts is split-set aware for folder_to_iso (it probes the
+    # .0 part), so a prior split build counts as an existing output here and in
+    # the /jobs/check-duplicates preflight alike.
+    output_exists, is_locked = check_output_conflicts(mode, output_path)
     if output_exists or is_locked:
         if duplicate_action == DuplicateAction.SKIP:
             raise SkipFile(SkipReason.OUTPUT_EXISTS)

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -60,7 +60,15 @@ def _fold_split_iso_entries(entries: list[FileEntry]) -> list[FileEntry]:
         match = _SPLIT_ISO_PART_RE.match(entry.name)
         if match:
             groups.setdefault(match.group("base"), {})[int(match.group("idx"))] = entry
-    foldable = {base: parts for base, parts in groups.items() if 0 in parts}
+    # Fold only a *complete* set: indices contiguous from 0 (0,1,…,N-1). An
+    # interrupted copy/write can leave a gap (e.g. .0 + .2, no .1); folding that
+    # would render one "valid" Game.iso hiding a corrupt/incomplete set, so leave
+    # such parts visible as their raw .N rows instead.
+    foldable = {
+        base: parts
+        for base, parts in groups.items()
+        if set(parts) == set(range(len(parts)))  # implies 0 in parts and no gaps
+    }
     if not foldable:
         return entries
 

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -1,5 +1,6 @@
 from logging_setup import get_logger
 import os
+import re
 import shutil
 from pathlib import Path
 
@@ -33,6 +34,59 @@ logger = get_logger("files")
 # Upper bound on archives summarized in one /archive-summary request. The browser
 # hydrates the visible page, so this is a safety ceiling, not the normal size.
 MAX_ARCHIVE_SUMMARY_PATHS = 1000
+
+
+# A makeps3iso ``-s`` split set: ``Game.iso.0``, ``Game.iso.1``, … The numeric
+# suffix follows a real ``.iso`` so a plain ``.iso`` never matches.
+_SPLIT_ISO_PART_RE = re.compile(r"^(?P<base>.+\.iso)\.(?P<idx>\d+)$", re.IGNORECASE)
+
+
+def _fold_split_iso_entries(entries: list[FileEntry]) -> list[FileEntry]:
+    """Collapse a makeps3iso split set into one logical ISO entry.
+
+    A ``-s`` build over 4 GB writes ``Game.iso.0`` / ``.1`` / … and no plain
+    ``Game.iso``. Listing them raw would scatter a single game across several
+    ``.0`` / ``.1`` rows, so fold each set (keyed on the ``.0`` part) into one
+    entry: display name ``Game.iso``, ``path`` pointing at the ``.0`` part (what
+    RPCS3 mounts), ``size`` summed across parts, and ``split_parts`` = the count.
+    The set is a final FAT32 deliverable, not a convertible source, so it carries
+    no ``convertible_by`` / ``verifiable_by`` (you'd re-pack from the folder, not
+    a partial first chunk). An orphan ``.1`` with no ``.0`` is left untouched.
+    """
+    groups: dict[str, dict[int, FileEntry]] = {}
+    for entry in entries:
+        if entry.type != "file":
+            continue
+        match = _SPLIT_ISO_PART_RE.match(entry.name)
+        if match:
+            groups.setdefault(match.group("base"), {})[int(match.group("idx"))] = entry
+    foldable = {base: parts for base, parts in groups.items() if 0 in parts}
+    if not foldable:
+        return entries
+
+    result: list[FileEntry] = []
+    emitted: set[str] = set()
+    for entry in entries:
+        match = _SPLIT_ISO_PART_RE.match(entry.name) if entry.type == "file" else None
+        base = match.group("base") if match else None
+        if base in foldable:
+            if base in emitted:
+                continue  # a sibling part of an already-folded set — drop it
+            parts = foldable[base]
+            result.append(
+                FileEntry(
+                    name=base,
+                    path=parts[0].path,  # the .0 part is the mount/readback target
+                    type="file",
+                    size=sum(p.size or 0 for p in parts.values()),
+                    extension=".iso",
+                    split_parts=len(parts),
+                ),
+            )
+            emitted.add(base)
+            continue
+        result.append(entry)
+    return result
 
 
 def _detect_file_outputs(
@@ -364,7 +418,7 @@ async def list_files(
             raise HTTPException(status_code=403, detail="Permission denied") from None
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail="Directory not found") from None
-        return entries
+        return _fold_split_iso_entries(entries)
 
     entries = await run_in_threadpool(
         scan_directory, path, show_archives, summarize_archives,

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -23,6 +23,7 @@ from services.concurrency_manager import concurrency_manager
 from services.disc_id import embed_in_chd as disc_id_embed
 from services.disc_id import extract_from_source as disc_id_from_source
 from services.lock_manager import lock_manager
+from services.makeps3iso import makeps3iso_service
 from services.tools import registry
 from services.verification_store import verification_store
 from services.z3ds_compress import Z3DS_DECOMPRESS_FORMATS, Z3DS_OUTPUT_FORMATS
@@ -697,6 +698,10 @@ class JobManager:
             # mutation: a target *inside* the in-flight folder is in use.
             if self._directory_job_blocks(job, target):
                 return job
+            # An in-flight split build's numbered parts (Game.iso.0/.1/…) count
+            # as the job's output even though they aren't in _candidate_paths.
+            if self._split_output_blocks(job, target):
+                return job
             for candidate in self._candidate_paths(job):
                 cand_path = self._normalize_path(candidate)
                 if cand_path is None:
@@ -727,6 +732,8 @@ class JobManager:
             # directory job's source folder (its whole subtree is in use).
             if self._directory_job_blocks(job, target):
                 return True
+            if self._split_output_blocks(job, target):
+                return True
             for candidate in self._candidate_paths(job):
                 cand_path = self._normalize_path(candidate)
                 if cand_path is None:
@@ -734,6 +741,54 @@ class JobManager:
                 if cand_path == target:
                     return True
         return False
+
+    def _split_output_blocks(self, job: ConversionJob, target: Path) -> bool:
+        """Whether ``target`` is a numbered split part of an active split job's
+        output (``Game.iso.0``/``.1``/…).
+
+        makeps3iso ``-s`` renames the locked base ``.iso`` to ``.iso.0`` and
+        writes ``.iso.1``/… mid-run, so those names don't exist when the job is
+        queued and can't be listed in the static ``_candidate_paths`` (which
+        carries the base ``output_path``). A prefix check marks the whole set
+        in-use so a rename/delete can't mutate a part while it's being written.
+        """
+        if not job.split or not job.output_path:
+            return False
+        out = self._normalize_path(job.output_path)
+        if out is None or target.parent != out.parent:
+            return False
+        prefix = out.name + "."
+        suffix = target.name[len(prefix):]
+        return target.name.startswith(prefix) and suffix.isdigit()
+
+    async def _clear_existing_output(self, job: ConversionJob) -> None:
+        """Remove a prior output ahead of an **authorized** overwrite.
+
+        Gated on ``allow_overwrite`` so it never deletes an output the user chose
+        to skip/rename — including a split set (``Game.iso.0``/…) that appeared
+        after planning but before the worker started (the per-path
+        ``acquire_lock`` only sees the bare base name).
+        """
+        if not job.allow_overwrite or not job.output_path:
+            return
+        if job.input_kind == InputKind.DIRECTORY:
+            # makeps3iso output is a single .iso OR a split set (.0/.1/…); clear
+            # all of it via the tool's own part-aware cleanup.
+            await asyncio.to_thread(
+                makeps3iso_service.remove_outputs, job.output_path,
+            )
+            await verification_store.clear(job.output_path)
+            return
+        if not os.path.exists(job.output_path):
+            return
+        if not os.path.isfile(job.output_path):
+            raise RuntimeError("Output path exists and is not a file")
+        os.remove(job.output_path)
+        await verification_store.clear(job.output_path)
+        if job.mode.value == "extractcd":
+            bin_path = str(Path(job.output_path).with_suffix(".bin"))
+            if os.path.isfile(bin_path):
+                os.remove(bin_path)
 
     def _get_queued_and_processing_jobs(self) -> tuple[list[str], list[str]]:
         """Get lists of queued and processing job IDs.
@@ -1615,15 +1670,7 @@ class JobManager:
                 if cancel_event.is_set():
                     raise ConversionCancelled("Conversion cancelled")
 
-            if job.allow_overwrite and os.path.exists(job.output_path):
-                if not os.path.isfile(job.output_path):
-                    raise RuntimeError("Output path exists and is not a file")
-                os.remove(job.output_path)
-                await verification_store.clear(job.output_path)
-                if job.mode.value == "extractcd":
-                    bin_path = str(Path(job.output_path).with_suffix(".bin"))
-                    if os.path.isfile(bin_path):
-                        os.remove(bin_path)
+            await self._clear_existing_output(job)
 
             _convert_service = registry.for_mode(job.mode.value)
             async for update in _convert_service.convert(
@@ -1666,7 +1713,18 @@ class JobManager:
                 job.progress = 100
 
                 # Get output file size
-                if os.path.exists(job.output_path):
+                if job.input_kind == InputKind.DIRECTORY:
+                    # makeps3iso may finish as a single .iso OR a split set
+                    # (.0/.1/…) with no bare .iso, so sum whatever was produced
+                    # (split_parts returns [base] or the numbered parts).
+                    total_size = 0
+                    for part in makeps3iso_service.split_parts(job.output_path):
+                        try:
+                            total_size += os.path.getsize(part)
+                        except OSError:
+                            pass
+                    job.output_size = total_size if total_size > 0 else None
+                elif os.path.exists(job.output_path):
                     if job.mode.value == "extractcd":
                         cue_size = 0
                         bin_size = 0

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -140,6 +140,7 @@ class JobManager:
         filename_override: Optional[str] = None,
         compression: Optional[str] = None,
         delete_on_verify: bool = False,
+        split: bool = False,
         delete_snapshot: Optional[Dict[str, object]] = None,
     ) -> ConversionJob:
         """Queue a job while holding _create_lock (no backpressure check here)."""
@@ -196,6 +197,7 @@ class JobManager:
             allow_overwrite=allow_overwrite,
             compression=compression,
             delete_on_verify=delete_on_verify,
+            split=split,
             input_kind=input_kind,
         )
 
@@ -230,6 +232,7 @@ class JobManager:
         filename_override: Optional[str] = None,
         compression: Optional[str] = None,
         delete_on_verify: bool = False,
+        split: bool = False,
         delete_snapshot: Optional[Dict[str, object]] = None,
     ) -> ConversionJob:
         """Create a new conversion job."""
@@ -244,6 +247,7 @@ class JobManager:
                 filename_override=filename_override,
                 compression=compression,
                 delete_on_verify=delete_on_verify,
+                split=split,
                 delete_snapshot=delete_snapshot,
             )
         await self._prune_jobs()
@@ -255,6 +259,7 @@ class JobManager:
         mode: ConversionMode,
         compression: Optional[str] = None,
         delete_on_verify: bool = False,
+        split: bool = False,
     ) -> List[ConversionJob]:
         """Create multiple jobs atomically under a single backpressure check."""
         if not job_specs:
@@ -282,6 +287,7 @@ class JobManager:
                         ),
                         compression=compression,
                         delete_on_verify=delete_on_verify,
+                        split=split,
                         delete_snapshot=spec.get("delete_snapshot"),
                     )
                 )
@@ -1625,6 +1631,7 @@ class JobManager:
                 job.output_path,
                 job.mode.value,
                 compression=job.compression,
+                split=job.split,
                 cancel_event=cancel_event,
             ):
                 if cancel_event.is_set():

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -190,7 +190,7 @@ class MakePs3IsoService:
         # ``-s`` only splits past 4 GB and the part names aren't known until now,
         # so discover what was actually written. Readback targets the first file
         # (the .0 part holds the PVD / PARAM.SFO).
-        parts = self.split_parts(output_path)
+        parts = await asyncio.to_thread(self.split_parts, output_path)
         readback_target = parts[0] if parts else output_path
         message = await asyncio.to_thread(
             self._readback_message, input_path, readback_target,

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -9,14 +9,22 @@ This is the first **directory-as-input** tool: its unit of work is a folder, not
 a file with a suffix, so it relies on the ``services.ps3`` source-layout detector
 (``ToolPlugin.accepts_directory``) instead of an extension match.
 
-CLI: ``makeps3iso <input_folder> <output.iso>`` (a ``-s`` flag would split the
-output at 4 GB for FAT32; we always emit a single ``.iso`` — target volumes are
-ext4/NTFS/exFAT). makeps3iso has no native verify, so after a successful build
-the service does a light **PARAM.SFO ``TITLE_ID`` readback** from the produced
-ISO (reusing ``services.ps3`` + the shared ISO 9660 reader) and confirms it
-matches the source folder. The readback is advisory: a mismatch / unreadable
-header logs a warning but does not fail the job (and never deletes the curated
-source folder — ``supports_delete_on_verify`` is ``False``).
+CLI: ``makeps3iso [-s] <input_folder> [<output.iso>]``. With the optional ``-s``
+**split** flag (opt-in per job, for FAT32 targets that can't hold a >4 GB file)
+makeps3iso writes the image in ~4 GB parts: it only splits once the image
+crosses the threshold (``0x1FFFE0`` sectors ≈ 4 GiB), renaming the first part to
+``<output>.iso.0`` and writing ``<output>.iso.1``, ``.2`` … RPCS3 mounts the
+``.0``. A sub-4 GB title still emits a single ``<output>.iso`` even with ``-s``,
+so the produced filenames are only known **after** the build — the service
+discovers them by probing for ``<output>`` then ``<output>.0``/``.1``/… on disk.
+
+makeps3iso has no native verify, so after a successful build the service does a
+light **PARAM.SFO ``TITLE_ID`` readback** from the produced ISO (reusing
+``services.ps3`` + the shared ISO 9660 reader). The PVD / PARAM.SFO live near the
+start, so the readback always targets the **first** produced file (the ``.0``
+part when split). The readback is advisory: a mismatch / unreadable header logs a
+warning but does not fail the job (and never deletes the curated source folder —
+``supports_delete_on_verify`` is ``False``).
 """
 from __future__ import annotations
 
@@ -60,12 +68,47 @@ class MakePs3IsoService:
 
     # ----- command ----------------------------------------------------------
 
-    def _build_command(self, folder: str, output_path: str) -> list[str]:
-        cmd = [self.makeps3iso_path, folder, output_path]
+    def _build_command(
+        self, folder: str, output_path: str, *, split: bool = False,
+    ) -> list[str]:
+        # ``-s`` (split for FAT32) goes BEFORE the input folder per makeps3iso's
+        # arg parser (``makeps3iso [-s] <folder> [<output>]``).
+        cmd = [self.makeps3iso_path]
+        if split:
+            cmd.append("-s")
+        cmd += [folder, output_path]
         # run() applies nice via preexec but not ionice, so wrap with the shared
         # ionice prefix here (mirrors chdman) — packing an ISO is I/O-heavy.
         prefix = ioprio_prefix(self._runner.owner)
         return prefix + cmd if prefix else cmd
+
+    @staticmethod
+    def _numbered_parts(output_path: str) -> list[str]:
+        """Ordered ``output_path.0`` / ``.1`` / … split parts that exist on disk."""
+        parts: list[tuple[int, str]] = []
+        with contextlib.suppress(OSError):
+            for sibling in os.scandir(os.path.dirname(output_path) or "."):
+                match = re.fullmatch(
+                    re.escape(os.path.basename(output_path)) + r"\.(\d+)",
+                    sibling.name,
+                )
+                if match and sibling.is_file():
+                    parts.append((int(match.group(1)), sibling.path))
+        return [path for _, path in sorted(parts)]
+
+    @classmethod
+    def split_parts(cls, output_path: str) -> list[str]:
+        """Files makeps3iso actually produced for ``output_path``, in order.
+
+        A single ``[output_path]`` for a sub-4 GB build (split or not), or the
+        ordered ``[output_path.0, output_path.1, ...]`` parts once a ``-s`` build
+        crossed the 4 GB threshold. Empty if nothing exists. Probing the disk is
+        the only reliable signal — whether a ``-s`` build split is size-dependent
+        and unknown until it finishes.
+        """
+        if os.path.isfile(output_path):
+            return [output_path]
+        return cls._numbered_parts(output_path)
 
     def _parse_progress(self, line: str) -> int | None:
         # Take the LAST percentage on the line (makeps3iso may redraw several on
@@ -111,9 +154,10 @@ class MakePs3IsoService:
         mode: str = "folder_to_iso",  # noqa: ARG002 - single-mode tool
         *,
         compression: str | None = None,  # noqa: ARG002 - no compression knob
+        split: bool = False,
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
-        cmd = self._build_command(input_path, output_path)
+        cmd = self._build_command(input_path, output_path, split=split)
         try:
             async for update in self._runner.run(
                 cmd,
@@ -135,18 +179,37 @@ class MakePs3IsoService:
             # (ConversionCancelled), AND task cancellation / generator close,
             # which raise the BaseException-derived CancelledError / GeneratorExit
             # — caught here too so the partial is never orphaned. Remove it
-            # *synchronously* (a single local unlink): awaiting during a
-            # cancellation could be re-cancelled and skip the cleanup. Re-raise so
-            # cancellation semantics are preserved. (run() does not clean the
-            # output itself.) A missing file raises OSError, which is suppressed.
-            with contextlib.suppress(OSError):
-                os.remove(output_path)
+            # *synchronously* (local unlinks): awaiting during a cancellation
+            # could be re-cancelled and skip the cleanup. A split run may have
+            # left several parts (output.0, .1, …) plus the not-yet-renamed base,
+            # so clear them all. Re-raise so cancellation semantics are preserved.
+            # (run() does not clean the output itself.)
+            self._remove_outputs(output_path)
             raise
 
+        # ``-s`` only splits past 4 GB and the part names aren't known until now,
+        # so discover what was actually written. Readback targets the first file
+        # (the .0 part holds the PVD / PARAM.SFO).
+        parts = self.split_parts(output_path)
+        readback_target = parts[0] if parts else output_path
         message = await asyncio.to_thread(
-            self._readback_message, input_path, output_path,
+            self._readback_message, input_path, readback_target,
         )
+        if len(parts) > 1:
+            message = f"{message} — split into {len(parts)} parts"
         yield {"progress": 100, "message": message}
+
+    @classmethod
+    def _remove_outputs(cls, output_path: str) -> None:
+        """Synchronously unlink the base output *and* any split parts.
+
+        A mid-split failure can leave both the not-yet-renamed base and some
+        numbered parts, so clear both unconditionally (don't go through
+        ``split_parts``, which stops at the base when it exists).
+        """
+        for target in [output_path, *cls._numbered_parts(output_path)]:
+            with contextlib.suppress(OSError):
+                os.remove(target)
 
     @staticmethod
     def _readback_message(folder: str, iso_path: str) -> str:

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -166,15 +166,15 @@ class MakePs3IsoService:
         # (``acquire_lock(allow_existing=…)`` gates the rest).
         await asyncio.to_thread(self._remove_outputs, output_path)
         cmd = self._build_command(input_path, output_path, split=split)
+
         # A split build renames the base .iso to .iso.0 and writes .iso.1/…, so
         # the bare output_path stops growing mid-run; widen the stall probe to
         # the whole set (summed size) so a healthy split isn't killed as stalled
         # when makeps3iso's percent plateaus during a large part write.
-        growth_paths = None
-        if split:
-            growth_paths = lambda: [  # noqa: E731 - tiny resolver closure
-                output_path, *self._numbered_parts(output_path),
-            ]
+        def _growth_paths() -> list[str]:
+            return [output_path, *self._numbered_parts(output_path)]
+
+        growth_paths = _growth_paths if split else None
         try:
             async for update in self._runner.run(
                 cmd,

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -157,7 +157,24 @@ class MakePs3IsoService:
         split: bool = False,
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
+        # Overwrite cleanly: a prior build at this path may be a single ``.iso``
+        # OR a split set (``.0``/``.1``/…). The generic overwrite cleanup only
+        # unlinks the plain ``output_path``, so it misses a split set's parts —
+        # clear base + every numbered part here so a new build can't strand a
+        # stale ``.iso.N``. Safe: convert is only reached when the target is free
+        # (a no-op scan here) or overwrite was authorized upstream
+        # (``acquire_lock(allow_existing=…)`` gates the rest).
+        await asyncio.to_thread(self._remove_outputs, output_path)
         cmd = self._build_command(input_path, output_path, split=split)
+        # A split build renames the base .iso to .iso.0 and writes .iso.1/…, so
+        # the bare output_path stops growing mid-run; widen the stall probe to
+        # the whole set (summed size) so a healthy split isn't killed as stalled
+        # when makeps3iso's percent plateaus during a large part write.
+        growth_paths = None
+        if split:
+            growth_paths = lambda: [  # noqa: E731 - tiny resolver closure
+                output_path, *self._numbered_parts(output_path),
+            ]
         try:
             async for update in self._runner.run(
                 cmd,
@@ -167,6 +184,7 @@ class MakePs3IsoService:
                 cancel_event=cancel_event,
                 fail_label="makeps3iso",
                 complete_message="ISO build complete",
+                output_growth_paths=growth_paths,
             ):
                 # Hold back the runner's terminal 100% so the readback message
                 # is the final update the job records.

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -157,14 +157,6 @@ class MakePs3IsoService:
         split: bool = False,
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
-        # Overwrite cleanly: a prior build at this path may be a single ``.iso``
-        # OR a split set (``.0``/``.1``/…). The generic overwrite cleanup only
-        # unlinks the plain ``output_path``, so it misses a split set's parts —
-        # clear base + every numbered part here so a new build can't strand a
-        # stale ``.iso.N``. Safe: convert is only reached when the target is free
-        # (a no-op scan here) or overwrite was authorized upstream
-        # (``acquire_lock(allow_existing=…)`` gates the rest).
-        await asyncio.to_thread(self._remove_outputs, output_path)
         cmd = self._build_command(input_path, output_path, split=split)
 
         # A split build renames the base .iso to .iso.0 and writes .iso.1/…, so
@@ -202,7 +194,7 @@ class MakePs3IsoService:
             # left several parts (output.0, .1, …) plus the not-yet-renamed base,
             # so clear them all. Re-raise so cancellation semantics are preserved.
             # (run() does not clean the output itself.)
-            self._remove_outputs(output_path)
+            self.remove_outputs(output_path)
             raise
 
         # ``-s`` only splits past 4 GB and the part names aren't known until now,
@@ -218,10 +210,12 @@ class MakePs3IsoService:
         yield {"progress": 100, "message": message}
 
     @classmethod
-    def _remove_outputs(cls, output_path: str) -> None:
+    def remove_outputs(cls, output_path: str) -> None:
         """Synchronously unlink the base output *and* any split parts.
 
-        A mid-split failure can leave both the not-yet-renamed base and some
+        Used both for failure cleanup here and for authorized overwrite cleanup
+        by the job pipeline (which gates the call on ``allow_overwrite``). A
+        mid-split failure can leave both the not-yet-renamed base and some
         numbered parts, so clear both unconditionally (don't go through
         ``split_parts``, which stops at the base when it exists).
         """

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -84,8 +84,15 @@ class MakePs3IsoService:
 
     @staticmethod
     def _numbered_parts(output_path: str) -> list[str]:
-        """Ordered ``output_path.0`` / ``.1`` / … split parts that exist on disk."""
-        parts: list[tuple[int, str]] = []
+        """Ordered ``output_path.0`` / ``.1`` / … split parts that exist on disk.
+
+        Taken only as a contiguous run starting at ``.0`` — an unrelated numbered
+        sibling (e.g. ``Game.iso.2024`` with no ``.0``, or one beyond a gap) is
+        never enumerated, so it is never summed, probed, or deleted as part of
+        this split set. This mirrors the file-browser fold, which likewise only
+        folds a contiguous ``.0``-based set.
+        """
+        found: dict[int, str] = {}
         with contextlib.suppress(OSError):
             for sibling in os.scandir(os.path.dirname(output_path) or "."):
                 match = re.fullmatch(
@@ -93,8 +100,13 @@ class MakePs3IsoService:
                     sibling.name,
                 )
                 if match and sibling.is_file():
-                    parts.append((int(match.group(1)), sibling.path))
-        return [path for _, path in sorted(parts)]
+                    found[int(match.group(1))] = sibling.path
+        parts: list[str] = []
+        idx = 0
+        while idx in found:
+            parts.append(found[idx])
+            idx += 1
+        return parts
 
     @classmethod
     def split_parts(cls, output_path: str) -> list[str]:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -259,6 +259,7 @@ class SubprocessRunner:
         fail_label: str = "process",
         complete_message: str = "Conversion complete",
         cwd: str | None = None,
+        output_growth_paths: Callable[[], list[str]] | None = None,
     ) -> AsyncGenerator[dict, None]:
         """Spawn ``cmd``, stream stdout, and yield ``{"progress", "message"}``.
 
@@ -269,6 +270,13 @@ class SubprocessRunner:
         cancel watcher (terminate -> kill), ``ConversionCancelled`` on request,
         a non-zero-exit ``RuntimeError`` carrying the output tail, and the final
         100% emit.
+
+        ``output_growth_paths`` is an optional callable returning the set of
+        files whose **summed** size is the growth signal for stall detection,
+        replacing the single ``output_path`` probe. A tool whose output filename
+        changes mid-run uses it so the probe keeps following the write — e.g.
+        makeps3iso ``-s`` renames the base ``.iso`` to ``.iso.0`` and then writes
+        ``.iso.1``/…, which the bare ``output_path`` probe would stop seeing.
         """
         output_dir = os.path.dirname(output_path)
         if output_dir:
@@ -345,21 +353,31 @@ class SubprocessRunner:
                     if len(output_lines) > 30:
                         output_lines.pop(0)
 
+            def _measure_output() -> int | None:
+                # Summed size of the growth-probe target(s). Default is the
+                # single output_path; output_growth_paths widens it to a set
+                # whose total grows monotonically even as filenames change
+                # mid-run (makeps3iso split). Returns None when nothing exists.
+                paths = (
+                    output_growth_paths() if output_growth_paths
+                    else ([output_path] if output_path else [])
+                )
+                total = 0
+                found = False
+                for probe in paths:
+                    try:
+                        total += os.path.getsize(probe)
+                        found = True
+                    except OSError:
+                        continue
+                return total if found else None
+
             def _update_output_activity(now: float):
                 nonlocal last_output_size, last_activity_at
-                if not output_path:
+                size = _measure_output()
+                if size is None:
                     return
-                try:
-                    if not os.path.exists(output_path):
-                        return
-                    size = os.path.getsize(output_path)
-                except OSError:
-                    return
-                if last_output_size is None:
-                    last_output_size = size
-                    last_activity_at = now
-                    return
-                if size > last_output_size:
+                if last_output_size is None or size > last_output_size:
                     last_output_size = size
                     last_activity_at = now
 

--- a/app/services/tools/base.py
+++ b/app/services/tools/base.py
@@ -99,9 +99,15 @@ class ToolPlugin(Protocol):
         mode: str,
         *,
         compression: str | None = None,
+        split: bool = False,
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
-        """Run a conversion, yielding ``{"progress", "message"}`` updates."""
+        """Run a conversion, yielding ``{"progress", "message"}`` updates.
+
+        ``split`` is honored only by tools whose mode declares it (makeps3iso
+        folder->iso, ``-s`` 4 GB FAT32 split); other tools accept and ignore it,
+        exactly as they do ``compression`` they don't use.
+        """
 
     async def verify(self, path: str) -> dict:
         """Verify an output file; returns ``{"valid", "message"}``."""

--- a/app/services/tools/chain.py
+++ b/app/services/tools/chain.py
@@ -128,6 +128,7 @@ class ChainTool(BaseTool):
         mode: str,
         *,
         compression: str | None = None,
+        split: bool = False,  # noqa: ARG002 - split applies only to makeps3iso
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
         return self._run(

--- a/app/services/tools/chdman.py
+++ b/app/services/tools/chdman.py
@@ -141,6 +141,7 @@ class ChdmanTool(BaseTool):
         mode: str,
         *,
         compression: str | None = None,
+        split: bool = False,  # noqa: ARG002 - split applies only to makeps3iso
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
         return self._service.convert(

--- a/app/services/tools/dolphin.py
+++ b/app/services/tools/dolphin.py
@@ -124,6 +124,7 @@ class DolphinTool(BaseTool):
         mode: str,
         *,
         compression: str | None = None,
+        split: bool = False,  # noqa: ARG002 - split applies only to makeps3iso
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
         return self._service.convert(

--- a/app/services/tools/makeps3iso.py
+++ b/app/services/tools/makeps3iso.py
@@ -99,12 +99,13 @@ class MakePs3IsoTool(BaseTool):
         output_path: str,
         mode: str,
         *,
-        compression: str | None = None,
+        compression: str | None = None,  # noqa: ARG002 - no compression knob
+        split: bool = False,
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
         return self._service.convert(
             input_path, output_path, mode,
-            compression=compression, cancel_event=cancel_event,
+            split=split, cancel_event=cancel_event,
         )
 
     async def verify(self, path: str) -> dict:

--- a/app/services/tools/maxcso.py
+++ b/app/services/tools/maxcso.py
@@ -146,6 +146,7 @@ class MaxcsoTool(BaseTool):
         mode: str,
         *,
         compression: str | None = None,
+        split: bool = False,  # noqa: ARG002 - split applies only to makeps3iso
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
         return self._service.convert(

--- a/app/services/tools/nsz.py
+++ b/app/services/tools/nsz.py
@@ -106,6 +106,7 @@ class NszTool(BaseTool):
         mode: str,
         *,
         compression: str | None = None,
+        split: bool = False,  # noqa: ARG002 - split applies only to makeps3iso
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
         return self._service.convert(

--- a/app/services/tools/romz.py
+++ b/app/services/tools/romz.py
@@ -148,6 +148,7 @@ class RomzTool(BaseTool):
         mode: str,
         *,
         compression: str | None = None,
+        split: bool = False,  # noqa: ARG002 - split applies only to makeps3iso
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
         return self._service.convert(

--- a/app/services/tools/z3ds.py
+++ b/app/services/tools/z3ds.py
@@ -107,6 +107,7 @@ class Z3dsTool(BaseTool):
         mode: str,
         *,
         compression: str | None = None,
+        split: bool = False,  # noqa: ARG002 - split applies only to makeps3iso
         cancel_event: asyncio.Event | None = None,
     ) -> AsyncGenerator[dict, None]:
         return self._service.convert(

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -470,9 +470,27 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   `conversion.allowsInputEntry`) while the name-click still navigates — a plain
   directory stays navigation-only.
 
-The `-s` 4 GB FAT32 split flag is not exposed (single `.iso`; target volumes are
-ext4/NTFS/exFAT). makeps3iso (GPL-3.0) is built unmodified from a pinned
-`bucanero/ps3iso-utils` commit in the multi-stage `Dockerfile`, mirroring maxcso.
+- **4 GB FAT32 split (`-s`).** An opt-in per-job toggle exposes makeps3iso's
+  split mode for FAT32 targets. `split` rides the shared `ToolPlugin.convert`
+  contract beside `compression` (file tools ignore it) and threads
+  request → `create_job`/`create_jobs_atomic` → `ConversionJob.split` →
+  `convert(split=…)`; the frontend gates the checkbox on a `supportsSplit` mode
+  flag. The split is **size-dependent and its part names are unknown until the
+  build finishes**: makeps3iso only splits past ~4 GB (`0x1FFFE0` sectors),
+  renaming the first part to `<output>.iso.0` and writing `.1`/`.2`/…, but emits
+  a single `<output>.iso` below the threshold. So the service never assumes a
+  shape — `split_parts()` probes the base then `.0`/`.1`/… post-build; the
+  `TITLE_ID` readback reads the first part; failure cleanup unlinks the base and
+  every numbered part. `_plan_directory_job` counts an existing split set as an
+  output collision (RENAME steps past it via `get_unique_ps3_iso_output_path`),
+  and `files.py` folds a set into one logical listing entry
+  (`_fold_split_iso_entries`: name `<base>.iso`, `path` = the `.0` part,
+  summed size, `FileEntry.split_parts` = count, no convertible/verify
+  affordances — it's a final deliverable, not a source). The recursive *search*
+  path only emits convertible sources, so split parts never surface there.
+
+makeps3iso (GPL-3.0) is built unmodified from a pinned `bucanero/ps3iso-utils`
+commit in the multi-stage `Dockerfile`, mirroring maxcso.
 
 ### 3.4 `registry.py`
 

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -488,14 +488,26 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   summed size, `FileEntry.split_parts` = count, no convertible/verify
   affordances — it's a final deliverable, not a source). The recursive *search*
   path only emits convertible sources, so split parts never surface there.
-  Lifecycle completeness: the split-set probe lives in `check_output_conflicts`
-  (mode `folder_to_iso`), so the `/jobs/check-duplicates` preflight and the plan
-  agree a set occupies the target; the service clears any prior output (base +
-  parts) before writing so an **overwrite** can't strand a stale `.iso.N`; the
-  stall probe is widened via `SubprocessRunner.run(output_growth_paths=…)` to
-  the summed size of the set, so a split build isn't killed as stalled once the
-  base is renamed away; and `RowActionsMenu` disables single-path rename/delete
-  on a folded set (its `path` is only the `.0` part).
+  Lifecycle completeness across the multi-file model:
+  - **Conflicts:** the split-set probe lives in `check_output_conflicts`
+    (mode `folder_to_iso`), so the `/jobs/check-duplicates` preflight and the
+    plan agree a set occupies the target.
+  - **Overwrite:** `JobManager._clear_existing_output` removes the prior output
+    (single `.iso` **or** the whole split set, via `makeps3iso_service`'s
+    part-aware `remove_outputs`) **only when `allow_overwrite` was granted** — so
+    a set that appears after planning is never deleted out from under a
+    skip/rename decision (the per-path `acquire_lock` only sees the bare name).
+  - **Completed size:** the completion block sums `split_parts()` for directory
+    jobs, so a split build reports a real `output_size` instead of `None`.
+  - **Stall detection:** widened via `SubprocessRunner.run(output_growth_paths=…)`
+    to the summed size of the set, so a split build isn't killed as stalled once
+    the base is renamed away.
+  - **In-flight protection:** `_split_output_blocks` marks a running split job's
+    numbered parts in-use in `find_active_job_for_path` /
+    `_is_path_in_use_by_other_job`, so a part can't be renamed/deleted mid-write.
+  - **Row actions:** `RowActionsMenu` disables single-path rename/delete and
+    `FileList.openBulkDelete` excludes a folded set (its `path` is only the `.0`
+    part, so a single-path op would orphan `.1+`).
 
 makeps3iso (GPL-3.0) is built unmodified from a pinned `bucanero/ps3iso-utils`
 commit in the multi-stage `Dockerfile`, mirroring maxcso.

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -488,6 +488,14 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   summed size, `FileEntry.split_parts` = count, no convertible/verify
   affordances — it's a final deliverable, not a source). The recursive *search*
   path only emits convertible sources, so split parts never surface there.
+  Lifecycle completeness: the split-set probe lives in `check_output_conflicts`
+  (mode `folder_to_iso`), so the `/jobs/check-duplicates` preflight and the plan
+  agree a set occupies the target; the service clears any prior output (base +
+  parts) before writing so an **overwrite** can't strand a stale `.iso.N`; the
+  stall probe is widened via `SubprocessRunner.run(output_growth_paths=…)` to
+  the summed size of the set, so a split build isn't killed as stalled once the
+  base is renamed away; and `RowActionsMenu` disables single-path rename/delete
+  on a folded set (its `path` is only the `.0` part).
 
 makeps3iso (GPL-3.0) is built unmodified from a pinned `bucanero/ps3iso-utils`
 commit in the multi-stage `Dockerfile`, mirroring maxcso.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -18,6 +18,14 @@
   in the job message. Decryption and keys are **out of scope** — this only
   repackages folders you already decrypted, and it never deletes the source
   folder (no delete-on-verify).
+- **Optional 4 GB split for FAT32 targets.** A per-job **Split into 4 GB parts
+  (FAT32)** toggle on the PS3 ISO tool runs makeps3iso with `-s`. A FAT32
+  filesystem can't hold a single file larger than 4 GB, so most PS3 discs won't
+  fit as one `.iso`; with the toggle on, an image over ~4 GB is written as
+  `Game.iso.0`, `Game.iso.1`, … (RPCS3 mounts the `.0`). A title under 4 GB
+  still produces a single `Game.iso`. The file browser **folds a split set into
+  one entry** — it shows `Game.iso` with the combined size and a part count, not
+  a row per chunk. Default off; ext4/NTFS/exFAT targets don't need it.
 
 #### Internal
 
@@ -36,6 +44,19 @@
   `Dockerfile`, mirroring maxcso, and confirmed to build on linux/amd64 and
   linux/arm64 (plain portable C, no x86 asm). Tests: `tests/test_makeps3iso.py`,
   plus directory coverage in `tests/test_ps3_detector.py`.
+- **Split (`-s`) plumbing.** A `split` bool joins the shared
+  `ToolPlugin.convert` contract next to `compression` (file tools accept and
+  ignore it) and threads request → `create_job`/`create_jobs_atomic` →
+  `ConversionJob` → `convert()`. makeps3iso's split output is **size-dependent**
+  (only >4 GB splits) and the part names aren't known until the build finishes,
+  so the service discovers them by probing `<output>` then `<output>.0`/`.1`/…;
+  the `TITLE_ID` readback targets the first part and failure cleanup removes the
+  base **and** every numbered part. `_plan_directory_job` treats an existing
+  split set as an output collision (and RENAME steps past it); the file listing
+  folds a set into one `FileEntry` (`split_parts` count, `.0` as the path).
+  Frontend: a `supportsSplit` mode flag gates the toggle, masked at submit like
+  `deleteOnVerify`. Tests in `tests/test_makeps3iso.py` (argv flag placement,
+  part detection, part-aware readback/cleanup, plan collision, listing fold).
 
 ### CSO → CHD in one step (issue #98, Phase 1)
 

--- a/src/lib/api/endpoints.js
+++ b/src/lib/api/endpoints.js
@@ -160,7 +160,14 @@ export const api = {
   },
 
   // ─── Jobs ─────────────────────────────────────────────────────────────
-  createJob(filePath, mode = 'createcd', outputDir = null, compression = null, deleteOnVerify = false) {
+  createJob(
+    filePath,
+    mode = 'createcd',
+    outputDir = null,
+    compression = null,
+    deleteOnVerify = false,
+    split = false,
+  ) {
     return jsonPost(
       `${API_BASE}/jobs`,
       {
@@ -169,6 +176,7 @@ export const api = {
         output_dir: outputDir,
         compression,
         delete_on_verify: deleteOnVerify,
+        split,
       },
       {},
       'Failed to create job',
@@ -182,6 +190,7 @@ export const api = {
     duplicateAction = 'skip',
     compression = null,
     deleteOnVerify = false,
+    split = false,
   ) {
     return jsonPost(
       `${API_BASE}/jobs/batch`,
@@ -192,6 +201,7 @@ export const api = {
         duplicate_action: duplicateAction,
         compression,
         delete_on_verify: deleteOnVerify,
+        split,
       },
       {},
       'Failed to create jobs',

--- a/src/lib/components/panels/ConvertPanel.svelte
+++ b/src/lib/components/panels/ConvertPanel.svelte
@@ -27,6 +27,7 @@
   const incompatibleCount = $derived(selectedCount - convertibleCount);
   const tool = $derived(conversion.currentTool);
   const supportsDeleteOnVerify = $derived(conversion.supportsDeleteOnVerify);
+  const supportsSplit = $derived(conversion.supportsSplit);
   const converting = $derived(conversion.converting);
 
   // Delete-on-verify is validated by the backend against a snapshot of
@@ -183,6 +184,14 @@
           bind:checked={conversion.deleteOnVerify}
           label="Delete sources after successful verification"
           description="The created output is verified before sources are deleted. Skipped if verify fails."
+        />
+      {/if}
+
+      {#if supportsSplit}
+        <Checkbox
+          bind:checked={conversion.split}
+          label="Split into 4 GB parts (FAT32)"
+          description="Writes Game.iso.0, Game.iso.1, … so the image fits on FAT32. RPCS3 mounts the .0 part. Single .iso below 4 GB."
         />
       {/if}
     </div>

--- a/src/lib/components/panels/FileList.svelte
+++ b/src/lib/components/panels/FileList.svelte
@@ -161,6 +161,10 @@
       const filePaths = entries
         .filter((e) => {
           if (!e?.path || e.type === 'directory' || e.type === 'archive') return false;
+          // A folded split set advertises `.iso` but its path is only the .0
+          // part; hashing that as a whole ISO yields a false unmatched badge
+          // (and wastes a 4 GB hash pass), so skip it.
+          if (e.split_parts != null) return false;
           const ext = (e.extension ?? '').toLowerCase();
           return ext && matchExtSet.has(ext);
         })
@@ -174,9 +178,11 @@
   function openBulkVerify() {
     // Forward only filesystem paths; the verify-batch endpoint
     // rejects `archive::member` paths (treat_archives=false +
-    // os.path.isfile on the literal string).
+    // os.path.isfile on the literal string). Folded split sets are excluded
+    // too — their path is only the .0 part, so a verify would inspect a
+    // partial image.
     ui.bulkVerifyItems = Array.from(fileBrowser.selectedFiles.values())
-      .filter((e) => e?.path && !e.path.includes('::'));
+      .filter((e) => e?.path && !e.path.includes('::') && e.split_parts == null);
   }
 
   function openBulkDelete() {

--- a/src/lib/components/panels/FileList.svelte
+++ b/src/lib/components/panels/FileList.svelte
@@ -181,9 +181,12 @@
 
   function openBulkDelete() {
     // Same filter as Verify, /files/delete-batch fails on archive
-    // members for the same treat_archives=false reason.
+    // members for the same treat_archives=false reason. Folded makeps3iso
+    // split sets are also excluded: their row path is only the .0 part, so a
+    // single-path delete-batch would orphan .1+ (matching the disabled
+    // single-row Delete action).
     ui.bulkDeleteEntries = Array.from(fileBrowser.selectedFiles.values())
-      .filter((e) => e?.path && !e.path.includes('::'));
+      .filter((e) => e?.path && !e.path.includes('::') && e.split_parts == null);
   }
 
   function sortIcon(field) {

--- a/src/lib/components/panels/RowActionsMenu.svelte
+++ b/src/lib/components/panels/RowActionsMenu.svelte
@@ -79,10 +79,16 @@
   });
   const canGetInfo = $derived(!!infoTool && !inArchive);
 
+  // A folded makeps3iso split set (Game.iso.0/.1/…) is shown as one row whose
+  // path is just the .0 part, so the single-path rename/delete endpoints would
+  // only touch .0 and orphan the rest. Disable both until the backend can act
+  // on the whole set (the parts are still individually manageable if needed).
+  const isSplitSet = $derived(entry?.split_parts != null);
+
   // Rename / Delete operate on the filesystem, archive members can't be
   // renamed or deleted in-place, so disable them inside archive views.
-  const canRename = $derived(!inArchive);
-  const canDelete = $derived(!inArchive);
+  const canRename = $derived(!inArchive && !isSplitSet);
+  const canDelete = $derived(!inArchive && !isSplitSet);
 
   async function handleVerify() {
     if (!verifyTool || !verifyPath) return;

--- a/src/lib/stores/conversion.svelte.js
+++ b/src/lib/stores/conversion.svelte.js
@@ -54,6 +54,7 @@ class ConversionStore {
   dolphinCompressionLevel = $state('19');
   outputDir = $state('');
   deleteOnVerify = $state(false);
+  split = $state(false);
   customFilterMode = $state(false);
 
   duplicateCheck = $state(null);
@@ -88,6 +89,10 @@ class ConversionStore {
 
   get supportsDeleteOnVerify() {
     return !!this.currentSpec?.supportsDeleteOnVerify;
+  }
+
+  get supportsSplit() {
+    return !!this.currentSpec?.supportsSplit;
   }
 
   get allowsArchiveInput() {
@@ -285,6 +290,8 @@ class ConversionStore {
     // The backend rejects the combination outright, so a sticky flag
     // would fail the next submission instead of silently degrading.
     if (!this.supportsDeleteOnVerify) this.deleteOnVerify = false;
+    // Likewise clear the split flag when leaving a mode that offers it.
+    if (!this.supportsSplit) this.split = false;
   }
 
   setCompression(list) {
@@ -423,6 +430,8 @@ class ConversionStore {
         // going through setMode (the backend rejects the combination
         // for extract/raw modes).
         deleteOnVerify: this.supportsDeleteOnVerify && this.deleteOnVerify,
+        // Same masking for the makeps3iso 4 GB FAT32 split toggle.
+        split: this.supportsSplit && this.split,
       });
       // Report what the backend actually created. createBatch can
       // legitimately return fewer jobs than requested when the user

--- a/src/lib/stores/jobs.svelte.js
+++ b/src/lib/stores/jobs.svelte.js
@@ -301,6 +301,7 @@ class JobsStore {
         opts.outputDir ?? null,
         opts.compression ?? null,
         opts.deleteOnVerify ?? false,
+        opts.split ?? false,
       );
       this._applyJob(job);
       return job;
@@ -320,6 +321,7 @@ class JobsStore {
         opts.duplicateAction ?? 'skip',
         opts.compression ?? null,
         opts.deleteOnVerify ?? false,
+        opts.split ?? false,
       );
       if (Array.isArray(created)) {
         for (const job of created) this._applyJob(job);

--- a/src/lib/tools/registry.js
+++ b/src/lib/tools/registry.js
@@ -83,6 +83,7 @@ const PS3_VERIFY_EXTS = [];
  * @property {boolean} supportsCompressionLevel
  * @property {boolean} supportsDeleteOnVerify
  * @property {boolean} allowsArchiveInput
+ * @property {boolean} [supportsSplit] makeps3iso -s 4 GB FAT32 split (opt-in)
  */
 
 /**
@@ -477,7 +478,9 @@ export const TOOLS = [
       { mode: 'folder_to_iso', kind: 'create', label: 'PS3 Folder → ISO', group: 'makeps3iso',
         outputExt: '.iso', inputExtensions: [], inputKinds: ['directory'],
         supportsCompression: false, supportsCompressionLevel: false,
-        supportsDeleteOnVerify: false, allowsArchiveInput: false },
+        supportsDeleteOnVerify: false, allowsArchiveInput: false,
+        // makeps3iso -s: split the output into ~4 GB parts for FAT32 targets.
+        supportsSplit: true },
     ],
     // No file-path Info/Verify: a folder has no extension to route on. Left
     // undefined so infoToolsForPath / toolForVerifyPath skip this tool.

--- a/tests/test_dispatch_routing.py
+++ b/tests/test_dispatch_routing.py
@@ -74,7 +74,7 @@ def test_convert_dispatch_matches_legacy_ladder(mode, monkeypatch):
 
     def _record(tool_id):
         def _convert(input_path, output_path, mode_, *, compression=None,
-                     cancel_event=None):
+                     split=False, cancel_event=None):
             called["id"] = tool_id
 
             async def _gen():

--- a/tests/test_dispatch_routing.py
+++ b/tests/test_dispatch_routing.py
@@ -93,7 +93,8 @@ def test_convert_dispatch_matches_legacy_ladder(mode, monkeypatch):
         return [
             u
             async for u in registry.for_mode(mode).convert(
-                "/data/in", "/data/out", mode, compression=None, cancel_event=None
+                "/data/in", "/data/out", mode, compression=None, split=False,
+                cancel_event=None,
             )
         ]
 

--- a/tests/test_files_outputs_parity.py
+++ b/tests/test_files_outputs_parity.py
@@ -213,7 +213,10 @@ async def test_list_files_json_keys_are_additive(parity_env):
     for entry in listing.entries:
         keys = set(entry.model_dump().keys())
         assert LEGACY_FILEENTRY_KEYS <= keys
-        assert keys - LEGACY_FILEENTRY_KEYS == NEW_KEYS_WITH_VERIFY
+        # split_parts (issue #98): present on every FileEntry (None unless this
+        # row is a folded makeps3iso split-ISO set). The search path emits plain
+        # dicts without it, so it's only added to the listing's key set.
+        assert keys - LEGACY_FILEENTRY_KEYS == NEW_KEYS_WITH_VERIFY | {"split_parts"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -411,12 +411,13 @@ def test_split_parts_single_vs_multipart(tmp_path):
     assert makeps3iso_service.split_parts(base) == [base]
 
     # A >4 GB split leaves only numbered parts (no plain base); returned in
-    # numeric order (.2 must sort after .10's sibling, not lexically).
+    # numeric order — a double-digit part proves it's numeric, not lexical
+    # (lexically ".10" would sort before ".2").
     Path(base).unlink()
-    for n in (0, 1, 2):
+    for n in (0, 1, 2, 10):
         Path(f"{base}.{n}").write_bytes(b"x")
     assert makeps3iso_service.split_parts(base) == [
-        f"{base}.0", f"{base}.1", f"{base}.2",
+        f"{base}.0", f"{base}.1", f"{base}.2", f"{base}.10",
     ]
 
 

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -412,13 +412,40 @@ def test_split_parts_single_vs_multipart(tmp_path):
 
     # A >4 GB split leaves only numbered parts (no plain base); returned in
     # numeric order — a double-digit part proves it's numeric, not lexical
-    # (lexically ".10" would sort before ".2").
+    # (lexically ".10" would sort before ".2"). makeps3iso writes a contiguous
+    # run from .0, so the set here is contiguous 0..10.
     Path(base).unlink()
-    for n in (0, 1, 2, 10):
+    for n in range(11):
         Path(f"{base}.{n}").write_bytes(b"x")
     assert makeps3iso_service.split_parts(base) == [
-        f"{base}.0", f"{base}.1", f"{base}.2", f"{base}.10",
+        f"{base}.{n}" for n in range(11)
     ]
+
+
+def test_split_parts_ignores_noncontiguous_siblings(tmp_path):
+    """An unrelated numbered sibling is never treated as part of the split set.
+
+    ``split_parts``/``remove_outputs`` only enumerate the contiguous run from
+    ``.0``; a ``Game.iso.2024`` backup with no ``.0`` (or one beyond a gap) must
+    be left alone so authorized-overwrite cleanup can't silently delete it.
+    """
+    base = str(tmp_path / "Game.iso")
+
+    # No .0 at all -> the lone numbered sibling is not a split part.
+    stray = Path(f"{base}.2024")
+    stray.write_bytes(b"backup")
+    assert makeps3iso_service.split_parts(base) == []
+    makeps3iso_service.remove_outputs(base)
+    assert stray.exists()
+
+    # A gap stops enumeration: .0/.1 belong to the set, .2024 sits past the gap.
+    for n in (0, 1):
+        Path(f"{base}.{n}").write_bytes(b"x")
+    assert makeps3iso_service.split_parts(base) == [f"{base}.0", f"{base}.1"]
+    makeps3iso_service.remove_outputs(base)
+    assert stray.exists()
+    assert not Path(f"{base}.0").exists()
+    assert not Path(f"{base}.1").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -602,3 +602,89 @@ def test_fold_split_iso_entries_noop_without_parts():
     ]
     # No .0 part present -> list returned unchanged (a plain .iso never matches).
     assert files_routes._fold_split_iso_entries(entries) == entries
+
+
+# --------------------------------------------------------------------------- #
+# Split: overwrite cleanup, conflict detection, stall-probe widening
+# --------------------------------------------------------------------------- #
+
+
+def test_check_output_conflicts_split_aware(tmp_path):
+    out = str(tmp_path / "Game.iso")
+    # A prior split build left only the .0 part (no plain Game.iso).
+    Path(out + ".0").write_bytes(b"p0")
+    exists, _ = convert_routes.check_output_conflicts("folder_to_iso", out)
+    assert exists is True
+    # A non-directory mode ignores the .0 probe (no plain file present).
+    exists_other, _ = convert_routes.check_output_conflicts("createcd", out)
+    assert exists_other is False
+
+
+@pytest.mark.asyncio
+async def test_service_convert_overwrites_existing_split_set(tmp_path, monkeypatch):
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out_iso = str(tmp_path / "MyGame.iso")
+    # A prior split build left parts; a new (single) build must not strand them.
+    Path(f"{out_iso}.0").write_bytes(b"old0")
+    Path(f"{out_iso}.1").write_bytes(b"old1")
+
+    async def fake_run(cmd, *, output_path, complete_message, **_kwargs):
+        Path(output_path).write_bytes(b"new single iso")
+        yield {"progress": 100, "message": complete_message}
+
+    monkeypatch.setattr(makeps3iso_service._runner, "run", fake_run)
+    _ = [
+        u
+        async for u in makeps3iso_service.convert(folder, out_iso, "folder_to_iso")
+    ]
+    assert Path(out_iso).exists()
+    assert not Path(f"{out_iso}.0").exists()
+    assert not Path(f"{out_iso}.1").exists()
+
+
+@pytest.mark.asyncio
+async def test_service_convert_split_widens_stall_probe(tmp_path, monkeypatch):
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out_iso = str(tmp_path / "MyGame.iso")
+    captured: dict = {}
+
+    async def fake_run(
+        cmd, *, output_path, complete_message, output_growth_paths=None, **_kwargs,
+    ):
+        captured["growth"] = output_growth_paths
+        Path(f"{output_path}.0").write_bytes(b"a")
+        Path(f"{output_path}.1").write_bytes(b"b")
+        yield {"progress": 100, "message": complete_message}
+
+    monkeypatch.setattr(makeps3iso_service._runner, "run", fake_run)
+    _ = [
+        u
+        async for u in makeps3iso_service.convert(
+            folder, out_iso, "folder_to_iso", split=True,
+        )
+    ]
+    # A split run widens the stall probe to follow the renamed/added parts.
+    assert callable(captured["growth"])
+    assert set(captured["growth"]()) == {out_iso, f"{out_iso}.0", f"{out_iso}.1"}
+
+
+@pytest.mark.asyncio
+async def test_service_convert_no_split_leaves_stall_probe_default(tmp_path, monkeypatch):
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out_iso = str(tmp_path / "MyGame.iso")
+    captured: dict = {}
+
+    async def fake_run(
+        cmd, *, output_path, complete_message, output_growth_paths=None, **_kwargs,
+    ):
+        captured["growth"] = output_growth_paths
+        Path(output_path).write_bytes(b"iso")
+        yield {"progress": 100, "message": complete_message}
+
+    monkeypatch.setattr(makeps3iso_service._runner, "run", fake_run)
+    _ = [
+        u
+        async for u in makeps3iso_service.convert(folder, out_iso, "folder_to_iso")
+    ]
+    # Non-split build uses the default single-path probe (None).
+    assert captured["growth"] is None

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -397,3 +397,156 @@ async def test_blocked_job_requeues_instead_of_failing(tmp_path):
         job_manager._cancelled.discard(job.id)
     # With the folder lock gone, the job is no longer blocked.
     assert job_manager._blocked_by_dir_lock(job) is False
+
+
+# --------------------------------------------------------------------------- #
+# Split (-s, 4 GB FAT32) — argv, dynamic part detection, readback, cleanup
+# --------------------------------------------------------------------------- #
+
+
+def test_split_parts_single_vs_multipart(tmp_path):
+    base = str(tmp_path / "Game.iso")
+    # A sub-4 GB build (split or not) leaves the plain file -> [base].
+    Path(base).write_bytes(b"single")
+    assert makeps3iso_service.split_parts(base) == [base]
+
+    # A >4 GB split leaves only numbered parts (no plain base); returned in
+    # numeric order (.2 must sort after .10's sibling, not lexically).
+    Path(base).unlink()
+    for n in (0, 1, 2):
+        Path(f"{base}.{n}").write_bytes(b"x")
+    assert makeps3iso_service.split_parts(base) == [
+        f"{base}.0", f"{base}.1", f"{base}.2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_service_convert_split_argv_places_flag_first(tmp_path, monkeypatch):
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out_iso = str(tmp_path / "MyGame.iso")
+
+    captured: dict = {}
+
+    async def fake_run(cmd, *, output_path, complete_message, **_kwargs):
+        captured["cmd"] = cmd
+        Path(output_path).write_bytes(b"small iso")  # sub-4GB: single file
+        yield {"progress": 100, "message": complete_message}
+
+    monkeypatch.setattr(makeps3iso_service._runner, "run", fake_run)
+
+    updates = [
+        u
+        async for u in makeps3iso_service.convert(
+            folder, out_iso, "folder_to_iso", split=True,
+        )
+    ]
+    # `-s` goes before the folder: `makeps3iso -s <folder> <out.iso>`.
+    assert captured["cmd"][-4:] == [
+        makeps3iso_service.makeps3iso_path, "-s", folder, out_iso,
+    ]
+    # A single-file (sub-4GB) result carries no split suffix.
+    assert "split into" not in updates[-1]["message"]
+
+
+@pytest.mark.asyncio
+async def test_service_convert_split_multipart_message_and_readback(
+    tmp_path, monkeypatch,
+):
+    from app.services import makeps3iso as mk_module
+
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out_iso = str(tmp_path / "MyGame.iso")
+
+    async def fake_run(cmd, *, output_path, complete_message, **_kwargs):
+        # Simulate a >4GB split: two numbered parts, no plain base file.
+        Path(f"{output_path}.0").write_bytes(b"part0")
+        Path(f"{output_path}.1").write_bytes(b"part1")
+        yield {"progress": 100, "message": complete_message}
+
+    monkeypatch.setattr(makeps3iso_service._runner, "run", fake_run)
+
+    readback_paths: list[str] = []
+    monkeypatch.setattr(mk_module.ps3, "ps3_title_id", lambda _f: "BLES00000")
+
+    def _iso_id(path):
+        readback_paths.append(path)
+        return "BLES00000"
+
+    monkeypatch.setattr(mk_module.ps3, "ps3_iso_title_id", _iso_id)
+
+    updates = [
+        u
+        async for u in makeps3iso_service.convert(
+            folder, out_iso, "folder_to_iso", split=True,
+        )
+    ]
+    # Readback targets the .0 part (it holds the PVD / PARAM.SFO).
+    assert readback_paths == [f"{out_iso}.0"]
+    # The final message reports the verified id AND the part count.
+    assert "split into 2 parts" in updates[-1]["message"]
+    assert "BLES00000" in updates[-1]["message"]
+
+
+@pytest.mark.asyncio
+async def test_service_convert_split_cleanup_removes_all_parts(tmp_path, monkeypatch):
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out_iso = str(tmp_path / "MyGame.iso")
+
+    async def fake_run(cmd, *, output_path, **_kwargs):
+        Path(f"{output_path}.0").write_bytes(b"part0")
+        Path(f"{output_path}.1").write_bytes(b"part1")
+        yield {"progress": 40, "message": "Writing..."}
+        raise ConversionCancelled("cancelled")
+
+    monkeypatch.setattr(makeps3iso_service._runner, "run", fake_run)
+
+    with pytest.raises(ConversionCancelled):
+        _ = [
+            u
+            async for u in makeps3iso_service.convert(
+                folder, out_iso, "folder_to_iso", split=True,
+            )
+        ]
+    # Every split part is removed, not just the (never-written) base path.
+    assert not Path(f"{out_iso}.0").exists()
+    assert not Path(f"{out_iso}.1").exists()
+
+
+# --------------------------------------------------------------------------- #
+# plan_job: a prior split set counts as an output collision
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rejects_existing_split_set(tmp_path, monkeypatch):
+    _confine_to_volume(monkeypatch, tmp_path)
+    _make_ps3_folder(tmp_path / "MyGame")
+    # A prior split build left only the .0 part (no plain MyGame.iso).
+    (tmp_path / "MyGame.iso.0").write_bytes(b"part0")
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(tmp_path / "MyGame"),
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.OUTPUT_EXISTS
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rename_steps_past_split_set(tmp_path, monkeypatch):
+    _confine_to_volume(monkeypatch, tmp_path)
+    _make_ps3_folder(tmp_path / "MyGame")
+    (tmp_path / "MyGame.iso.0").write_bytes(b"part0")
+    plan = await convert_routes.plan_job(
+        str(tmp_path / "MyGame"),
+        spec=registry.spec("folder_to_iso"),
+        mode="folder_to_iso",
+        output_dir=None,
+        duplicate_action=convert_routes.DuplicateAction.RENAME,
+        delete_on_verify=False,
+    )
+    # RENAME bumps past the occupied split set to a free name.
+    assert plan.output_path == str(tmp_path / "MyGame_1.iso")

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -604,6 +604,23 @@ def test_fold_split_iso_entries_noop_without_parts():
     assert files_routes._fold_split_iso_entries(entries) == entries
 
 
+def test_fold_split_iso_entries_requires_contiguous_parts():
+    from app.models import FileEntry
+
+    # A gap (.0 + .2, no .1) is an incomplete/corrupt set — don't fold it into a
+    # single "valid" row; leave the raw parts visible so the gap is obvious.
+    entries = [
+        FileEntry(name="Game.iso.0", path="/d/Game.iso.0", type="file", size=1,
+                  extension=".0"),
+        FileEntry(name="Game.iso.2", path="/d/Game.iso.2", type="file", size=1,
+                  extension=".2"),
+    ]
+    folded = files_routes._fold_split_iso_entries(entries)
+    names = [e.name for e in folded]
+    assert names == ["Game.iso.0", "Game.iso.2"]
+    assert all(e.split_parts is None for e in folded)
+
+
 # --------------------------------------------------------------------------- #
 # Split: overwrite cleanup, conflict detection, stall-probe widening
 # --------------------------------------------------------------------------- #

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -621,25 +621,70 @@ def test_check_output_conflicts_split_aware(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_service_convert_overwrites_existing_split_set(tmp_path, monkeypatch):
-    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
-    out_iso = str(tmp_path / "MyGame.iso")
-    # A prior split build left parts; a new (single) build must not strand them.
-    Path(f"{out_iso}.0").write_bytes(b"old0")
-    Path(f"{out_iso}.1").write_bytes(b"old1")
+async def test_clear_existing_output_gated_on_overwrite(tmp_path, monkeypatch):
+    # Overwrite cleanup of a prior split set is gated on allow_overwrite, so a
+    # set that wasn't authorized for replacement (e.g. appeared post-plan) is
+    # never deleted out from under a skip/rename decision.
+    import app.services.job_manager as jm_module
+    from app.services.job_manager import job_manager
 
-    async def fake_run(cmd, *, output_path, complete_message, **_kwargs):
-        Path(output_path).write_bytes(b"new single iso")
-        yield {"progress": 100, "message": complete_message}
+    # The verification store needs a DB; stub its clear for this unit test.
+    async def _noop_clear(_path):
+        return None
 
-    monkeypatch.setattr(makeps3iso_service._runner, "run", fake_run)
-    _ = [
-        u
-        async for u in makeps3iso_service.convert(folder, out_iso, "folder_to_iso")
-    ]
-    assert Path(out_iso).exists()
-    assert not Path(f"{out_iso}.0").exists()
-    assert not Path(f"{out_iso}.1").exists()
+    monkeypatch.setattr(jm_module.verification_store, "clear", _noop_clear)
+
+    out = str(tmp_path / "MyGame.iso")
+    Path(f"{out}.0").write_bytes(b"0")
+    Path(f"{out}.1").write_bytes(b"1")
+    job = ConversionJob(
+        id="ps3ovw1",
+        file_path=str(tmp_path / "MyGame"),
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=out,
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=False,
+    )
+    await job_manager._clear_existing_output(job)
+    assert Path(f"{out}.0").exists() and Path(f"{out}.1").exists()
+
+    job.allow_overwrite = True
+    await job_manager._clear_existing_output(job)
+    assert not Path(f"{out}.0").exists() and not Path(f"{out}.1").exists()
+
+
+def test_find_active_job_for_inflight_split_part(tmp_path):
+    # While a split build runs, its numbered parts (Game.iso.0/.1/…) must read
+    # as in-use even though they aren't in the static candidate paths, so a
+    # rename/delete can't mutate a part mid-write.
+    from app.services.job_manager import job_manager
+
+    out = str(tmp_path / "MyGame.iso")
+    job = ConversionJob(
+        id="ps3split1",
+        file_path=str(tmp_path / "src.iso"),
+        filename="src.iso",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=out,
+        input_kind=InputKind.DIRECTORY,
+        split=True,
+    )
+    job_manager.jobs[job.id] = job
+    try:
+        assert job_manager.find_active_job_for_path(f"{out}.0") is job
+        assert job_manager.find_active_job_for_path(f"{out}.1") is job
+        # An unrelated sibling is not in use.
+        assert job_manager.find_active_job_for_path(str(tmp_path / "Other.iso")) is None
+        # Without split, a numbered part is no longer matched.
+        job.split = False
+        assert job_manager.find_active_job_for_path(f"{out}.1") is None
+    finally:
+        job_manager.jobs.pop(job.id, None)
 
 
 @pytest.mark.asyncio

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -550,3 +550,54 @@ async def test_plan_job_rename_steps_past_split_set(tmp_path, monkeypatch):
     )
     # RENAME bumps past the occupied split set to a free name.
     assert plan.output_path == str(tmp_path / "MyGame_1.iso")
+
+
+# --------------------------------------------------------------------------- #
+# File listing: fold a split ISO set into one logical entry
+# --------------------------------------------------------------------------- #
+
+
+def test_fold_split_iso_entries():
+    from app.models import FileEntry
+
+    entries = [
+        FileEntry(name="A.iso.0", path="/d/A.iso.0", type="file",
+                  size=4_000_000_000, extension=".0"),
+        FileEntry(name="A.iso.1", path="/d/A.iso.1", type="file",
+                  size=2_000_000_000, extension=".1"),
+        FileEntry(name="B.chd", path="/d/B.chd", type="file", size=10,
+                  extension=".chd", convertible_by=["chdman"]),
+        FileEntry(name="orphan.iso.1", path="/d/orphan.iso.1", type="file",
+                  size=5, extension=".1"),
+        FileEntry(name="sub", path="/d/sub", type="directory"),
+    ]
+    folded = files_routes._fold_split_iso_entries(entries)
+    names = [e.name for e in folded]
+
+    # The A.iso set collapses into one entry; siblings dropped.
+    assert "A.iso" in names
+    assert "A.iso.0" not in names and "A.iso.1" not in names
+    # An orphan .1 (no .0) and unrelated rows pass through untouched.
+    assert "orphan.iso.1" in names
+    assert "B.chd" in names and "sub" in names
+
+    folded_iso = next(e for e in folded if e.name == "A.iso")
+    assert folded_iso.path == "/d/A.iso.0"          # .0 is the mount target
+    assert folded_iso.size == 6_000_000_000          # summed across parts
+    assert folded_iso.extension == ".iso"
+    assert folded_iso.split_parts == 2
+    assert folded_iso.convertible_by == []           # a deliverable, not a source
+    assert folded_iso.verifiable_by == []
+
+
+def test_fold_split_iso_entries_noop_without_parts():
+    from app.models import FileEntry
+
+    entries = [
+        FileEntry(name="Game.iso", path="/d/Game.iso", type="file", size=1,
+                  extension=".iso"),
+        FileEntry(name="x.chd", path="/d/x.chd", type="file", size=1,
+                  extension=".chd"),
+    ]
+    # No .0 part present -> list returned unchanged (a plain .iso never matches).
+    assert files_routes._fold_split_iso_entries(entries) == entries


### PR DESCRIPTION
Adds an opt-in **Split into 4 GB parts (FAT32)** toggle to the PS3 ISO tool (makeps3iso `-s`), and folds the resulting multi-part set into one logical entry in the file browser. Follow-up to #158.

### Why
A FAT32 filesystem can't hold a single file >4 GB, so most PS3 discs won't fit as one `.iso`. With the toggle on, makeps3iso writes the image as `Game.iso.0`, `Game.iso.1`, … (RPCS3 mounts the `.0`); a title under 4 GB still produces a single `Game.iso`. Default off.

### The tricky bit
makeps3iso's split output is **size-dependent and its filenames aren't known until the build finishes** (it only splits past ~4 GB). So nothing downstream assumes a shape:
- **Service** (`makeps3iso.py`): `-s` placed before the folder per the binary's parser; `split_parts()` probes `<output>` then `<output>.0`/`.1`/… post-build; `TITLE_ID` readback targets the `.0` part; failure cleanup removes the base **and** every numbered part.
- **Plan** (`_plan_directory_job`): an existing split set counts as an output collision; RENAME steps past it.
- **Listing** (`files.py`): `_fold_split_iso_entries` collapses a set into one `FileEntry` — name `Game.iso`, `path` = the `.0` part, summed size, `split_parts` count, no convertible/verify affordances (it's a final deliverable). Search only emits convertible sources, so parts never surfaced there.

### Threading
`split` rides the shared `ToolPlugin.convert` contract next to `compression` (file tools accept and ignore it): request → `create_job`/`create_jobs_atomic` → `ConversionJob.split` → `convert(split=…)`. Frontend gates the checkbox on a new `supportsSplit` mode flag, masked at submit like `deleteOnVerify`.

### Tests
`tests/test_makeps3iso.py`: argv flag placement, single-vs-multipart `split_parts`, part-aware readback + part-count message, multi-part cleanup, plan-time split collision + rename, and the listing fold (+ no-op). Backend suite green except the pre-existing chdman-binary-dependent `test_archive_conversion_e2e` (absent in CI-less dev env; unrelated). `ruff`, `eslint`, and `vite build` all clean.

### Note
`docs/RELEASE_NOTES.md` / `docs/DESIGN_tool_plugin_architecture.md` are also touched by the open docs PR #159; edits here are localized to the makeps3iso/split regions, so any merge overlap is small and additive.

https://claude.ai/code/session_018MavEx3D8vzgkj7t2ttsS5

---
_Generated by [Claude Code](https://claude.ai/code/session_018MavEx3D8vzgkj7t2ttsS5)_



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional PS3 ISO "split into ~4GB parts" per-job toggle; split outputs folded into a single file-browser entry with part count.

* **Improvements**
  * Better collision detection and planning that treats entire split sets as occupied.
  * UI now disables/omits unsafe Rename/Delete and bulk actions for folded split entries.

* **Documentation**
  * Added design and release notes describing split workflow and behavior.

* **Tests**
  * Expanded tests covering split creation, folding, collision, cleanup, and stall/progress tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in `makeps3iso -s` split toggle that writes PS3 ISO output as `Game.iso.0`, `Game.iso.1`, … for FAT32 targets, and folds the resulting part set into a single logical browser entry. It also resolves two previously flagged issues with stale split parts on overwrite and missing `output_size` for split builds.

- **Backend**: `MakePs3IsoService` gains `-s` flag placement, a `split_parts()` / `remove_outputs()` discovery layer, and part-aware readback; `_clear_existing_output` delegates to `remove_outputs` for directory-mode jobs; `output_size` now sums all parts; `check_output_conflicts` / `get_unique_ps3_iso_output_path` probe for the `.0` sentinel; stall detection is widened to track summed part sizes via an `output_growth_paths` callable.
- **File browser**: `_fold_split_iso_entries` collapses a complete contiguous set into one `FileEntry` (name = base ISO, path = `.0` part, summed size); rename/delete/verify/bulk-delete actions are gated on `split_parts == null`.
- **Frontend**: A `supportsSplit` mode flag gates the new "Split into 4 GB parts" checkbox; the split value rides the existing `convert`/`createBatch` call path; full test coverage added in `test_makeps3iso.py`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. Both previously flagged overwrite-cleanup and output-size issues are fully addressed, and no new defects were found.

The overwrite cleanup now correctly delegates to `remove_outputs` for all directory-mode jobs, eliminating stale parts when a split set is overwritten. Output size is now summed across parts via `split_parts()`. The new `_fold_split_iso_entries` logic is guarded against incomplete sets, orphaned parts, and non-file entries. Frontend gating (rename/delete/bulk actions) is consistently applied. The test suite covers every named edge case.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/services/makeps3iso.py | Core split implementation: `-s` flag placement, `split_parts()` / `_numbered_parts()` / `remove_outputs()`, part-aware readback targeting `.0`, failure cleanup for all parts, stall-probe widening via `output_growth_paths`. |
| app/services/job_manager.py | Fixes both previously flagged issues: `_clear_existing_output` now calls `remove_outputs` for DIRECTORY jobs (removing stale parts on overwrite); `output_size` is now summed across parts for directory-mode jobs. Also adds `_split_output_blocks` for in-flight part protection. |
| app/routes/files.py | Adds `_fold_split_iso_entries`: collapses a complete contiguous split set into one `FileEntry`; gap detection leaves incomplete sets unfolded; orphan parts pass through untouched. |
| app/routes/convert.py | Adds `_ps3_iso_output_taken` / `get_unique_ps3_iso_output_path` that probe the `.0` sentinel; `check_output_conflicts` extended for `folder_to_iso` split-set collision; `split` threaded through `create_job` / `create_batch_jobs`. |
| app/services/subprocess_runner.py | Stall-detection refactored: `_measure_output` sums a dynamic list of paths; `output_growth_paths` callable replaces the single-path probe, tracking renamed/added parts correctly. |
| tests/test_makeps3iso.py | 380 lines of new tests covering argv placement, single-vs-multipart detection, readback targeting `.0`, failure cleanup, plan-time collision/rename, overwrite gating, in-flight blocking, stall-probe widening, and the listing fold including gap/orphan edge cases. |
| app/models.py | Adds `split_parts: int | None` to `FileEntry`; adds `split: bool` to `ConversionJob`, `JobCreateRequest`, and `BatchJobCreateRequest`. |
| src/lib/components/panels/FileList.svelte | Excludes folded split entries from hash checking, bulk-verify, and bulk-delete — correct since the row path is only the `.0` part. |
| src/lib/components/panels/RowActionsMenu.svelte | Disables rename and delete for folded split-set rows via `isSplitSet` derived from `split_parts != null`. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as ConvertPanel (Svelte)
    participant API as POST /jobs
    participant Plan as _plan_directory_job
    participant JM as JobManager
    participant Svc as MakePs3IsoService
    participant Runner as SubprocessRunner
    participant FS as Filesystem

    UI->>API: "{mode: folder_to_iso, split: true}"
    API->>Plan: check_output_conflicts (probes .0 sentinel)
    Plan-->>API: output_path (or _1 if renamed past split set)
    API->>JM: "create_job(split=true)"
    JM-->>API: "ConversionJob{split:true}"

    JM->>JM: "_clear_existing_output()<br/>(remove_outputs: base + .0/.1/...)"
    JM->>Svc: "convert(split=true)"
    Svc->>Runner: "run(cmd=[makeps3iso,-s,folder,out.iso],<br/>output_growth_paths=_growth_paths)"

    loop writing parts
        Runner->>FS: write Game.iso then renames to .0 writes .1...
        Runner->>Runner: _measure_output() sums growth paths
    end

    Runner-->>Svc: progress 100
    Svc->>FS: "split_parts(out.iso) -> [.0, .1]"
    Svc->>FS: _readback_message(folder, out.iso.0)
    Svc-->>JM: "{progress:100, message: split into 2 parts}"
    JM->>FS: "split_parts -> sum output_size"

    UI->>API: GET /files
    API->>API: "_fold_split_iso_entries()<br/>collapses .0/.1 -> Game.iso (split_parts=2)"
    API-->>UI: "FileEntry{name:Game.iso, path:.0, split_parts:2}"
    UI->>UI: disable rename/delete/verify for split row
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `app/services/job_manager.py`, line 1618-1622 ([link](https://github.com/pacnpal/compressatorium/blob/7cbb707ae961c59f98f8d57312573e673015dcd9/app/services/job_manager.py#L1618-L1622)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale split parts after OVERWRITE**

   When overwriting an existing split set (`Game.iso.0` / `Game.iso.1` with no plain `Game.iso`), `_ps3_iso_output_taken` correctly returns `True` and `allow_overwrite = True` is set in the plan. However, the cleanup branch here checks `os.path.exists(job.output_path)` against the **base** path (`Game.iso`), which does not exist — so the branch is skipped entirely and no old parts are removed before the new build starts.

   Two scenarios cause stale artifacts: (1) the new game is under 4 GB, so makeps3iso writes a plain `Game.iso`, leaving the old `Game.iso.0`/`.1` alongside it — `_fold_split_iso_entries` would then create a second folded entry also named `Game.iso` from the orphaned parts; (2) the new build splits into fewer parts than the old build, leaving an extra trailing part on disk. Both outcomes corrupt the file-browser view for that directory.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fjob_manager.py%0ALine%3A%201618-1622%0A%0AComment%3A%0A**Stale%20split%20parts%20after%20OVERWRITE**%0A%0AWhen%20overwriting%20an%20existing%20split%20set%20%28%60Game.iso.0%60%20%2F%20%60Game.iso.1%60%20with%20no%20plain%20%60Game.iso%60%29%2C%20%60_ps3_iso_output_taken%60%20correctly%20returns%20%60True%60%20and%20%60allow_overwrite%20%3D%20True%60%20is%20set%20in%20the%20plan.%20However%2C%20the%20cleanup%20branch%20here%20checks%20%60os.path.exists%28job.output_path%29%60%20against%20the%20**base**%20path%20%28%60Game.iso%60%29%2C%20which%20does%20not%20exist%20%E2%80%94%20so%20the%20branch%20is%20skipped%20entirely%20and%20no%20old%20parts%20are%20removed%20before%20the%20new%20build%20starts.%0A%0ATwo%20scenarios%20cause%20stale%20artifacts%3A%20%281%29%20the%20new%20game%20is%20under%204%20GB%2C%20so%20makeps3iso%20writes%20a%20plain%20%60Game.iso%60%2C%20leaving%20the%20old%20%60Game.iso.0%60%2F%60.1%60%20alongside%20it%20%E2%80%94%20%60_fold_split_iso_entries%60%20would%20then%20create%20a%20second%20folded%20entry%20also%20named%20%60Game.iso%60%20from%20the%20orphaned%20parts%3B%20%282%29%20the%20new%20build%20splits%20into%20fewer%20parts%20than%20the%20old%20build%2C%20leaving%20an%20extra%20trailing%20part%20on%20disk.%20Both%20outcomes%20corrupt%20the%20file-browser%20view%20for%20that%20directory.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2Fps3-iso-split%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fps3-iso-split%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fjob_manager.py%0ALine%3A%201618-1622%0A%0AComment%3A%0A**Stale%20split%20parts%20after%20OVERWRITE**%0A%0AWhen%20overwriting%20an%20existing%20split%20set%20%28%60Game.iso.0%60%20%2F%20%60Game.iso.1%60%20with%20no%20plain%20%60Game.iso%60%29%2C%20%60_ps3_iso_output_taken%60%20correctly%20returns%20%60True%60%20and%20%60allow_overwrite%20%3D%20True%60%20is%20set%20in%20the%20plan.%20However%2C%20the%20cleanup%20branch%20here%20checks%20%60os.path.exists%28job.output_path%29%60%20against%20the%20**base**%20path%20%28%60Game.iso%60%29%2C%20which%20does%20not%20exist%20%E2%80%94%20so%20the%20branch%20is%20skipped%20entirely%20and%20no%20old%20parts%20are%20removed%20before%20the%20new%20build%20starts.%0A%0ATwo%20scenarios%20cause%20stale%20artifacts%3A%20%281%29%20the%20new%20game%20is%20under%204%20GB%2C%20so%20makeps3iso%20writes%20a%20plain%20%60Game.iso%60%2C%20leaving%20the%20old%20%60Game.iso.0%60%2F%60.1%60%20alongside%20it%20%E2%80%94%20%60_fold_split_iso_entries%60%20would%20then%20create%20a%20second%20folded%20entry%20also%20named%20%60Game.iso%60%20from%20the%20orphaned%20parts%3B%20%282%29%20the%20new%20build%20splits%20into%20fewer%20parts%20than%20the%20old%20build%2C%20leaving%20an%20extra%20trailing%20part%20on%20disk.%20Both%20outcomes%20corrupt%20the%20file-browser%20view%20for%20that%20directory.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `app/services/job_manager.py`, line 1668-1686 ([link](https://github.com/pacnpal/compressatorium/blob/7cbb707ae961c59f98f8d57312573e673015dcd9/app/services/job_manager.py#L1668-L1686)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`output_size` is never set for split builds**

   For a successful >4 GB split build, `job.output_path` is the plain `Game.iso` path, but makeps3iso actually wrote `Game.iso.0` / `Game.iso.1` (no plain base exists). `os.path.exists(job.output_path)` is therefore `False`, so the entire size-capture block is skipped and `job.output_size` remains `None`. The job completes successfully but the reported output size is always absent, making the job card/log misleading for multi-part results.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fjob_manager.py%0ALine%3A%201668-1686%0A%0AComment%3A%0A**%60output_size%60%20is%20never%20set%20for%20split%20builds**%0A%0AFor%20a%20successful%20%3E4%20GB%20split%20build%2C%20%60job.output_path%60%20is%20the%20plain%20%60Game.iso%60%20path%2C%20but%20makeps3iso%20actually%20wrote%20%60Game.iso.0%60%20%2F%20%60Game.iso.1%60%20%28no%20plain%20base%20exists%29.%20%60os.path.exists%28job.output_path%29%60%20is%20therefore%20%60False%60%2C%20so%20the%20entire%20size-capture%20block%20is%20skipped%20and%20%60job.output_size%60%20remains%20%60None%60.%20The%20job%20completes%20successfully%20but%20the%20reported%20output%20size%20is%20always%20absent%2C%20making%20the%20job%20card%2Flog%20misleading%20for%20multi-part%20results.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2Fps3-iso-split%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fps3-iso-split%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fjob_manager.py%0ALine%3A%201668-1686%0A%0AComment%3A%0A**%60output_size%60%20is%20never%20set%20for%20split%20builds**%0A%0AFor%20a%20successful%20%3E4%20GB%20split%20build%2C%20%60job.output_path%60%20is%20the%20plain%20%60Game.iso%60%20path%2C%20but%20makeps3iso%20actually%20wrote%20%60Game.iso.0%60%20%2F%20%60Game.iso.1%60%20%28no%20plain%20base%20exists%29.%20%60os.path.exists%28job.output_path%29%60%20is%20therefore%20%60False%60%2C%20so%20the%20entire%20size-capture%20block%20is%20skipped%20and%20%60job.output_size%60%20remains%20%60None%60.%20The%20job%20completes%20successfully%20but%20the%20reported%20output%20size%20is%20always%20absent%2C%20making%20the%20job%20card%2Flog%20misleading%20for%20multi-part%20results.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/lat..."](https://github.com/pacnpal/compressatorium/commit/e2ae095863a25b20d628514c17fab8666d18aea6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37398344)</sub>

<!-- /greptile_comment -->