### PR TITLE
fix(determinism): stabilize ordering across registry unions, search, runner & FIFO ticket

### DIFF
--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -518,7 +518,9 @@ async def search_files(
                 return
             visited_dirs.add(real_dir)
             try:
-                for item in os.listdir(dir_path):
+                # Sorted for deterministic search order, matching scan_directory's
+                # sorted walk above; raw readdir order varies by FS (issue #183).
+                for item in sorted(os.listdir(dir_path)):
                     if is_junk_entry(item):
                         continue
                     item_path = os.path.join(dir_path, item)

--- a/app/routes/info.py
+++ b/app/routes/info.py
@@ -232,7 +232,7 @@ async def scan_metadata_task(
     # subsystem, never DAT-matchable as a whole, so the romz tool advertising
     # .7z/.zip outputs must not make the scan enumerate and hash every unrelated
     # archive under the configured volumes.
-    scan_extensions = registry.scannable_extensions() - ARCHIVE_EXTENSIONS
+    scan_extensions = frozenset(registry.scannable_extensions()) - ARCHIVE_EXTENSIONS
 
     def collect_scannable_paths():
         """Collect all scannable output paths from volumes (runs in thread pool)."""

--- a/app/services/archive.py
+++ b/app/services/archive.py
@@ -155,8 +155,8 @@ class ArchiveService:
             from services.tools import registry
 
             exts = (
-                registry.convertible_extensions()
-                | registry.archive_input_extensions()
+                frozenset(registry.convertible_extensions())
+                | frozenset(registry.archive_input_extensions())
             ) - ARCHIVE_EXTENSIONS
             if exts:
                 return exts
@@ -180,7 +180,7 @@ class ArchiveService:
         try:
             from services.tools import registry
 
-            exts = registry.archive_input_extensions()
+            exts = frozenset(registry.archive_input_extensions())
             if exts:
                 return exts
         except Exception:  # pragma: no cover - registry always loads in-app

--- a/app/services/concurrency_manager.py
+++ b/app/services/concurrency_manager.py
@@ -29,6 +29,19 @@ class ConcurrencyManager:
                     fh.write("0")
             except OSError:
                 pass
+        # Per-reservation sequence: a uniqueness tiebreaker baked into each
+        # ticket filename so two reservations never sort to the same slot.
+        self._seq = 0
+        # Seed the in-process fallback ticket above any value already on disk so
+        # a later counter-read failure still issues strictly-increasing, in-range
+        # tickets (see _next_ticket) rather than a wall-clock number.
+        self._fallback_ticket = 0
+        try:
+            with open(self._ticket_counter_path, "r", encoding="utf-8") as fh:
+                raw = fh.read().strip()
+                self._fallback_ticket = int(raw) if raw else 0
+        except (OSError, ValueError):
+            self._fallback_ticket = 0
 
     def reserve_ticket(self, key: str) -> int:
         """Reserve a FIFO ticket for the job."""
@@ -36,7 +49,11 @@ class ConcurrencyManager:
             return self._ticket_handles[key][0]
 
         ticket = self._next_ticket()
-        ticket_path = os.path.join(self.lock_dir, f"queue_{ticket}_{key}.ticket")
+        self._seq += 1
+        seq = self._seq
+        ticket_path = os.path.join(
+            self.lock_dir, f"queue_{ticket}_{seq}_{key}.ticket"
+        )
         self._create_ticket_file(ticket_path, ticket)
         self._ticket_handles[key] = (ticket, ticket_path)
         return ticket
@@ -110,33 +127,44 @@ class ConcurrencyManager:
         while True:
             if cancel_event and cancel_event.is_set():
                 return False
-            tickets = self._list_tickets()
-            if ticket not in tickets:
+            queued_keys = self._list_tickets()
+            if key not in queued_keys:
                 self._restore_ticket_file(key, ticket)
                 await asyncio.sleep(0.2)
                 continue
-            if ticket in tickets[: self.max_concurrent]:
+            if key in queued_keys[: self.max_concurrent]:
                 return True
             await asyncio.sleep(0.2)
 
-    def _list_tickets(self) -> list[int]:
-        tickets = []
+    def _list_tickets(self) -> list[str]:
+        """Return queued job keys in FIFO order.
+
+        Ordered by ``(ticket, seq, key)``: the shared-counter ticket is the
+        primary FIFO key, the per-reservation ``seq`` breaks ties if two tickets
+        ever collide (e.g. a counter-file read fallback), and the unique job
+        ``key`` is the final tiebreaker. Returning keys (not raw ticket ints)
+        means a colliding ticket can never put two jobs in the same admitted
+        prefix slot (issue #183, site 4).
+        """
+        entries: list[tuple[int, int, str]] = []
         try:
             for name in os.listdir(self.lock_dir):
                 if not name.startswith("queue_") or not name.endswith(".ticket"):
                     continue
-                parts = name.split("_", 2)
+                core = name[len("queue_"):-len(".ticket")]
+                parts = core.split("_", 2)
                 if len(parts) < 3:
                     continue
                 try:
-                    ticket = int(parts[1])
+                    ticket = int(parts[0])
+                    seq = int(parts[1])
                 except ValueError:
                     continue
-                tickets.append(ticket)
+                entries.append((ticket, seq, parts[2]))
         except OSError:
             return []
-        tickets.sort()
-        return tickets
+        entries.sort()
+        return [key for _, _, key in entries]
 
     def _next_ticket(self) -> int:
         try:
@@ -151,9 +179,18 @@ class ConcurrencyManager:
                 fh.flush()
                 os.fsync(fh.fileno())
                 fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+                # Track the high-water mark so the OSError fallback below stays
+                # strictly increasing and in the same numeric range.
+                self._fallback_ticket = max(self._fallback_ticket, next_ticket)
                 return next_ticket
         except OSError:
-            return int(os.times().elapsed * 1000)
+            # Counter file unreadable/unwritable: issue a strictly-increasing
+            # in-process ticket seeded above the last value seen on disk instead
+            # of a wall-clock number that could collide or sort out of range and
+            # mis-order FIFO admission (issue #183, site 4). MAX_CONCURRENT_JOBS
+            # concurrency lives in one process, so this counter is authoritative.
+            self._fallback_ticket += 1
+            return self._fallback_ticket
 
     def _create_ticket_file(self, ticket_path: str, ticket: int) -> None:
         tmp_path = f"{ticket_path}.tmp"

--- a/app/services/concurrency_manager.py
+++ b/app/services/concurrency_manager.py
@@ -183,8 +183,10 @@ class ConcurrencyManager:
                 # strictly increasing and in the same numeric range.
                 self._fallback_ticket = max(self._fallback_ticket, next_ticket)
                 return next_ticket
-        except OSError:
-            # Counter file unreadable/unwritable: issue a strictly-increasing
+        except (OSError, ValueError):
+            # Counter file unreadable/unwritable, or its contents corrupted
+            # (a partial write -> non-numeric body that int() rejects): issue a
+            # strictly-increasing
             # in-process ticket seeded above the last value seen on disk instead
             # of a wall-clock number that could collide or sort out of range and
             # mis-order FIFO admission (issue #183, site 4). MAX_CONCURRENT_JOBS

--- a/app/services/concurrency_manager.py
+++ b/app/services/concurrency_manager.py
@@ -32,16 +32,12 @@ class ConcurrencyManager:
         # Per-reservation sequence: a uniqueness tiebreaker baked into each
         # ticket filename so two reservations never sort to the same slot.
         self._seq = 0
-        # Seed the in-process fallback ticket above any value already on disk so
-        # a later counter-read failure still issues strictly-increasing, in-range
-        # tickets (see _next_ticket) rather than a wall-clock number.
-        self._fallback_ticket = 0
-        try:
-            with open(self._ticket_counter_path, "r", encoding="utf-8") as fh:
-                raw = fh.read().strip()
-                self._fallback_ticket = int(raw) if raw else 0
-        except (OSError, ValueError):
-            self._fallback_ticket = 0
+        # Seed the in-process fallback ticket above any value already on disk
+        # AND above any live ticket file preserved across a restart, so a later
+        # counter-read failure -- or a missing/corrupt counter at startup while a
+        # slot is still busy -- still issues strictly-increasing tickets that
+        # sort after older queued work (see _next_ticket).
+        self._fallback_ticket = self._highest_known_ticket()
 
     def reserve_ticket(self, key: str) -> int:
         """Reserve a FIFO ticket for the job."""
@@ -176,6 +172,30 @@ class ConcurrencyManager:
             return []
         entries.sort()
         return [key for _, _, key in entries]
+
+    def _highest_known_ticket(self) -> int:
+        """Highest ticket number across the on-disk counter and any live ticket
+        files, so the in-process fallback resumes above existing queued work even
+        when the counter is missing/corrupt (e.g. a busy-slot restart that
+        preserved older, higher-numbered tickets)."""
+        highest = 0
+        try:
+            with open(self._ticket_counter_path, "r", encoding="utf-8") as fh:
+                raw = fh.read().strip()
+                if raw:
+                    highest = int(raw)
+        except (OSError, ValueError):
+            highest = 0
+        try:
+            for name in os.listdir(self.lock_dir):
+                if not name.startswith("queue_") or not name.endswith(".ticket"):
+                    continue
+                first = name[len("queue_"):-len(".ticket")].split("_", 1)[0]
+                if first.isdigit():
+                    highest = max(highest, int(first))
+        except OSError:
+            pass
+        return highest
 
     def _next_ticket(self) -> int:
         try:

--- a/app/services/concurrency_manager.py
+++ b/app/services/concurrency_manager.py
@@ -202,7 +202,16 @@ class ConcurrencyManager:
             with open(self._ticket_counter_path, "r+", encoding="utf-8") as fh:
                 fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
                 raw = fh.read().strip()
-                on_disk = int(raw) if raw else 0
+                try:
+                    on_disk = int(raw) if raw else 0
+                except ValueError:
+                    # Corrupt body (a partial write -> non-numeric content):
+                    # recover the high-water mark from the preserved ticket files
+                    # and let the truncate/write below REPAIR the counter in place
+                    # under the lock, so every process converges back on the
+                    # shared counter instead of each falling into its own
+                    # in-process counter (which would collide across processes).
+                    on_disk = self._highest_known_ticket()
                 # Resume above any tickets the in-process fallback handed out
                 # while the counter was transiently unavailable: a recovered
                 # counter still holds its pre-failure value, so without this it
@@ -220,14 +229,12 @@ class ConcurrencyManager:
                 fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
                 self._fallback_ticket = next_ticket
                 return next_ticket
-        except (OSError, ValueError):
-            # Counter file unreadable/unwritable, or its contents corrupted
-            # (a partial write -> non-numeric body that int() rejects): issue a
-            # strictly-increasing
-            # in-process ticket seeded above the last value seen on disk instead
-            # of a wall-clock number that could collide or sort out of range and
-            # mis-order FIFO admission (issue #183, site 4). MAX_CONCURRENT_JOBS
-            # concurrency lives in one process, so this counter is authoritative.
+        except OSError:
+            # Counter file unreadable/unwritable (the locked write path can't
+            # complete): issue a strictly-increasing in-process ticket seeded
+            # above the last value seen on disk instead of a wall-clock number
+            # that could collide or sort out of range and mis-order FIFO
+            # admission (issue #183, site 4).
             self._fallback_ticket += 1
             return self._fallback_ticket
 

--- a/app/services/concurrency_manager.py
+++ b/app/services/concurrency_manager.py
@@ -145,6 +145,12 @@ class ConcurrencyManager:
         ``key`` is the final tiebreaker. Returning keys (not raw ticket ints)
         means a colliding ticket can never put two jobs in the same admitted
         prefix slot (issue #183, site 4).
+
+        Both the current ``queue_<ticket>_<seq>_<key>.ticket`` shape and the
+        previous ``queue_<ticket>_<key>.ticket`` shape are parsed, so a rolling
+        restart that leaves a still-active legacy ticket on disk keeps its FIFO
+        position (legacy tickets predate the upgrade, so they sort ahead of new
+        ones at the same ticket via ``seq = 0``).
         """
         entries: list[tuple[int, int, str]] = []
         try:
@@ -153,14 +159,19 @@ class ConcurrencyManager:
                     continue
                 core = name[len("queue_"):-len(".ticket")]
                 parts = core.split("_", 2)
-                if len(parts) < 3:
+                if len(parts) < 2:
                     continue
                 try:
                     ticket = int(parts[0])
-                    seq = int(parts[1])
                 except ValueError:
                     continue
-                entries.append((ticket, seq, parts[2]))
+                if len(parts) >= 3 and parts[1].isdigit():
+                    seq, key = int(parts[1]), parts[2]
+                else:
+                    # Legacy pre-seq filename: reserved before the upgrade, so
+                    # sort it ahead of new (seq >= 1) tickets at the same ticket.
+                    seq, key = 0, "_".join(parts[1:])
+                entries.append((ticket, seq, key))
         except OSError:
             return []
         entries.sort()
@@ -171,7 +182,15 @@ class ConcurrencyManager:
             with open(self._ticket_counter_path, "r+", encoding="utf-8") as fh:
                 fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
                 raw = fh.read().strip()
-                current = int(raw) if raw else 0
+                on_disk = int(raw) if raw else 0
+                # Resume above any tickets the in-process fallback handed out
+                # while the counter was transiently unavailable: a recovered
+                # counter still holds its pre-failure value, so without this it
+                # would reissue a number the fallback already used. That
+                # collision would put two jobs on the same ticket in
+                # _list_tickets and disagree with job_manager's (ticket, job_id)
+                # PriorityQueue order, stalling the queue at MAX_CONCURRENT_JOBS=1.
+                current = max(on_disk, self._fallback_ticket)
                 next_ticket = current + 1
                 fh.seek(0)
                 fh.truncate()
@@ -179,9 +198,7 @@ class ConcurrencyManager:
                 fh.flush()
                 os.fsync(fh.fileno())
                 fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
-                # Track the high-water mark so the OSError fallback below stays
-                # strictly increasing and in the same numeric range.
-                self._fallback_ticket = max(self._fallback_ticket, next_ticket)
+                self._fallback_ticket = next_ticket
                 return next_ticket
         except (OSError, ValueError):
             # Counter file unreadable/unwritable, or its contents corrupted

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -130,6 +130,22 @@ def verify_timeout(owner: str | None = None) -> int:
     return max(0, int(_resolve_policy("verify_timeout", owner) or 0))
 
 
+def _split_stream_lines(buffer: str) -> tuple[list[str], str]:
+    """Segment accumulated subprocess output into complete lines + a remainder.
+
+    Segmentation is a pure function of the byte stream, independent of where
+    ``read()`` chunk boundaries fall: CRLF and bare CR (progress redraws) are
+    normalized to LF, then the buffer is split on LF. The text after the final
+    LF is returned as the remainder to prepend to the next chunk. Lines are
+    stripped and blanks dropped, matching the prior per-separator loop's output
+    minus its chunk-boundary sensitivity (issue #183, site 5).
+    """
+    normalized = buffer.replace("\r\n", "\n").replace("\r", "\n")
+    segments = normalized.split("\n")
+    remainder = segments[-1]
+    return [s.strip() for s in segments[:-1] if s.strip()], remainder
+
+
 class SubprocessRunner:
     """Spawns a conversion subprocess and streams progress updates.
 
@@ -425,28 +441,22 @@ class SubprocessRunner:
 
                 buffer += chunk.decode("utf-8", errors="replace")
 
-                while "\r" in buffer or "\n" in buffer:
-                    sep = "\r" if "\r" in buffer else "\n"
-                    parts = buffer.split(sep)
-                    for part in parts[:-1]:
-                        line = part.strip()
-                        if not line:
-                            continue
-                        _record_line(line)
-                        now = time.monotonic()
-                        progress = parse_progress(line)
-                        if progress is not None and progress > last_progress_value:
-                            last_progress_value = progress
-                            last_activity_at = now
-                        yield {
-                            "progress": (
-                                progress
-                                if progress is not None
-                                else last_progress_value
-                            ),
-                            "message": line,
-                        }
-                    buffer = parts[-1]
+                lines, buffer = _split_stream_lines(buffer)
+                for line in lines:
+                    _record_line(line)
+                    now = time.monotonic()
+                    progress = parse_progress(line)
+                    if progress is not None and progress > last_progress_value:
+                        last_progress_value = progress
+                        last_activity_at = now
+                    yield {
+                        "progress": (
+                            progress
+                            if progress is not None
+                            else last_progress_value
+                        ),
+                        "message": line,
+                    }
                 if await _check_stall(time.monotonic()):
                     break
 

--- a/app/services/tools/registry.py
+++ b/app/services/tools/registry.py
@@ -54,12 +54,15 @@ class ToolRegistry:
     def mode_specs(self) -> list[ModeSpec]:
         return [m for t in self._tools.values() for m in t.modes]
 
-    def convertible_extensions(self) -> frozenset[str]:
-        return frozenset().union(
-            *(t.input_extensions for t in self._tools.values())
-        )
+    def convertible_extensions(self) -> tuple[str, ...]:
+        # Sorted tuple, not a frozenset: hash-seeded set iteration order varies
+        # across processes, so any consumer that serializes this into an ordered
+        # list or filter would churn run-to-run (issue #183).
+        return tuple(sorted(
+            set().union(*(t.input_extensions for t in self._tools.values()))
+        ))
 
-    def archive_input_extensions(self) -> frozenset[str]:
+    def archive_input_extensions(self) -> tuple[str, ...]:
         """Input extensions accepted by at least one mode that allows
         archive members as input.
 
@@ -76,7 +79,7 @@ class ToolRegistry:
             for mode in tool.modes:
                 if mode.allows_archive_input:
                     exts.update(mode.input_extensions)
-        return frozenset(exts)
+        return tuple(sorted(exts))  # sorted for cross-run determinism (issue #183)
 
     def tools_accepting_archive_member(self, ext: str) -> list[str]:
         """Tool ids with at least one ``allows_archive_input`` mode for ``ext``.
@@ -131,7 +134,7 @@ class ToolRegistry:
         """
         return [t for t in self._tools.values() if t.verifies_path(path)]
 
-    def verify_extensions(self) -> frozenset[str]:
+    def verify_extensions(self) -> tuple[str, ...]:
         """Union of every registered tool's verify_extensions.
 
         Used by file rename/delete handlers to decide whether the path
@@ -139,24 +142,28 @@ class ToolRegistry:
         check hard-coded `.chd`, which left .rvz / .z3ds / etc. records
         orphaned in the persistent store when the file was removed.
         """
-        return frozenset().union(
-            *(t.verify_extensions for t in self._tools.values())
-        )
+        return tuple(sorted(
+            set().union(*(t.verify_extensions for t in self._tools.values()))
+        ))
 
-    def output_extensions(self) -> frozenset[str]:
+    def output_extensions(self) -> tuple[str, ...]:
         """Union of every registered tool's output_extensions.
 
         These are the file types the tools *produce* (.chd, .rvz, .nsz, ...).
         """
-        return frozenset().union(
-            *(t.output_extensions for t in self._tools.values())
-        )
+        return tuple(sorted(
+            set().union(*(t.output_extensions for t in self._tools.values()))
+        ))
 
-    def scannable_extensions(self) -> frozenset[str]:
+    def scannable_extensions(self) -> tuple[str, ...]:
         """Extensions the library metadata scan should walk for.
 
         The union of produced outputs and verifiable inputs, so every
         registered tool's outputs are eligible for discovery rather than
-        the historical hard-coded ``.chd`` walk (issue #131).
+        the historical hard-coded ``.chd`` walk (issue #131). Sorted tuple
+        for determinism (issue #183); the two inputs are already sorted
+        tuples, so re-union via sets before sorting.
         """
-        return self.output_extensions() | self.verify_extensions()
+        return tuple(sorted(
+            set(self.output_extensions()) | set(self.verify_extensions())
+        ))

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -274,7 +274,10 @@ class SubprocessRunner:
                   parse_progress, cancel_event=None, cwd=None,
                   start_message="Starting...") -> AsyncGenerator[dict, None]:
         """Spawn cmd, stream stdout, yield {"progress","message"}.
-        Handles: nice/ionice wrap, stdbuf, PID tracking, \\r/\\n line buffering,
+        Handles: nice/ionice wrap, stdbuf, PID tracking, deterministic \\r/\\n
+        line buffering (CRLF/CR normalized to LF in one pass via
+        `_split_stream_lines` so segmentation is a pure function of the byte
+        stream, not chunk boundaries -- issue #183),
         stall timeout via compute_progress_stall_timeout, cancel-watcher
         (terminate->kill, clean partial output), ConversionCancelled, non-zero
         exit -> RuntimeError(tail), final 100%.
@@ -555,8 +558,8 @@ class ToolRegistry:
     def for_mode(self, mode: str) -> ToolPlugin: return self._by_mode[mode]
     def spec(self, mode: str) -> ModeSpec: return self.for_mode(mode).spec(mode)
     def mode_specs(self) -> list[ModeSpec]: return [m for t in self._tools.values() for m in t.modes]
-    def convertible_extensions(self) -> frozenset[str]:
-        return frozenset().union(*(t.input_extensions for t in self._tools.values()))
+    def convertible_extensions(self) -> tuple[str, ...]:   # sorted (issue #183)
+        return tuple(sorted(set().union(*(t.input_extensions for t in self._tools.values()))))
     def tools_for_input(self, filename: str) -> list[ToolPlugin]:
         ext = Path(filename).suffix.lower()
         return [t for t in self._tools.values() if ext in t.input_extensions]
@@ -566,13 +569,21 @@ class ToolRegistry:
     # Discovery helpers (issue #131): the union of every tool's produced /
     # verifiable extensions drives the registry-driven library scan, so a new
     # tool's outputs become scannable for free.
-    def output_extensions(self) -> frozenset[str]:
-        return frozenset().union(*(t.output_extensions for t in self._tools.values()))
-    def verify_extensions(self) -> frozenset[str]:
-        return frozenset().union(*(t.verify_extensions for t in self._tools.values()))
-    def scannable_extensions(self) -> frozenset[str]:
-        return self.output_extensions() | self.verify_extensions()
+    def output_extensions(self) -> tuple[str, ...]:
+        return tuple(sorted(set().union(*(t.output_extensions for t in self._tools.values()))))
+    def verify_extensions(self) -> tuple[str, ...]:
+        return tuple(sorted(set().union(*(t.verify_extensions for t in self._tools.values()))))
+    def scannable_extensions(self) -> tuple[str, ...]:
+        return tuple(sorted(set(self.output_extensions()) | set(self.verify_extensions())))
 ```
+
+> **Ordering (issue #183):** the extension-union helpers return a **sorted
+> `tuple`**, not a `frozenset`. Hash-seeded set iteration order varies across
+> processes, so any consumer that serializes an extension list (or uses it as an
+> ordered filter) would churn run-to-run; sorting at the seam makes every
+> consumer deterministic for free. The few consumers that still need set algebra
+> (`registry.scannable_extensions() - ARCHIVE_EXTENSIONS`, the archive
+> listable/gate unions) wrap the result in `set(...)` / `frozenset(...)` locally.
 
 `__init__.py`:
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## Unreleased
+
+### Changed
+
+- **Deterministic ordering across the registry, search, and runner (issue
+  #183).** The `ToolRegistry` extension-union helpers (`convertible_extensions`,
+  `archive_input_extensions`, `verify_extensions`, `output_extensions`,
+  `scannable_extensions`) now return a **sorted `tuple`** instead of a
+  `frozenset`, so any serialized extension list is byte-stable run-to-run.
+  Recursive `/api/files/search` results are sorted to match the directory
+  listing, the file browser keeps a stable order for rows with equal sort keys,
+  and subprocess progress-line segmentation no longer depends on read-chunk
+  boundaries. The cross-process FIFO job ticket is hardened against counter
+  fallback/recovery collisions and now preserves legacy ticket files across a
+  rolling restart. No wire-API change.
+
 ## 4.2.0 (2026-06-13)
 
 This release adds the first folder-input tool and the first cross-tool chain. PS3

--- a/src/lib/stores/fileBrowser.svelte.js
+++ b/src/lib/stores/fileBrowser.svelte.js
@@ -138,6 +138,13 @@ class FileBrowserStore {
       }
       if (av < bv) return -1 * order;
       if (av > bv) return 1 * order;
+      // Stable final tiebreaker: rows with equal primary keys keep a
+      // deterministic order across refreshes, so they don't jump when the
+      // [...files, ...archives] input order shifts (issue #183).
+      const ap = (a.path ?? '').toLowerCase();
+      const bp = (b.path ?? '').toLowerCase();
+      if (ap < bp) return -1;
+      if (ap > bp) return 1;
       return 0;
     });
     return list;

--- a/src/lib/stores/fileBrowser.svelte.js
+++ b/src/lib/stores/fileBrowser.svelte.js
@@ -146,6 +146,13 @@ class FileBrowserStore {
       const bp = (b.path ?? '').toLowerCase();
       if (ap < bp) return -1 * order;
       if (ap > bp) return 1 * order;
+      // Case-sensitive final tiebreaker: on a case-sensitive volume /Foo.iso and
+      // /foo.iso are distinct rows that tie on the lowercased compare above, so
+      // fall through to the raw path for a total, stable order (issue #183).
+      const aps = a.path ?? '';
+      const bps = b.path ?? '';
+      if (aps < bps) return -1 * order;
+      if (aps > bps) return 1 * order;
       return 0;
     });
     return list;

--- a/src/lib/stores/fileBrowser.svelte.js
+++ b/src/lib/stores/fileBrowser.svelte.js
@@ -140,11 +140,12 @@ class FileBrowserStore {
       if (av > bv) return 1 * order;
       // Stable final tiebreaker: rows with equal primary keys keep a
       // deterministic order across refreshes, so they don't jump when the
-      // [...files, ...archives] input order shifts (issue #183).
+      // [...files, ...archives] input order shifts (issue #183). Follows the
+      // sort direction so toggling asc/desc fully inverts the view.
       const ap = (a.path ?? '').toLowerCase();
       const bp = (b.path ?? '').toLowerCase();
-      if (ap < bp) return -1;
-      if (ap > bp) return 1;
+      if (ap < bp) return -1 * order;
+      if (ap > bp) return 1 * order;
       return 0;
     });
     return list;

--- a/tests/test_archive_preference.py
+++ b/tests/test_archive_preference.py
@@ -35,7 +35,7 @@ def test_archive_input_extensions_cover_all_source_tools():
     # archive: chdman create sources, Dolphin sources, 3DS sources (issue #113),
     # Switch (nsz) sources, and .chd (chdman extract decompresses a .chd pulled
     # out of an archive back to a disc image).
-    exts = registry.archive_input_extensions()
+    exts = set(registry.archive_input_extensions())
     assert {".3ds", ".cci", ".cia"} <= exts          # 3DS (the reported gap)
     assert {".rvz", ".gcz", ".wia", ".wbfs"} <= exts  # Dolphin
     assert {".gdi", ".iso", ".cue", ".bin"} <= exts   # chdman create
@@ -52,7 +52,7 @@ def test_browse_listing_is_global_known_superset_of_convert_gate():
     # source extension shows (so romz ROMs aren't an "Empty folder"), and it's a
     # superset of the convert-gate set the search/conversion path uses.
     listable = archive_service._listable_extensions()
-    convertible = registry.archive_input_extensions()
+    convertible = set(registry.archive_input_extensions())
     assert convertible <= listable
     # Handheld ROMs surface in browse because they're known sources...
     assert {".gb", ".gbc", ".gba", ".nds"} <= listable

--- a/tests/test_determinism_183.py
+++ b/tests/test_determinism_183.py
@@ -195,6 +195,18 @@ def test_list_tickets_includes_legacy_filenames(tmp_path):
     assert "newjob" in keys
 
 
+def test_seed_considers_preserved_tickets_when_counter_corrupt(tmp_path):
+    cm = _mk_cm(tmp_path)
+    # Busy-slot restart: the counter is corrupt but a high-numbered ticket file
+    # was preserved. The fallback seed must resume above it, not restart at 1.
+    with open(cm._ticket_counter_path, "w", encoding="utf-8") as fh:
+        fh.write("not-a-number")
+    with open(os.path.join(cm.lock_dir, "queue_100_oldjob.ticket"), "w", encoding="utf-8") as fh:
+        fh.write("{}")
+
+    assert cm._highest_known_ticket() >= 100
+
+
 def test_colliding_ticket_int_does_not_double_admit(tmp_path, monkeypatch):
     # Force every ticket to the SAME integer (simulating a counter collision);
     # admission must still pick exactly the first max_concurrent by (seq, key),

--- a/tests/test_determinism_183.py
+++ b/tests/test_determinism_183.py
@@ -148,6 +148,19 @@ def test_counter_fallback_is_strictly_increasing_and_in_range(tmp_path, monkeypa
     assert fallbacks[0] > 2                       # seeded above the on-disk high-water mark
 
 
+def test_corrupted_counter_file_falls_back_without_crashing(tmp_path):
+    cm = _mk_cm(tmp_path)
+    cm._next_ticket()  # advance to 1
+    # A partial write leaves a non-numeric body; int() would raise ValueError,
+    # which must be caught (like an OSError) and fall through to the fallback.
+    with open(cm._ticket_counter_path, "w", encoding="utf-8") as fh:
+        fh.write("not-a-number")
+
+    ticket = cm._next_ticket()  # must not raise
+
+    assert ticket >= 2
+
+
 def test_colliding_ticket_int_does_not_double_admit(tmp_path, monkeypatch):
     # Force every ticket to the SAME integer (simulating a counter collision);
     # admission must still pick exactly the first max_concurrent by (seq, key),

--- a/tests/test_determinism_183.py
+++ b/tests/test_determinism_183.py
@@ -161,6 +161,40 @@ def test_corrupted_counter_file_falls_back_without_crashing(tmp_path):
     assert ticket >= 2
 
 
+def test_recovered_counter_does_not_reissue_fallback_tickets(tmp_path):
+    cm = _mk_cm(tmp_path)
+    first = cm._next_ticket()  # from the on-disk counter
+
+    # Transient failure: the fallback issues tickets WITHOUT persisting to disk.
+    original = cm._ticket_counter_path
+    cm._ticket_counter_path = str(tmp_path / "gone" / "counter")
+    fb1 = cm._next_ticket()
+    fb2 = cm._next_ticket()
+
+    # Counter recovers, but on-disk still holds the stale pre-failure value.
+    cm._ticket_counter_path = original
+    recovered = cm._next_ticket()
+
+    issued = [first, fb1, fb2, recovered]
+    assert issued == sorted(issued)          # strictly increasing throughout
+    assert len(set(issued)) == 4             # recovery never reissues a fallback ticket
+    assert recovered > fb2
+
+
+def test_list_tickets_includes_legacy_filenames(tmp_path):
+    cm = _mk_cm(tmp_path)
+    # A pre-seq ticket left by an older version: queue_<ticket>_<key>.ticket.
+    legacy = os.path.join(cm.lock_dir, "queue_5_oldjob.ticket")
+    with open(legacy, "w", encoding="utf-8") as fh:
+        fh.write("{}")
+    cm.reserve_ticket("newjob")
+
+    keys = cm._list_tickets()
+
+    assert "oldjob" in keys   # legacy ticket is not silently dropped from FIFO
+    assert "newjob" in keys
+
+
 def test_colliding_ticket_int_does_not_double_admit(tmp_path, monkeypatch):
     # Force every ticket to the SAME integer (simulating a counter collision);
     # admission must still pick exactly the first max_concurrent by (seq, key),

--- a/tests/test_determinism_183.py
+++ b/tests/test_determinism_183.py
@@ -148,17 +148,21 @@ def test_counter_fallback_is_strictly_increasing_and_in_range(tmp_path, monkeypa
     assert fallbacks[0] > 2                       # seeded above the on-disk high-water mark
 
 
-def test_corrupted_counter_file_falls_back_without_crashing(tmp_path):
+def test_corrupted_counter_file_is_repaired_in_place(tmp_path):
     cm = _mk_cm(tmp_path)
     cm._next_ticket()  # advance to 1
-    # A partial write leaves a non-numeric body; int() would raise ValueError,
-    # which must be caught (like an OSError) and fall through to the fallback.
+    # A partial write leaves a non-numeric body; int() raises ValueError, which
+    # must be caught under the lock and the counter REPAIRED in place rather than
+    # leaving every process stuck in its own in-process counter.
     with open(cm._ticket_counter_path, "w", encoding="utf-8") as fh:
         fh.write("not-a-number")
 
     ticket = cm._next_ticket()  # must not raise
 
     assert ticket >= 2
+    # The corrupt body was healed to a valid integer the next read can use.
+    with open(cm._ticket_counter_path, encoding="utf-8") as fh:
+        assert int(fh.read().strip()) == ticket
 
 
 def test_recovered_counter_does_not_reissue_fallback_tickets(tmp_path):
@@ -205,6 +209,9 @@ def test_seed_considers_preserved_tickets_when_counter_corrupt(tmp_path):
         fh.write("{}")
 
     assert cm._highest_known_ticket() >= 100
+    # Exercise the actual reservation path, not just the helper: a corrupt
+    # counter recovers the high-water mark from the preserved ticket file.
+    assert cm._next_ticket() > 100
 
 
 def test_colliding_ticket_int_does_not_double_admit(tmp_path, monkeypatch):

--- a/tests/test_determinism_183.py
+++ b/tests/test_determinism_183.py
@@ -1,0 +1,162 @@
+"""Determinism guards for issue #183.
+
+One test per ordering site the audit flagged: the registry extension-union
+helpers, the recursive search walk, subprocess line segmentation, and the
+cross-process FIFO concurrency ticket. Each asserts the output is a pure,
+stable function of its input rather than of hash-seed / readdir / chunk-boundary
+/ wall-clock order.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.routes import files as files_routes
+from app.services.concurrency_manager import ConcurrencyManager
+from app.services.subprocess_runner import _split_stream_lines
+from app.services.tools import registry
+
+# ---------------------------------------------------------------------------
+# Site 1: registry union helpers return sorted, stable sequences
+# ---------------------------------------------------------------------------
+
+UNION_HELPERS = [
+    "convertible_extensions",
+    "archive_input_extensions",
+    "verify_extensions",
+    "output_extensions",
+    "scannable_extensions",
+]
+
+
+@pytest.mark.parametrize("helper", UNION_HELPERS)
+def test_registry_union_helpers_return_sorted_tuples(helper):
+    result = getattr(registry, helper)()
+    assert isinstance(result, tuple), f"{helper} must return a tuple"
+    assert list(result) == sorted(result), f"{helper} must be sorted"
+    assert len(result) == len(set(result)), f"{helper} must be deduplicated"
+
+
+@pytest.mark.parametrize("helper", UNION_HELPERS)
+def test_registry_union_helpers_are_byte_stable(helper):
+    fn = getattr(registry, helper)
+    assert fn() == fn()  # identical ordered sequence run-to-run
+
+
+# ---------------------------------------------------------------------------
+# Site 2: recursive search returns sorted order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_files_returns_sorted_order(tmp_path, monkeypatch):
+    # Convertible (.cue -> chdman) files created in non-alphabetical order.
+    for name in ["zebra.cue", "alpha.cue", "mango.cue", "beta.cue", "delta.cue"]:
+        (tmp_path / name).write_bytes(b"cue")
+    monkeypatch.setattr(files_routes.settings, "chd_volumes", str(tmp_path))
+    monkeypatch.setattr(files_routes.settings, "data_mount_root", str(tmp_path))
+
+    result = await files_routes.search_files(path=str(tmp_path))
+    names = [f["name"] for f in result["files"]]
+
+    assert names == sorted(names)
+    assert names == ["alpha.cue", "beta.cue", "delta.cue", "mango.cue", "zebra.cue"]
+
+
+# ---------------------------------------------------------------------------
+# Site 5: line segmentation is a pure function of the byte stream
+# ---------------------------------------------------------------------------
+
+
+def test_split_stream_lines_is_chunk_boundary_independent():
+    # CRLF, a bare CR (progress redraw), an LF, and a partial trailing line.
+    stream = "alpha\r\nbeta\rgamma\ndelta"
+    whole_lines, whole_remainder = _split_stream_lines(stream)
+    assert whole_lines == ["alpha", "beta", "gamma"]
+    assert whole_remainder == "delta"
+
+    # Feeding the same bytes split at *every* boundary yields identical lines.
+    for cut in range(len(stream) + 1):
+        buf = ""
+        emitted: list[str] = []
+        for piece in (stream[:cut], stream[cut:]):
+            buf += piece
+            lines, buf = _split_stream_lines(buf)
+            emitted.extend(lines)
+        assert emitted == whole_lines, f"cut={cut}"
+        assert buf == whole_remainder, f"cut={cut}"
+
+
+def test_split_stream_lines_strips_and_drops_blanks():
+    lines, remainder = _split_stream_lines("  a  \n\n b \n")
+    assert lines == ["a", "b"]
+    assert remainder == ""
+
+
+# ---------------------------------------------------------------------------
+# Site 4: FIFO ticket is unique, ordered, and fallback-safe
+# ---------------------------------------------------------------------------
+
+
+def _mk_cm(tmp_path, n=1):
+    return ConcurrencyManager(max_concurrent=n, lock_dir=str(tmp_path / "locks"))
+
+
+def test_tickets_are_monotonic_and_fifo_by_key(tmp_path):
+    cm = _mk_cm(tmp_path)
+    t1 = cm.reserve_ticket("jobA")
+    t2 = cm.reserve_ticket("jobB")
+    t3 = cm.reserve_ticket("jobC")
+    assert t1 < t2 < t3
+    assert cm._list_tickets() == ["jobA", "jobB", "jobC"]
+
+
+def test_reserve_ticket_is_idempotent_per_key(tmp_path):
+    cm = _mk_cm(tmp_path)
+    assert cm.reserve_ticket("job") == cm.reserve_ticket("job")
+    assert cm._list_tickets() == ["job"]
+
+
+def test_ticket_files_are_unique_per_reservation(tmp_path):
+    cm = _mk_cm(tmp_path)
+    for key in ("a", "b", "c", "d"):
+        cm.reserve_ticket(key)
+    ticket_files = [
+        f for f in os.listdir(cm.lock_dir)
+        if f.startswith("queue_") and f.endswith(".ticket")
+    ]
+    assert len(ticket_files) == len(set(ticket_files)) == 4
+
+
+def test_counter_fallback_is_strictly_increasing_and_in_range(tmp_path, monkeypatch):
+    cm = _mk_cm(tmp_path)
+    cm._next_ticket()  # advance the on-disk counter to 1
+    cm._next_ticket()  # ... and 2, so the fallback must seed above it
+
+    # Point the counter at a path under a missing dir so reads/writes raise
+    # OSError and the in-process fallback takes over.
+    monkeypatch.setattr(
+        cm, "_ticket_counter_path", str(tmp_path / "missing" / "counter"),
+    )
+    fallbacks = [cm._next_ticket() for _ in range(3)]
+
+    assert fallbacks == sorted(fallbacks)        # strictly increasing
+    assert len(set(fallbacks)) == 3              # unique, never colliding
+    assert all(t < 10_000 for t in fallbacks)    # small in-range ints, not wall-clock ms
+    assert fallbacks[0] > 2                       # seeded above the on-disk high-water mark
+
+
+def test_colliding_ticket_int_does_not_double_admit(tmp_path, monkeypatch):
+    # Force every ticket to the SAME integer (simulating a counter collision);
+    # admission must still pick exactly the first max_concurrent by (seq, key),
+    # not let a duplicated int put two jobs in the same prefix slot.
+    cm = ConcurrencyManager(max_concurrent=2, lock_dir=str(tmp_path / "locks"))
+    monkeypatch.setattr(cm, "_next_ticket", lambda: 7)
+    for key in ("a", "b", "c"):
+        cm.reserve_ticket(key)
+
+    keys = cm._list_tickets()
+    assert keys == ["a", "b", "c"]   # ordered by reservation seq, then key
+    assert keys[:2] == ["a", "b"]    # only the first two are admitted

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -349,7 +349,7 @@ def test_output_extensions_cover_mode_output_exts(tool_id):
 
 def test_output_extensions_union_covers_every_tool():
     """registry.output_extensions() is the union of all tools' outputs."""
-    union = registry.output_extensions()
+    union = set(registry.output_extensions())
     for tool in registry.all():
         assert tool.output_extensions <= union
     # Representative outputs from each tool.
@@ -358,8 +358,10 @@ def test_output_extensions_union_covers_every_tool():
 
 def test_scannable_extensions_are_output_plus_verify():
     """Discovery walks produced outputs *and* verifiable inputs (issue #131)."""
-    scannable = registry.scannable_extensions()
-    assert scannable == registry.output_extensions() | registry.verify_extensions()
+    scannable = set(registry.scannable_extensions())
+    assert scannable == set(registry.output_extensions()) | set(
+        registry.verify_extensions()
+    )
     # Non-CHD outputs that historically were never scanned are now eligible.
     assert {".chd", ".rvz", ".wia", ".gcz", ".nsz", ".xcz"} <= scannable
     # The extractcd .bin data-track sidecar (what Redump DATs index) is in too.


### PR DESCRIPTION
## Summary

Closes the five ordering soft-spots from the #177 audit (issue #183). Each let an output depend on **hash-seed / readdir / chunk-boundary / wall-clock** order instead of an explicit, stable one. No wire-API change.

| # | Site | Fix |
|---|------|-----|
| 1 | `registry.py` extension-union helpers (`convertible_extensions`, `archive_input_extensions`, `verify_extensions`, `output_extensions`, `scannable_extensions`) returned a `frozenset` (hash-seeded iteration order) | Return a **sorted `tuple`**. The two consumers that did set algebra (`info.py` `scannable - ARCHIVE`, `archive.py` listable/gate unions) wrap locally in `set()`/`frozenset()`. |
| 2 | `files.py` recursive search walker (`_scan`) used unsorted `os.listdir` while sibling `scan_directory` sorted | Iterate `sorted(os.listdir(...))` so `/api/files/search` no longer returns raw readdir order. |
| 3 | Frontend `sortedEntries` returned `0` for equal keys → rows jump when the `[...files, ...archives]` input order shifts | Add a stable `path` tiebreaker. |
| 4 | Concurrency FIFO ticket: OSError fallback was `int(os.times().elapsed*1000)` (different range → collide/mis-order; the ticket is also a `PriorityQueue` key in `job_manager`) | Strictly-increasing **in-process counter** seeded above the on-disk value; a per-reservation `seq` baked into each ticket filename; admission is now by **unique job key**, so a colliding ticket int can't double-admit. |
| 5 | `subprocess_runner.py` line segmentation picked `\r` *or* `\n` per chunk → emitted lines depended on read-chunk boundaries | Extract a pure `_split_stream_lines` that normalizes CRLF/CR → LF in one pass. Behavior-preserving (same lines), now a pure function of the byte stream. |

## Notes for review

- **Site 4 is the only hot-path change.** It's covered by a new characterization test (strictly-increasing/unique/in-range fallback + a forced-collision admission test) per the epic's hot-path guidance. `_list_tickets` now returns FIFO-ordered **keys** (was ticket ints); its only consumers are `_wait_for_turn` and `get_stats` len. The ticket int returned by `reserve_ticket` stays monotonic (still the `PriorityQueue` priority).
- **Site 1 return-type change** is a documented shared-seam contract change → DESIGN §3.4 updated (and §3.3 for the runner). Two existing registry/archive tests updated to `set(...)`-wrap where they did set algebra.

## Testing

- New `tests/test_determinism_183.py` (18 tests): sorted+byte-stable registry unions (all 5 helpers), sorted `search_files` output, chunk-boundary-independent `_split_stream_lines`, and the FIFO ticket's strictly-increasing fallback + collision-safe admission.
- Frontend change run through the Svelte autofixer (no issues).
- `PYTHONPATH=app python -m pytest -q` → **1012 passed**, 1 skipped; `--ignore` the binary-only e2e file → **1009 passed, 0 failed**. The 27 `test_archive_conversion_e2e.py` failures are pre-existing/environmental (this container lacks `chdman`/`dolphin-tool`/`z3ds`/`maxcso`/`makeps3iso`) and reproduce identically on the clean base.
- `ruff check .` → clean.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recursive file search and directory listings are now deterministically sorted across runs.
  * Improved cross-process job queue ordering with more robust FIFO ticket tracking and recovery.
  * Subprocess progress parsing is now more reliable across varying output read chunk sizes.
  * File browser rows now break ties deterministically when sort keys match.

* **Documentation**
  * Updated the tool-plugin architecture notes and release notes to document determinism improvements.

* **Tests**
  * Added/expanded determinism-focused test coverage for sorted outputs, progress parsing, and queue ticket ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves determinism and shared subprocess handling across the conversion pipeline. The main changes are:

- Stable ordering for registry extension unions, recursive file search, and file-browser tie breaks.
- FIFO ticket handling with unique queue keys and legacy ticket parsing.
- Shared subprocess runner support for deterministic line splitting, size-based progress, env forwarding, and required-output checks.
- Conversion services for NSZ, CSO, and Z3DS moved onto the shared runner.
- Job and metadata cache updates for stronger background-task retention and fresher CHD metadata reads.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changes appear merge-safe with deterministic ordering and subprocess behavior covered by targeted tests.

The implementation is narrowly scoped, includes characterization coverage for the ordering and FIFO-ticket behavior, and no accepted issues remain.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the registry helpers and subprocess runner checks before and after installing runtime requirements, documenting unsorted iteration order and missing \_split\_stream\_lines before, and sorted results and stable line emission after.
- I executed the portable FIFO ticket validation harness for both commits, recording repeated fallback values before and clean head values with a zero exit code after the second commit.
- I validated stable path tiebreaking for equal-size keys across permutations of /zeta/same.bin and /alpha/archive.zip::same.bin; the head commit shows the stable order /alpha/archive.zip::same.bin before /zeta/same.bin for both permutations.

<a href="https://app.greptile.com/trex/runs/12158706/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (7): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/lat..."](https://github.com/pacnpal/compressatorium/commit/1db69b3cb911f013a5bf4313da202f329dde9a0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39355831)</sub>

<!-- /greptile_comment -->