### PR TITLE
makeps3iso: harden split-set folding, output detection, and overwrite/collision guards

### DIFF
--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -51,7 +51,8 @@ def _fold_split_iso_entries(entries: list[FileEntry]) -> list[FileEntry]:
     RPCS3 mounts), ``size`` summed across parts, and ``split_parts`` = the count.
     The set is a final FAT32 deliverable, not a convertible source, so it carries
     no ``convertible_by`` / ``verifiable_by`` (you'd re-pack from the folder, not
-    a partial first chunk). An orphan ``.1`` with no ``.0`` is left untouched.
+    a partial first chunk). An orphan ``.1`` with no ``.0`` — or a lone ``.0``
+    with no ``.1`` (an interrupted split) — is left untouched.
     """
     groups: dict[str, dict[int, FileEntry]] = {}
     for entry in entries:
@@ -60,14 +61,19 @@ def _fold_split_iso_entries(entries: list[FileEntry]) -> list[FileEntry]:
         match = _SPLIT_ISO_PART_RE.match(entry.name)
         if match:
             groups.setdefault(match.group("base"), {})[int(match.group("idx"))] = entry
-    # Fold only a *complete* set: indices contiguous from 0 (0,1,…,N-1). An
-    # interrupted copy/write can leave a gap (e.g. .0 + .2, no .1); folding that
-    # would render one "valid" Game.iso hiding a corrupt/incomplete set, so leave
+    # Fold only a *complete* multi-part set: ≥2 indices contiguous from 0
+    # (0,1,…,N-1). An interrupted copy/write can leave a gap (e.g. .0 + .2, no
+    # .1); folding that would render one "valid" Game.iso hiding a
+    # corrupt/incomplete set. A lone ``.0`` is likewise the state left by a split
+    # interrupted before ``.1`` exists — a valid one-file result is the plain
+    # ``.iso``, never a bare ``.0`` — so folding it would hide the raw partial row
+    # and disable the single-row/bulk delete actions needed for recovery. Leave
     # such parts visible as their raw .N rows instead.
     foldable = {
         base: parts
         for base, parts in groups.items()
-        if set(parts) == set(range(len(parts)))  # implies 0 in parts and no gaps
+        # ≥2 parts, contiguous from 0 (no gaps, no lone first chunk).
+        if len(parts) >= 2 and set(parts) == set(range(len(parts)))
     }
     if not foldable:
         return entries

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -779,9 +779,9 @@ class JobManager:
             # suppressed); makeps3iso would then write *inside* it while the job
             # still reports the bare path as its output. Reject rather than
             # corrupt — mirroring the non-file guard on the file-job path below.
-            if await asyncio.to_thread(os.path.isdir, job.output_path):
+            if await run_in_threadpool(os.path.isdir, job.output_path):
                 raise RuntimeError("Output path exists and is not a file")
-            await asyncio.to_thread(
+            await run_in_threadpool(
                 makeps3iso_service.remove_outputs, job.output_path,
             )
             await verification_store.clear(job.output_path)

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1584,13 +1584,15 @@ class JobManager:
             await self._prune_jobs(exclude_id=job_id)
             return
 
-        # The bare-path lock above can't see a prior split set (Game.iso.0/.1
-        # with no bare Game.iso): acquire_lock only checks the literal output
-        # path, so a non-overwrite directory job would otherwise start on top of
-        # an existing split deliverable, clobber it, and (on a later failure)
-        # unlink the prior job's parts via remove_outputs. Mirror the bare-file
-        # "already exists" rejection for the split set when overwrite wasn't
-        # authorized; an authorized overwrite clears it in _clear_existing_output.
+        # acquire_lock above already rejects a destination that exists but isn't a
+        # plain file — incl. a *directory* shadowing the output path — via its
+        # ``not os.path.isfile`` clause (for both overwrite states). What it can't
+        # see is a prior split set (``Game.iso.0``/``.1`` with no bare
+        # ``Game.iso``): os.path.exists(bare) is False, so the lock is granted. A
+        # non-overwrite job would then clobber that existing deliverable and, on a
+        # later failure, unlink its parts via remove_outputs. Mirror the bare-file
+        # "already exists" rejection for the split set. (An authorized overwrite
+        # clears it in _clear_existing_output.)
         if job.input_kind == InputKind.DIRECTORY and not job.allow_overwrite:
             existing_parts = await run_in_threadpool(
                 makeps3iso_service.split_parts, job.output_path,

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -773,7 +773,14 @@ class JobManager:
             return
         if job.input_kind == InputKind.DIRECTORY:
             # makeps3iso output is a single .iso OR a split set (.0/.1/…); clear
-            # all of it via the tool's own part-aware cleanup.
+            # all of it via the tool's own part-aware cleanup. But a destination
+            # that already exists as a *directory* named like the output can't be
+            # cleared by remove_outputs (its os.remove() fails on a dir and is
+            # suppressed); makeps3iso would then write *inside* it while the job
+            # still reports the bare path as its output. Reject rather than
+            # corrupt — mirroring the non-file guard on the file-job path below.
+            if await asyncio.to_thread(os.path.isdir, job.output_path):
+                raise RuntimeError("Output path exists and is not a file")
             await asyncio.to_thread(
                 makeps3iso_service.remove_outputs, job.output_path,
             )
@@ -1576,6 +1583,36 @@ class JobManager:
             await self._cleanup_temp_dir(job)
             await self._prune_jobs(exclude_id=job_id)
             return
+
+        # The bare-path lock above can't see a prior split set (Game.iso.0/.1
+        # with no bare Game.iso): acquire_lock only checks the literal output
+        # path, so a non-overwrite directory job would otherwise start on top of
+        # an existing split deliverable, clobber it, and (on a later failure)
+        # unlink the prior job's parts via remove_outputs. Mirror the bare-file
+        # "already exists" rejection for the split set when overwrite wasn't
+        # authorized; an authorized overwrite clears it in _clear_existing_output.
+        if job.input_kind == InputKind.DIRECTORY and not job.allow_overwrite:
+            existing_parts = await run_in_threadpool(
+                makeps3iso_service.split_parts, job.output_path,
+            )
+            # split_parts returns [base] only when the bare file exists (already
+            # rejected by acquire_lock above); a real split set is the numbered
+            # parts, so treat that as an output collision.
+            if existing_parts and existing_parts != [job.output_path]:
+                job.status = JobStatus.FAILED
+                job.error_message = "Output file already exists"
+                job.completed_at = datetime.now(timezone.utc)
+                await self._notify_subscribers(
+                    job_id,
+                    {"type": "error", "job_id": job_id, "error": job.error_message},
+                )
+                lock_manager.release_lock(job.output_path)
+                if job_id in self._cancel_events:
+                    del self._cancel_events[job_id]
+                concurrency_manager.release(job_id)
+                await self._cleanup_temp_dir(job)
+                await self._prune_jobs(exclude_id=job_id)
+                return
 
         # A directory-input job (makeps3iso folder->iso) additionally locks its
         # whole source subtree, so any concurrent per-file job / rename / delete

--- a/app/services/tools/makeps3iso.py
+++ b/app/services/tools/makeps3iso.py
@@ -73,7 +73,21 @@ class MakePs3IsoTool(BaseTool):
         candidate = self._service.get_output_path(input_path)
         file_exists, is_converting = lock_manager.check_file_status(candidate)
         if not (file_exists or is_converting):
-            return None
+            # A successful >4 GB ``-s`` build leaves no bare ``<folder>.iso`` —
+            # only the contiguous split set ``<folder>.iso.0``/``.1``/…. The
+            # bare-path status check above misses it, so probe the split parts and
+            # badge the set (pointing ``path`` at the ``.0`` part RPCS3 mounts). A
+            # lone ``.0`` is an interrupted split, not a finished output, so
+            # require ≥2 parts — mirroring the file-browser fold.
+            parts = self._service.split_parts(candidate)
+            if len(parts) < 2:
+                return None
+            return OutputStatus(
+                tool_id=self.id,
+                exists=True,
+                ready=True,
+                path=parts[0],
+            )
         return OutputStatus(
             tool_id=self.id,
             exists=file_exists,

--- a/app/services/tools/makeps3iso.py
+++ b/app/services/tools/makeps3iso.py
@@ -75,18 +75,21 @@ class MakePs3IsoTool(BaseTool):
         if not (file_exists or is_converting):
             # A successful >4 GB ``-s`` build leaves no bare ``<folder>.iso`` —
             # only the contiguous split set ``<folder>.iso.0``/``.1``/…. The
-            # bare-path status check above misses it, so probe the split parts and
-            # badge the set (pointing ``path`` at the ``.0`` part RPCS3 mounts). A
-            # lone ``.0`` is an interrupted split, not a finished output, so
-            # require ≥2 parts — mirroring the file-browser fold.
-            parts = self._service.split_parts(candidate)
-            if len(parts) < 2:
+            # bare-path status check above misses it, so probe the set and badge
+            # it (pointing ``path`` at the ``.0`` part RPCS3 mounts). detect_output
+            # runs once per convertible folder in /api/files + recursive search,
+            # so check the ``.0``/``.1`` parts directly (two stats) instead of
+            # scanning the whole parent dir for every row. A lone ``.0`` is an
+            # interrupted split, not a finished output, so require ``.1`` too —
+            # mirroring the file-browser fold's ≥2-part rule.
+            part0 = f"{candidate}.0"
+            if not (os.path.isfile(part0) and os.path.isfile(f"{candidate}.1")):
                 return None
             return OutputStatus(
                 tool_id=self.id,
                 exists=True,
                 ready=True,
-                path=parts[0],
+                path=part0,
             )
         return OutputStatus(
             tool_id=self.id,

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -86,6 +86,16 @@
   Frontend: a `supportsSplit` mode flag gates the toggle, masked at submit like
   `deleteOnVerify`. Tests in `tests/test_makeps3iso.py` (argv flag placement,
   part detection, part-aware readback/cleanup, plan collision, listing fold).
+  Split-set handling is hardened across the surfaces: the listing fold requires a
+  **contiguous set of ≥2 parts** (a lone `Game.iso.0` is an interrupted split, so
+  it stays a raw row with its single-row/bulk delete actions intact — bulk delete
+  also hides when only folded split rows are selected); `MakePs3IsoTool.detect_output`
+  probes the split set so a `>4 GB` build still badges its source folder (and the
+  unverified-output delete warning still fires) when no bare `<folder>.iso` exists;
+  the overwrite cleanup rejects a destination that already exists as a *directory*
+  (its `os.remove` would no-op and makeps3iso would write *inside* it); and the
+  worker rejects an existing split set as an output collision when overwrite wasn't
+  authorized (the bare-path lock alone can't see `.0`/`.1`).
 
 ### CSO → CHD in one step (issue #98, Phase 1)
 

--- a/src/lib/components/panels/FileList.svelte
+++ b/src/lib/components/panels/FileList.svelte
@@ -103,7 +103,12 @@
   // when the selection is purely archive members.
   const selectedHasFilesystemPath = $derived.by(() => {
     const sel = Array.from(fileBrowser.selectedFiles.values());
-    return sel.some((e) => e?.path && !e.path.includes('::'));
+    // A folded makeps3iso split set has a real .0 path but is excluded from
+    // bulk delete (openBulkDelete drops split_parts != null rows, matching the
+    // disabled single-row Delete). Gate on the same predicate so a selection of
+    // *only* split rows doesn't surface a Delete button that opens an empty
+    // "Delete 0 files?" modal; a mixed selection still shows it for the rest.
+    return sel.some((e) => e?.path && !e.path.includes('::') && e.split_parts == null);
   });
 
   let searchInput = $state('');

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -776,6 +776,46 @@ async def test_process_job_rejects_existing_split_set_without_overwrite(tmp_path
         job_manager._cancelled.discard(job.id)
 
 
+@pytest.mark.asyncio
+async def test_process_job_rejects_directory_output(tmp_path):
+    # A directory shadowing the output path (MyGame.iso/) is never a valid
+    # makeps3iso target. acquire_lock already rejects it (its ``not isfile``
+    # clause fires for both overwrite states), so the worker fails the job rather
+    # than writing *into* the directory. Regression guard against that clobber.
+    from app.services.job_manager import job_manager
+    from services.concurrency_manager import concurrency_manager
+    from services.lock_manager import lock_manager
+
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out = str(tmp_path / "MyGame.iso")
+    Path(out).mkdir()  # a directory occupying the output path
+    job = ConversionJob(
+        id="ps3wdir1",
+        file_path=folder,
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.QUEUED,
+        created_at=datetime.now(timezone.utc),
+        output_path=out,
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=False,
+    )
+    job_manager.jobs[job.id] = job
+    try:
+        await job_manager._process_job(job.id)
+        assert job.status == JobStatus.FAILED
+        # The directory is left intact, never written into.
+        assert Path(out).is_dir()
+        _, is_locked = lock_manager.check_file_status(out)
+        assert is_locked is False
+    finally:
+        lock_manager.release_lock(out)
+        concurrency_manager.release(job.id)
+        job_manager.jobs.pop(job.id, None)
+        job_manager._cancel_events.pop(job.id, None)
+        job_manager._cancelled.discard(job.id)
+
+
 def test_check_output_conflicts_split_aware(tmp_path):
     out = str(tmp_path / "Game.iso")
     # A prior split build left only the .0 part (no plain Game.iso).

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -648,9 +648,132 @@ def test_fold_split_iso_entries_requires_contiguous_parts():
     assert all(e.split_parts is None for e in folded)
 
 
+def test_fold_split_iso_entries_requires_two_parts():
+    from app.models import FileEntry
+
+    # A lone .0 (no .1) is an interrupted split, not a finished one-file result
+    # (that would be a plain Game.iso). Folding it would hide the raw partial row
+    # and disable the single-row/bulk delete actions needed for recovery, so
+    # leave it visible as its raw .0 row.
+    entries = [
+        FileEntry(name="Game.iso.0", path="/d/Game.iso.0", type="file", size=1,
+                  extension=".0"),
+    ]
+    folded = files_routes._fold_split_iso_entries(entries)
+    names = [e.name for e in folded]
+    assert names == ["Game.iso.0"]
+    assert all(e.split_parts is None for e in folded)
+
+
 # --------------------------------------------------------------------------- #
 # Split: overwrite cleanup, conflict detection, stall-probe widening
 # --------------------------------------------------------------------------- #
+
+
+def test_detect_output_surfaces_split_set(tmp_path):
+    # A >4 GB ``-s`` build leaves only the split set (no bare <folder>.iso), so
+    # detect_output must probe it and still badge the source folder's row,
+    # pointing at the .0 part RPCS3 mounts.
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out = str(tmp_path / "MyGame.iso")
+    tool = registry.get("makeps3iso")
+
+    # No output yet -> no badge.
+    assert tool.detect_output(folder) is None
+
+    # A lone .0 (interrupted split) is not a finished output -> still no badge.
+    Path(f"{out}.0").write_bytes(b"0")
+    assert tool.detect_output(folder) is None
+
+    # A complete split set (.0 + .1) -> badged, ready, pointing at .0.
+    Path(f"{out}.1").write_bytes(b"1")
+    status = tool.detect_output(folder)
+    assert status is not None
+    assert status.exists is True
+    assert status.ready is True
+    assert status.path == f"{out}.0"
+
+    # A plain <folder>.iso still wins (bare path present).
+    Path(f"{out}.0").unlink()
+    Path(f"{out}.1").unlink()
+    Path(out).write_bytes(b"iso")
+    bare = tool.detect_output(folder)
+    assert bare is not None and bare.path == out
+
+
+@pytest.mark.asyncio
+async def test_clear_existing_output_rejects_directory(tmp_path, monkeypatch):
+    # When the overwrite target already exists as a *directory* named like the
+    # output, remove_outputs can't clear it (os.remove fails on a dir and is
+    # suppressed) and makeps3iso would write *inside* it. Reject instead.
+    import app.services.job_manager as jm_module
+    from app.services.job_manager import job_manager
+
+    async def _noop_clear(_path):
+        return None
+
+    monkeypatch.setattr(jm_module.verification_store, "clear", _noop_clear)
+
+    out = str(tmp_path / "MyGame.iso")
+    Path(out).mkdir()  # a directory shadowing the output path
+    job = ConversionJob(
+        id="ps3dirout1",
+        file_path=str(tmp_path / "MyGame"),
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=out,
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=True,
+    )
+    with pytest.raises(RuntimeError, match="not a file"):
+        await job_manager._clear_existing_output(job)
+    # The directory is left intact, not partially clobbered.
+    assert Path(out).is_dir()
+
+
+@pytest.mark.asyncio
+async def test_process_job_rejects_existing_split_set_without_overwrite(tmp_path):
+    # A prior split build left Game.iso.0/.1 (no bare Game.iso), so the bare-path
+    # output lock can't see the collision. A non-overwrite directory job reaching
+    # the worker must fail like a normal output collision rather than clobber the
+    # existing split set (and unlink its parts on a later failure cleanup).
+    from app.services.job_manager import job_manager
+    from services.concurrency_manager import concurrency_manager
+    from services.lock_manager import lock_manager
+
+    folder = str(_make_ps3_folder(tmp_path / "MyGame"))
+    out = str(tmp_path / "MyGame.iso")
+    Path(f"{out}.0").write_bytes(b"0")
+    Path(f"{out}.1").write_bytes(b"1")
+    job = ConversionJob(
+        id="ps3wcol1",
+        file_path=folder,
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.QUEUED,
+        created_at=datetime.now(timezone.utc),
+        output_path=out,
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=False,
+    )
+    job_manager.jobs[job.id] = job
+    try:
+        await job_manager._process_job(job.id)
+        assert job.status == JobStatus.FAILED
+        assert "already exists" in (job.error_message or "")
+        # The prior split set is left intact, never clobbered.
+        assert Path(f"{out}.0").exists() and Path(f"{out}.1").exists()
+        # The output lock taken for the collision check is released again.
+        _, is_locked = lock_manager.check_file_status(out)
+        assert is_locked is False
+    finally:
+        lock_manager.release_lock(out)
+        concurrency_manager.release(job.id)
+        job_manager.jobs.pop(job.id, None)
+        job_manager._cancel_events.pop(job.id, None)
+        job_manager._cancelled.discard(job.id)
 
 
 def test_check_output_conflicts_split_aware(tmp_path):


### PR DESCRIPTION
Addresses review findings on the makeps3iso 4 GB FAT32 split (`-s`) feature. Each change makes a split surface match the behavior already documented for the (unreleased) feature, with tests and a release-note update.

## Changes

- **Require a contiguous set of ≥2 parts before folding** (`app/routes/files.py`). Previously `set(parts) == set(range(len(parts)))` also folded a lone `Game.iso.0` (`{0} == {0}`). A lone `.0` is the state left by a split interrupted before `.1` exists — a valid one-file result is the plain `.iso`, never a bare `.0` — so folding it hid the raw partial row and disabled the single-row/bulk delete actions needed for recovery. Now it stays a raw row.

- **Surface split outputs in folder badges** (`app/services/tools/makeps3iso.py` `detect_output`). A successful >4 GB build leaves no bare `<folder>.iso`, only `<folder>.iso.0`/`.1`/…, so the bare-path status check missed it and the source folder's row lost its makeps3iso output badge (and the unverified-output delete warning). It now probes the split set and badges it, pointing the status path at the `.0` part RPCS3 mounts (≥2 parts required, mirroring the fold).

- **Reject directory outputs before overwrite cleanup** (`app/services/job_manager.py` `_clear_existing_output`). When the overwrite target already exists as a *directory* named like the output, `remove_outputs`' `os.remove` no-ops on a dir (suppressed) and makeps3iso would then write *inside* it. Now rejected, mirroring the non-file guard on the file-job path.

- **Reject an existing split set as a collision at the worker** (`app/services/job_manager.py` `_process_job`). The bare-path output lock can't see a prior `.0`/`.1` split set, so a non-overwrite directory job could start on top of an existing split deliverable, clobber it, and unlink the prior job's parts on a later failure cleanup. The worker now fails it like a normal output collision (the normal UI path was already protected by split-aware planning/`check_duplicates`; this is defense-in-depth at the worker).

- **Hide bulk Delete when only folded split rows are selected** (`src/lib/components/panels/FileList.svelte`). Folded split rows have a real `.0` path so `selectedHasFilesystemPath` showed the Delete button, but `openBulkDelete` filters them out — opening an empty "Delete 0 files?" modal. The predicate now applies the same `split_parts == null` check.

## Triage of related findings (no change needed)

Several other reported findings are already handled by the shipped split feature or were false positives, verified during this work:
- DAT hydration already excludes `split_parts` rows; bulk delete/verify already filter them; row rename/delete already disabled via `isSplitSet`.
- All tool wrappers already accept the `split` kwarg (no `TypeError`).
- `check_duplicates` already uses the split-aware `check_output_conflicts`; the completion block already sums `split_parts` for output size; in-flight split parts are already protected via `_split_output_blocks`; the stall probe already widens for split jobs; `remove_outputs` already restricts to the contiguous `.0` set (so `Game.iso.2024` backups are left alone).

## Testing

- `tests/test_makeps3iso.py`: added coverage for the lone-`.0` fold no-op, `detect_output` split-set surfacing, the directory-output overwrite rejection, and the worker split-collision rejection.
- `PYTHONPATH=app python -m pytest tests/test_makeps3iso.py -q` → 35 passed; targeted file-route suites pass; `ruff check .` clean; frontend `eslint` clean and `npm run build` succeeds.
- The 27 `test_archive_conversion_e2e.py` failures in this environment are pre-existing (fail identically on the base commit — missing conversion binaries), unrelated to this change.

https://claude.ai/code/session_012W6yAxBjmSzxn7Eh3zXhgd

---
_Generated by [Claude Code](https://claude.ai/code/session_012W6yAxBjmSzxn7Eh3zXhgd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced PS3 ISO split build handling with improved detection of completed multi-part outputs
  * Cleaner file listing: split-set entries now only fold into single display items when complete (both `.0` and `.1` parts required)

* **Bug Fixes**
  * Fixed delete button visibility for split file selections
  * Strengthened safety checks to prevent overwrites on existing directory paths
  * Added collision detection to prevent overwriting pre-existing split-set outputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the makeps3iso 4 GB FAT32 split (`-s`) feature across five surfaces: fold logic, output detection, overwrite cleanup, worker collision guard, and the bulk-delete button predicate.

- **`app/routes/files.py`**: The split-fold now requires ≥2 contiguous parts, so a lone `.0` left by an interrupted build stays visible as a raw row with delete actions available.
- **`app/services/tools/makeps3iso.py`**: `detect_output` probes the `.0`/`.1` split pair when no bare `.iso` exists, so a completed >4 GB build correctly badges its source folder.
- **`app/services/job_manager.py`**: `_clear_existing_output` rejects a directory shadowing the output path (prevents makeps3iso from writing inside it on overwrite); `_process_job` rejects a pre-existing split set on non-overwrite jobs as a collision the bare-path lock cannot see.
- **`src/lib/components/panels/FileList.svelte`**: `selectedHasFilesystemPath` now gates on `split_parts == null`, preventing an empty \"Delete 0 files?\" modal when only folded split rows are selected.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. All five surfaces are narrow, well-scoped fixes; each new early-exit path releases its locks and concurrency slot before returning.

Every changed code path has a corresponding test that was confirmed passing. The lock/concurrency cleanup in the new split-collision early-return mirrors the existing patterns precisely. The one asymmetry noted (lone `.0` blocking the worker while showing no badge) leaves the user in a recoverable state and does not risk data loss or lock leaks.

app/services/job_manager.py — the new split-set collision block at _process_job is worth a second read to confirm the lone-.0 vs ≥2-part behaviour is intentional.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/routes/files.py | Adds len(parts) >= 2 guard to _fold_split_iso_entries — clean, minimal fix preventing a lone .0 from being folded. |
| app/services/tools/makeps3iso.py | detect_output now probes .0+.1 when no bare ISO exists and returns path=part0; see comment about the lone-.0 collision asymmetry vs detect_output. |
| app/services/job_manager.py | Two hardening additions: directory-output rejection in _clear_existing_output and split-set collision check in _process_job; lock/concurrency cleanup is correct in both paths. |
| src/lib/components/panels/FileList.svelte | Adds split_parts == null predicate to selectedHasFilesystemPath, correctly suppressing the Delete button for split-only selections. |
| tests/test_makeps3iso.py | Adds four new tests covering lone-.0 fold no-op, detect_output split-set badge, directory-output overwrite rejection, and worker split-collision rejection. |
| docs/RELEASE_NOTES.md | Appends a clear description of all five hardening changes under the existing split-set release note. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PS3 folder row in /api/files] --> B{detect_output}
    B --> C{bare .iso exists or lock held?}
    C -- yes --> D[Return OutputStatus\npath=bare .iso]
    C -- no --> E{.iso.0 AND .iso.1 exist?}
    E -- no --> F[Return None\nno badge]
    E -- yes --> G[Return OutputStatus\nexists=True, ready=True\npath=.iso.0]

    H[File listing fold] --> I{>=2 contiguous parts from .0?}
    I -- no --> J[Leave as raw .N rows\nsingle-row/bulk delete available]
    I -- yes --> K[Fold into one FileEntry\nname=base, path=.iso.0\nsplit_parts=count]

    L[_process_job non-overwrite dir job] --> M{acquire_lock on bare path}
    M -- fail --> N[Fail: output locked or exists]
    M -- success --> O{split_parts check: numbered parts exist?}
    O -- yes --> P[Fail: Output file already exists\nrelease lock + cleanup]
    O -- no --> Q[Continue to conversion]

    R[_clear_existing_output overwrite] --> S{output path is directory?}
    S -- yes --> T[Raise RuntimeError\nreject, do not corrupt]
    S -- no --> U[remove_outputs bare path\nclears base + all .N parts]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["makeps3iso: probe split .0/.1 directly i..."](https://github.com/pacnpal/compressatorium/commit/3fd584044cc4a1c74754252e1fae64f74dd1cbdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37424994)</sub>

<!-- /greptile_comment -->