### PR TITLE
fix(version): single-source the app version from package.json

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
+import json
 import logging
 from logging_setup import get_logger
 import os
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from config import settings
 from fastapi import FastAPI
@@ -12,13 +14,38 @@ from services.job_manager import job_manager
 from services.nsz import nsz_service
 
 
-def get_version() -> str:
-    """Return app version from APP_VERSION env var (set by Docker build arg).
+# package.json (repo root) is the single source of truth for the version.
+_PACKAGE_JSON = Path(__file__).resolve().parent.parent / "package.json"
 
-    In production containers the version is injected at build time from the
-    GitHub release tag.  Local / dev runs fall back to "dev".
+
+def _version_from_package_json() -> str | None:
+    """Return ``version`` from the repo-root ``package.json``, or ``None``.
+
+    ``None`` when the file is missing or unparseable (e.g. a slim image that
+    does not ship ``package.json``), so the caller can fall back to ``"dev"``.
     """
-    return os.environ.get("APP_VERSION", "dev")
+    try:
+        with _PACKAGE_JSON.open(encoding="utf-8") as fh:
+            version = json.load(fh).get("version")
+    except (OSError, ValueError):
+        return None
+    return version or None
+
+
+def get_version() -> str:
+    """Return the application version.
+
+    ``APP_VERSION`` (the Docker build arg, derived from the release tag) wins so
+    container builds stay authoritative. When it is unset or empty (local
+    ``./run_dev.sh`` runs, tests, CI) fall back to the ``version`` field in the
+    repo-root ``package.json`` -- which ``AGENTS.md`` names the single source of
+    truth -- so the served version cannot silently drift from the file.
+    ``"dev"`` is the last resort when neither is available.
+    """
+    env_version = os.environ.get("APP_VERSION")
+    if env_version:
+        return env_version
+    return _version_from_package_json() or "dev"
 
 
 _LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"

--- a/app/main.py
+++ b/app/main.py
@@ -19,17 +19,22 @@ _PACKAGE_JSON = Path(__file__).resolve().parent.parent / "package.json"
 
 
 def _version_from_package_json() -> str | None:
-    """Return ``version`` from the repo-root ``package.json``, or ``None``.
+    """Return the ``version`` string from the repo-root ``package.json``, or ``None``.
 
-    ``None`` when the file is missing or unparseable (e.g. a slim image that
-    does not ship ``package.json``), so the caller can fall back to ``"dev"``.
+    ``get_version()`` runs while the FastAPI app is constructed, so this never
+    raises: it returns ``None`` (caller falls back to ``"dev"``) when the file is
+    missing, unparseable, not a JSON object, or carries a missing / non-string /
+    empty ``version`` -- e.g. a slim image that does not ship ``package.json``, or
+    a top-level array/null/number that would otherwise ``AttributeError`` on
+    ``.get()``.
     """
     try:
         with _PACKAGE_JSON.open(encoding="utf-8") as fh:
-            version = json.load(fh).get("version")
+            data = json.load(fh)
     except (OSError, ValueError):
         return None
-    return version or None
+    version = data.get("version") if isinstance(data, dict) else None
+    return version if isinstance(version, str) and version.strip() else None
 
 
 def get_version() -> str:

--- a/tests/test_version_ssot.py
+++ b/tests/test_version_ssot.py
@@ -10,6 +10,9 @@ import asyncio
 import json
 from pathlib import Path
 
+import pytest
+
+import main
 from main import get_version, health_check
 from routes.info import get_app_version
 
@@ -63,3 +66,41 @@ def test_api_version_endpoint_reports_real_version(monkeypatch):
     payload = asyncio.run(get_app_version())
 
     assert payload["version"] == _package_json_version()
+
+
+@pytest.mark.parametrize(
+    "bad_content",
+    [
+        "[]",                  # top-level array -> .get() would AttributeError
+        "null",                # top-level null
+        "42",                  # top-level number
+        '"4.2.0"',             # top-level string
+        "{ not valid json",    # unparseable
+        '{"version": 42}',     # non-string version
+        '{"version": ""}',     # empty version
+        "{}",                  # no version key
+    ],
+)
+def test_malformed_or_wrong_shape_package_json_degrades_to_dev(
+    monkeypatch, tmp_path, bad_content
+):
+    """A missing/malformed/wrong-shaped package.json degrades to 'dev', never raises.
+
+    get_version() runs while the FastAPI app is constructed, so a valid-but-
+    wrong-shaped file (e.g. a top-level array/null/number) must not raise at
+    startup -- it must fall through to the "dev" last resort.
+    """
+    monkeypatch.delenv("APP_VERSION", raising=False)
+    bad = tmp_path / "package.json"
+    bad.write_text(bad_content, encoding="utf-8")
+    monkeypatch.setattr(main, "_PACKAGE_JSON", bad)
+
+    assert get_version() == "dev"
+
+
+def test_missing_package_json_degrades_to_dev(monkeypatch, tmp_path):
+    """An absent package.json (e.g. a slim container image) yields 'dev', not a crash."""
+    monkeypatch.delenv("APP_VERSION", raising=False)
+    monkeypatch.setattr(main, "_PACKAGE_JSON", tmp_path / "nope.json")
+
+    assert get_version() == "dev"

--- a/tests/test_version_ssot.py
+++ b/tests/test_version_ssot.py
@@ -1,0 +1,65 @@
+"""SSOT for the application version (#178).
+
+``AGENTS.md`` names ``package.json`` the single source of truth for the
+version. These tests pin ``get_version()`` (and the ``/health`` + ``/api/version``
+endpoints that surface it) to that file when ``APP_VERSION`` is unset/empty,
+while keeping ``APP_VERSION`` as the authoritative container override.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+from main import get_version, health_check
+from routes.info import get_app_version
+
+# Resolve package.json independently of main's own path constant so the test
+# genuinely asserts the served version is coupled to the file on disk.
+_PACKAGE_JSON = Path(__file__).resolve().parent.parent / "package.json"
+
+
+def _package_json_version() -> str:
+    return json.loads(_PACKAGE_JSON.read_text(encoding="utf-8"))["version"]
+
+
+def test_get_version_falls_back_to_package_json(monkeypatch):
+    """APP_VERSION unset -> served version is package.json's version, not 'dev'."""
+    monkeypatch.delenv("APP_VERSION", raising=False)
+
+    version = get_version()
+
+    assert version == _package_json_version()
+    assert version != "dev"  # the regression this closes: never the old default
+
+
+def test_empty_app_version_is_treated_as_unset(monkeypatch):
+    """An empty APP_VERSION ('') falls back to package.json, not served verbatim."""
+    monkeypatch.setenv("APP_VERSION", "")
+
+    assert get_version() == _package_json_version()
+
+
+def test_app_version_env_overrides_package_json(monkeypatch):
+    """A non-empty APP_VERSION still wins so container builds stay authoritative."""
+    monkeypatch.setenv("APP_VERSION", "9.9.9-from-build-arg")
+
+    assert get_version() == "9.9.9-from-build-arg"
+
+
+def test_health_endpoint_reports_real_version(monkeypatch):
+    """/health surfaces the package.json version in a plain pytest/local run."""
+    monkeypatch.delenv("APP_VERSION", raising=False)
+
+    payload = asyncio.run(health_check())
+
+    assert payload["status"] == "healthy"
+    assert payload["version"] == _package_json_version()
+
+
+def test_api_version_endpoint_reports_real_version(monkeypatch):
+    """/api/version surfaces the package.json version in a plain pytest/local run."""
+    monkeypatch.delenv("APP_VERSION", raising=False)
+
+    payload = asyncio.run(get_app_version())
+
+    assert payload["version"] == _package_json_version()


### PR DESCRIPTION
## Summary

`AGENTS.md` names `package.json` the single source of truth for the version, but the runtime never read it. `get_version()` returned `os.environ.get("APP_VERSION", "dev")`, so:

- Any non-container run (local `./run_dev.sh`, tests, CI) reported `version: "dev"`.
- In containers it reported whatever the Docker build arg injected, which could silently drift from `package.json`.

`get_version()` feeds the startup log, the FastAPI `version=`, `/health`, and `/api/version` — so all of them were affected. This is the SSOT break in sub-issue #178.

## Change

- `get_version()` now falls back to parsing `version` from the repo-root `package.json` (resolved relative to `app/main.py`) when `APP_VERSION` is **unset or empty**.
- `APP_VERSION` stays the authoritative **override**, so container builds (which set it from the release tag) still win.
- `"dev"` remains the last resort when neither is available (e.g. a slim image that doesn't ship `package.json`); the parse is guarded against a missing/unparseable file rather than crashing startup.

No wire-API change — `/health` and `/api/version` JSON shapes are identical, just with a real version value.

## Scope note

The issue's second "Fix" bullet (derive the release pipeline's `APP_VERSION` build arg from `package.json`) touches release machinery and is **not** part of the issue's Acceptance criteria, which are entirely about the runtime fallback + a test. This PR satisfies both Acceptance bullets; the pipeline hardening can be a separate change if wanted.

## Testing

- New `tests/test_version_ssot.py` (5 tests):
  - `APP_VERSION` unset → `get_version()` equals `package.json`'s `version` (and is not `"dev"`).
  - Empty `APP_VERSION` (`""`) is treated as unset.
  - Non-empty `APP_VERSION` still overrides.
  - `/health` and `/api/version` handlers surface the `package.json` version (called directly, matching the suite's `asyncio.run` style — no `TestClient`/lifespan).
- `PYTHONPATH=app python -m pytest -q` → **999 passed, 5 new passing**, 1 skipped.
  - The 27 failures in `tests/test_archive_conversion_e2e.py` are **pre-existing and environmental** — this fresh container lacks the conversion binaries (`chdman`, `dolphin-tool`, `z3ds`, `maxcso`, `makeps3iso`). They reproduce identically on the clean base branch with my changes stashed, and are untouched by this change.
- `ruff check .` → clean.
- Manual confirmation with `APP_VERSION` unset: `get_version()`, `/health`, `/api/version`, and FastAPI `app.version` all report `4.2.0-beta-2`; with `APP_VERSION` set, the override wins.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application version detection with enhanced fallback logic to ensure reliable version reporting across different configuration sources.

* **Tests**
  * Added comprehensive tests verifying version consistency across API endpoints and configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes runtime version reporting to use `package.json` when no environment override is set. The main changes are:

- Adds a `package.json` version fallback in `get_version()`.
- Keeps non-empty `APP_VERSION` as the override.
- Falls back to `"dev"` when package metadata is missing or invalid.
- Adds tests for local fallback, override behavior, and version endpoints.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is narrowly scoped to version resolution and endpoint reporting, with no accepted correctness or security issues identified.

The implementation preserves the environment override, adds a guarded package metadata fallback, and includes focused tests for the local fallback, empty environment value, override behavior, and surfaced endpoint values.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the pre-change behavior of APP\_VERSION and package.json fallback logic, noting how /health and /api/version responded.
- Validated the post-change behavior described in the PR, confirming that unset/empty APP\_VERSION now uses package.json version 4.2.0-beta-2, non-empty APP\_VERSION preserves 9.9.9-override, and missing or wrong-shape package.json yields dev without crashing; endpoints continue to expose the same keys and statuses.
- Attached and reviewed evidence artifacts that capture the baseline and post-change checks, including two logs and a Python script.

<a href="https://app.greptile.com/trex/runs/12038400/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/main.py`, line 306-312 ([link](https://github.com/pacnpal/compressatorium/blob/6543b58fb6ffcf04c213a65dba120e524f9e3186/app/main.py#L306-L312)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Avoid version split**

   `app.version` is computed once at import, while `/health` and `/api/version` call `get_version()` each time. If `APP_VERSION` is changed after import in tests or embedding, or package metadata changes under a long-lived process, OpenAPI reports one version while the runtime endpoints report another. Consider computing one module-level version value and using it for FastAPI plus both endpoints, or add tests that pin `app.version` under the intended import-time environment.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fmain.py%0ALine%3A%20306-312%0A%0AComment%3A%0A**Avoid%20version%20split**%0A%0A%60app.version%60%20is%20computed%20once%20at%20import%2C%20while%20%60%2Fhealth%60%20and%20%60%2Fapi%2Fversion%60%20call%20%60get_version%28%29%60%20each%20time.%20If%20%60APP_VERSION%60%20is%20changed%20after%20import%20in%20tests%20or%20embedding%2C%20or%20package%20metadata%20changes%20under%20a%20long-lived%20process%2C%20OpenAPI%20reports%20one%20version%20while%20the%20runtime%20endpoints%20report%20another.%20Consider%20computing%20one%20module-level%20version%20value%20and%20using%20it%20for%20FastAPI%20plus%20both%20endpoints%2C%20or%20add%20tests%20that%20pin%20%60app.version%60%20under%20the%20intended%20import-time%20environment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=187&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2F178-version-ssot%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2F178-version-ssot%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fmain.py%0ALine%3A%20306-312%0A%0AComment%3A%0A**Avoid%20version%20split**%0A%0A%60app.version%60%20is%20computed%20once%20at%20import%2C%20while%20%60%2Fhealth%60%20and%20%60%2Fapi%2Fversion%60%20call%20%60get_version%28%29%60%20each%20time.%20If%20%60APP_VERSION%60%20is%20changed%20after%20import%20in%20tests%20or%20embedding%2C%20or%20package%20metadata%20changes%20under%20a%20long-lived%20process%2C%20OpenAPI%20reports%20one%20version%20while%20the%20runtime%20endpoints%20report%20another.%20Consider%20computing%20one%20module-level%20version%20value%20and%20using%20it%20for%20FastAPI%20plus%20both%20endpoints%2C%20or%20add%20tests%20that%20pin%20%60app.version%60%20under%20the%20intended%20import-time%20environment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=187&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(version): harden package.json parsin..."](https://github.com/pacnpal/compressatorium/commit/edfce6d50d133e1bb94b4afa588c73781d79ea84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39346755)</sub>

<!-- /greptile_comment -->