### PR TITLE
refactor(dispatch): replace residual tool/mode-identity branches with ModeSpec reads

### DIFF
--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -381,6 +381,21 @@ _SKIP_HTTP: dict[SkipReason, tuple[int, str]] = {
 }
 
 
+# Tools whose plan-time input validation is the generic "the input extension
+# must be one the mode declares" check (collapsed from the former per-tool
+# is_<tool> ladder, design §3.1). chdman is intentionally absent: it validates
+# by .chd presence (create needs non-.chd, extract/copy need .chd) because it
+# drops .chd from input_extensions. Each tool keeps its own skip reason/message.
+_BAD_EXTENSION_REASON: dict[str, SkipReason] = {
+    "dolphin": SkipReason.DOLPHIN_BAD_EXTENSION,
+    "z3ds": SkipReason.Z3DS_BAD_EXTENSION,
+    "nsz": SkipReason.NSZ_BAD_EXTENSION,
+    "cso": SkipReason.CSO_BAD_EXTENSION,
+    "chain": SkipReason.CHAIN_BAD_EXTENSION,
+    "romz": SkipReason.ROMZ_BAD_EXTENSION,
+}
+
+
 async def _plan_directory_job(
     file_path: str,
     *,
@@ -481,13 +496,6 @@ async def plan_job(
     backpressure, the cross-file archive multi-select guard, the batch dedup
     pass) stay in the endpoints, not here.
     """
-    is_dolphin = spec.tool_id == "dolphin"
-    is_z3ds = spec.tool_id == "z3ds"
-    is_nsz = spec.tool_id == "nsz"
-    is_cso = spec.tool_id == "cso"
-    is_romz = spec.tool_id == "romz"
-    is_chain = spec.tool_id == "chain"
-
     # Directory-as-input mode (makeps3iso folder->iso): a folder, not a file with
     # a suffix. Validate isdir + the tool's source-layout detector instead of
     # isfile + an extension match, and derive the output / display name from the
@@ -556,66 +564,38 @@ async def plan_job(
     if spec.kind == ModeKind.CREATE and file_path.lower().endswith(".chd"):
         raise SkipFile(SkipReason.CREATE_REQUIRES_NON_CHD)
 
-    if is_dolphin:
-        # Use the archive-aware extension (the member's, not the ".zip"
-        # container's) so archive members are validated against the real input.
+    # Generic input-extension gate (collapsed from the per-tool is_<tool>
+    # ladder, design §3.1): every non-chdman tool validates that the
+    # archive-aware input extension (the member's, not the ".zip" container's)
+    # is one its mode declares. spec.input_extensions is per-mode, so each
+    # direction is validated against the right set. chdman is handled above by
+    # the .chd create/extract checks (it drops .chd from input_extensions). The
+    # per-tool skip reason carries the tool-specific message.
+    bad_ext_reason = _BAD_EXTENSION_REASON.get(spec.tool_id)
+    if bad_ext_reason is not None:
         ext = _input_extension(file_path)
         if ext not in spec.input_extensions:
-            raise SkipFile(SkipReason.DOLPHIN_BAD_EXTENSION)
+            raise SkipFile(bad_ext_reason)
 
-    if is_z3ds:
-        ext = _input_extension(file_path)
-        if ext not in spec.input_extensions:
-            raise SkipFile(SkipReason.Z3DS_BAD_EXTENSION)
-
-    if is_nsz:
-        # spec.input_extensions is per-mode, so this validates the right set for
-        # whichever direction (compress: .nsp/.xci, decompress: .nsz/.xcz).
-        ext = _input_extension(file_path)
-        if ext not in spec.input_extensions:
-            raise SkipFile(SkipReason.NSZ_BAD_EXTENSION)
-
-    if is_cso:
-        # spec.input_extensions is per-mode: compress (.iso) vs decompress
-        # (.cso/.zso/.dax).
-        ext = _input_extension(file_path)
-        if ext not in spec.input_extensions:
-            raise SkipFile(SkipReason.CSO_BAD_EXTENSION)
-
-    if is_chain:
-        # Composite modes (tool_id="chain") match none of the legacy per-tool
-        # branches, so without this a direct API/batch submission would accept
-        # any non-.chd file and fail late in the worker. Validate the chain's
-        # declared source extensions (cso_to_chd: .cso/.zso/.dax).
-        ext = _input_extension(file_path)
-        if ext not in spec.input_extensions:
-            raise SkipFile(SkipReason.CHAIN_BAD_EXTENSION)
-
-    if is_romz:
-        # spec.input_extensions is per-mode: compress (.gb/.gbc/.gba/.nds) vs
-        # extract (.7z/.zip).
-        ext = _input_extension(file_path)
-        if ext not in spec.input_extensions:
-            raise SkipFile(SkipReason.ROMZ_BAD_EXTENSION)
-        if mode == "romz_extract":
-            # Validate the archive is a real single-ROM archive BEFORE planning
-            # an output / allowing overwrite. get_output_path_for_mode falls
-            # back to the suffix-stripped stem for unreadable/invalid archives,
-            # so without this an ordinary/corrupt/multi-ROM archive next to an
-            # existing same-stem file could drive duplicate_action=overwrite to
-            # delete that unrelated file before convert() ever validates.
-            try:
-                await run_in_threadpool(
-                    romz_service._single_rom_member, file_path,
-                )
-            except Exception as exc:
-                # Broad by design: corrupt/multi-ROM archives surface as
-                # ValueError, zipfile.BadZipFile, py7zr errors, OSError, … and
-                # all map to the same skip. Log the cause for troubleshooting.
-                logger.debug(
-                    "romz_extract validation failed for %s: %s", file_path, exc,
-                )
-                raise SkipFile(SkipReason.ROMZ_INVALID_ARCHIVE) from None
+    if mode == "romz_extract":
+        # romz-specific: validate the archive is a real single-ROM archive
+        # BEFORE planning an output / allowing overwrite. get_output_path_for_mode
+        # falls back to the suffix-stripped stem for unreadable/invalid archives,
+        # so without this an ordinary/corrupt/multi-ROM archive next to an
+        # existing same-stem file could drive duplicate_action=overwrite to
+        # delete that unrelated file before convert() ever validates.
+        try:
+            await run_in_threadpool(
+                romz_service._single_rom_member, file_path,
+            )
+        except Exception as exc:
+            # Broad by design: corrupt/multi-ROM archives surface as
+            # ValueError, zipfile.BadZipFile, py7zr errors, OSError, … and
+            # all map to the same skip. Log the cause for troubleshooting.
+            logger.debug(
+                "romz_extract validation failed for %s: %s", file_path, exc,
+            )
+            raise SkipFile(SkipReason.ROMZ_INVALID_ARCHIVE) from None
 
     # Calculate output path and handle duplicates
     # For archive files: use output_dir if specified, otherwise save next to archive
@@ -641,11 +621,14 @@ async def plan_job(
                     output_path = get_unique_output_path(output_path)
 
     if (
-        is_dolphin
+        spec.kind != ModeKind.COPY
         and duplicate_action == DuplicateAction.OVERWRITE
         and output_path
         and _is_same_path(output_path, file_path)
     ):
+        # Any non-copy mode writing over its own source would destroy it; only
+        # chdman copy (.chd -> .chd) is an intentional in-place recompress, and
+        # every other mode changes the extension so output never equals input.
         raise SkipFile(SkipReason.DOLPHIN_SAME_PATH)
 
     allow_overwrite = (
@@ -806,15 +789,12 @@ async def create_job(request: JobCreateRequest):
             status_code=400,
             detail="Compression levels are only supported for Dolphin and Switch formats",
         )
-    if compression and mode == "dolphin_iso":
+    if compression and not (
+        spec.supports_compression or spec.supports_compression_level
+    ):
         raise HTTPException(
             status_code=400,
-            detail="Compression not applicable for ISO extraction",
-        )
-    if compression and mode == "dolphin_gcz":
-        raise HTTPException(
-            status_code=400,
-            detail="GCZ uses fixed internal compression",
+            detail="Compression is not supported for this conversion mode",
         )
     if compression and is_dolphin and "," in compression:
         raise HTTPException(
@@ -913,15 +893,12 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
             status_code=400,
             detail="Compression levels are only supported for Dolphin and Switch formats",
         )
-    if compression and mode == "dolphin_iso":
+    if compression and not (
+        spec.supports_compression or spec.supports_compression_level
+    ):
         raise HTTPException(
             status_code=400,
-            detail="Compression not applicable for ISO extraction",
-        )
-    if compression and mode == "dolphin_gcz":
-        raise HTTPException(
-            status_code=400,
-            detail="GCZ uses fixed internal compression",
+            detail="Compression is not supported for this conversion mode",
         )
     if compression and is_dolphin and "," in compression:
         raise HTTPException(

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -396,6 +396,18 @@ _BAD_EXTENSION_REASON: dict[str, SkipReason] = {
 }
 
 
+# Dolphin modes that take no compression input, with their specific advisory
+# message. Collapsed from the former per-mode dolphin_iso / dolphin_gcz branches
+# via a data lookup (not a capability branch), so the exact wire detail is
+# preserved while the gate is driven by spec fields. Scoped to dolphin because
+# other tools that merely ignore compression (e.g. the cso_to_chd chain, whose
+# ChainTool drops a stale preset) historically queued rather than 400'd.
+_NO_COMPRESSION_DETAIL: dict[str, str] = {
+    "dolphin_iso": "Compression not applicable for ISO extraction",
+    "dolphin_gcz": "GCZ uses fixed internal compression",
+}
+
+
 async def _plan_directory_job(
     file_path: str,
     *,
@@ -789,12 +801,16 @@ async def create_job(request: JobCreateRequest):
             status_code=400,
             detail="Compression levels are only supported for Dolphin and Switch formats",
         )
-    if compression and not (
-        spec.supports_compression or spec.supports_compression_level
+    if (
+        compression
+        and spec.tool_id == "dolphin"
+        and not (spec.supports_compression or spec.supports_compression_level)
     ):
         raise HTTPException(
             status_code=400,
-            detail="Compression is not supported for this conversion mode",
+            detail=_NO_COMPRESSION_DETAIL.get(
+                mode, "Compression is not supported for this Dolphin mode"
+            ),
         )
     if compression and is_dolphin and "," in compression:
         raise HTTPException(
@@ -893,12 +909,16 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
             status_code=400,
             detail="Compression levels are only supported for Dolphin and Switch formats",
         )
-    if compression and not (
-        spec.supports_compression or spec.supports_compression_level
+    if (
+        compression
+        and spec.tool_id == "dolphin"
+        and not (spec.supports_compression or spec.supports_compression_level)
     ):
         raise HTTPException(
             status_code=400,
-            detail="Compression is not supported for this conversion mode",
+            detail=_NO_COMPRESSION_DETAIL.get(
+                mode, "Compression is not supported for this Dolphin mode"
+            ),
         )
     if compression and is_dolphin and "," in compression:
         raise HTTPException(

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -24,9 +24,8 @@ from services.disc_id import embed_in_chd as disc_id_embed
 from services.disc_id import extract_from_source as disc_id_from_source
 from services.lock_manager import lock_manager
 from services.makeps3iso import makeps3iso_service
-from services.tools import registry
+from services.tools import ModeKind, registry
 from services.verification_store import verification_store
-from services.z3ds_compress import Z3DS_DECOMPRESS_FORMATS, Z3DS_OUTPUT_FORMATS
 from utils.delete_plan import build_delete_plan
 from utils.path_utils import is_within_configured_volumes, strip_archive_path
 
@@ -154,19 +153,20 @@ class JobManager:
                 mode.value, file_path, output_dir,
             )
             # The HTTP routes validate inputs before passing an explicit
-            # output_path; direct service callers reach this fallback, so
-            # re-assert the guards the legacy per-tool fallback enforced.
-            if mode == ConversionMode.Z3DS_COMPRESS:
+            # output_path; direct service callers reach this fallback. Most
+            # tools' output_path() raises for an unsupported extension, but
+            # z3ds's does not, so keep its input-extension gate -- now read from
+            # the mode's declared input_extensions instead of the per-direction
+            # Z3DS_*_FORMATS constants.
+            spec = registry.spec(mode.value)
+            if spec.tool_id == "z3ds":
                 ext = Path(file_path).suffix.lower()
-                if ext not in Z3DS_OUTPUT_FORMATS:
+                if ext not in spec.input_extensions:
                     raise ValueError(f"Unsupported file extension: {ext}")
-            elif mode == ConversionMode.Z3DS_DECOMPRESS:
-                ext = Path(file_path).suffix.lower()
-                if ext not in Z3DS_DECOMPRESS_FORMATS:
-                    raise ValueError(f"Unsupported file extension: {ext}")
-            elif mode.value.startswith("dolphin_") and _paths_collide(
-                output_path, file_path,
-            ):
+            # Generic same-path guard: a non-copy mode must never write over its
+            # own source (chdman copy is an intentional in-place .chd recompress;
+            # every other mode changes the extension so output != input).
+            if spec.kind != ModeKind.COPY and _paths_collide(output_path, file_path):
                 raise ValueError(
                     "Output path matches input; refusing to overwrite source"
                 )
@@ -1821,7 +1821,7 @@ class JobManager:
                 verified = False
                 source_deleted = False
                 if job.delete_on_verify:
-                    if job.mode.value.startswith("extract"):
+                    if not registry.spec(job.mode.value).supports_delete_on_verify:
                         raise RuntimeError(
                             "Delete-on-verify is only supported for "
                             "create/copy/Dolphin/3DS/Switch-compress modes"
@@ -1830,11 +1830,7 @@ class JobManager:
                         raise ConversionCancelled("Conversion cancelled")
 
                     verified = False
-                    job.message = (
-                        "Verifying output (zstd -t)..."
-                        if job.mode.value == "z3ds_compress"
-                        else "Verifying output..."
-                    )
+                    job.message = "Verifying output..."
                     await self._notify_subscribers(
                         job_id,
                         {

--- a/src/lib/stores/conversion.svelte.js
+++ b/src/lib/stores/conversion.svelte.js
@@ -27,16 +27,11 @@ function defaultModeFor(toolId) {
 // submitted a Dolphin job without first opening the codec picker. Seed with
 // a tool-appropriate default so the first submission always works.
 function defaultCompressionFor(toolId) {
-  if (toolId === 'dolphin') return ['zstd'];
-  if (toolId === 'nsz') return ['solid'];
-  // CSO ships a strong default: the 'max' effort preset (extra Zopfli/libdeflate
-  // trials for CSO/CSO2/DAX, brute-forced lz4 for ZSO) for the smallest output.
-  // It's lossless either way, and the Reset-to-default button brings it back.
-  if (toolId === 'cso') return ['max'];
-  // Handheld ROM packer defaults to 'max' (the -mx9 -md=256m -mfb=273 LZMA2
-  // profile) for the smallest archive; lossless either way.
-  if (toolId === 'romz') return ['max'];
-  return ['zlib'];
+  // The per-tool default codec seed now lives on each registry descriptor
+  // (`defaultCompression`), so this is a lookup instead of an
+  // `if (toolId === ...)` ladder. Each tool's rationale (Dolphin zstd, Switch
+  // 'solid', CSO/romz 'max' effort preset) is documented inline in registry.js.
+  return registry.forTool(toolId)?.defaultCompression ?? ['zlib'];
 }
 
 const PREF_SAVE_DEBOUNCE_MS = 500;

--- a/src/lib/tools/registry.js
+++ b/src/lib/tools/registry.js
@@ -115,6 +115,10 @@ function swapExt(path, newExt) {
 export const TOOLS = [
   {
     id: 'chdman',
+    // Per-tool default compression seed (replaces the old defaultCompressionFor
+    // `if (toolId === ...)` ladder in conversion.svelte.js): the first selection
+    // when this tool becomes primary, before the user opens the codec picker.
+    defaultCompression: ['zlib'],
     label: 'CHDMAN',
     hint: 'Convert CD / DVD / LaserDisc images to and from CHD.',
     // chdman is the original endpoint set, so it has no URL prefix:
@@ -204,6 +208,7 @@ export const TOOLS = [
   },
   {
     id: 'dolphin',
+    defaultCompression: ['zstd'],
     label: 'Dolphin',
     hint: 'Compress GameCube / Wii discs to RVZ, WIA, or GCZ.',
     verifyPrefix: 'dolphin',
@@ -250,6 +255,7 @@ export const TOOLS = [
   },
   {
     id: 'z3ds',
+    defaultCompression: ['zlib'],
     label: '3DS',
     hint: 'Compress and decompress Nintendo 3DS ROMs (.3ds/.cci/.cia/.cxi/.3dsx ↔ Z3DS).',
     verifyPrefix: 'z3ds',
@@ -285,6 +291,7 @@ export const TOOLS = [
   },
   {
     id: 'nsz',
+    defaultCompression: ['solid'],
     label: 'Switch',
     hint: 'Compress and decompress Nintendo Switch dumps (NSP/XCI ↔ NSZ/XCZ). Needs your own prod.keys.',
     verifyPrefix: 'nsz',
@@ -330,6 +337,7 @@ export const TOOLS = [
   },
   {
     id: 'cso',
+    defaultCompression: ['max'],
     label: 'CSO',
     hint: 'Compress PSP / PS2 ISO images to CSO / CSO v2 / ZSO / DAX (and back).',
     verifyPrefix: 'cso',
@@ -404,6 +412,7 @@ export const TOOLS = [
   },
   {
     id: 'romz',
+    defaultCompression: ['max'],
     label: 'Handheld ROM',
     hint: 'Compress Game Boy / GBC / GBA / DS ROM dumps to .7z / .zip (and back).',
     verifyPrefix: 'romz',
@@ -458,6 +467,7 @@ export const TOOLS = [
   },
   {
     id: 'makeps3iso',
+    defaultCompression: ['zlib'],
     label: 'PS3 ISO',
     hint: 'Build a PS3 .iso from a decrypted disc/JB folder (a PS3_GAME/ root). No keys, no decryption.',
     // No verify endpoint: makeps3iso's only check is a backend PARAM.SFO

--- a/tests/test_modespec_branches_180.py
+++ b/tests/test_modespec_branches_180.py
@@ -1,0 +1,43 @@
+"""Guard for #180: the dispatch/consumer sites must read ModeSpec/registry
+fields, not branch on tool/mode identity.
+
+The design doc's §3.1 mapping table says every `mode.startswith(...)` /
+`== "<modestring>"` capability check should become a `ModeSpec` field read. This
+pins the greppable Acceptance (no such residual checks survive in `convert.py` /
+`job_manager.py`) and documents the collapsed extension gate's coverage.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from routes.convert import _BAD_EXTENSION_REASON
+
+_APP = Path(__file__).resolve().parent.parent / "app"
+
+# The capability checks §3.1 says must become ModeSpec field reads. Note this is
+# deliberately narrow: the kept `mode == "romz_extract"` (romz single-ROM
+# validation) and `mode == "extractcd"` (rename helper) are NOT capability
+# checks and must stay allowed.
+_FORBIDDEN = re.compile(
+    r'startswith\("(?:dolphin_|extract|z3ds_)"\)'
+    r'|== "(?:z3ds_compress|dolphin_iso|dolphin_gcz)"'
+)
+
+
+@pytest.mark.parametrize("rel", ["routes/convert.py", "services/job_manager.py"])
+def test_no_residual_capability_branches(rel):
+    src = (_APP / rel).read_text(encoding="utf-8")
+    hits = _FORBIDDEN.findall(src)
+    assert not hits, f"residual tool/mode-identity capability branch in {rel}: {hits}"
+
+
+def test_bad_extension_reason_covers_non_chdman_tools():
+    # The collapsed extension gate is driven by this map. chdman is intentionally
+    # absent (it validates by .chd presence, having dropped .chd from
+    # input_extensions); makeps3iso (directory input, no suffix) is too.
+    assert set(_BAD_EXTENSION_REASON) == {
+        "dolphin", "z3ds", "nsz", "cso", "chain", "romz",
+    }
+    assert "chdman" not in _BAD_EXTENSION_REASON

--- a/tests/test_modespec_branches_180.py
+++ b/tests/test_modespec_branches_180.py
@@ -29,7 +29,10 @@ _FORBIDDEN = re.compile(
 @pytest.mark.parametrize("rel", ["routes/convert.py", "services/job_manager.py"])
 def test_no_residual_capability_branches(rel):
     src = (_APP / rel).read_text(encoding="utf-8")
-    hits = _FORBIDDEN.findall(src)
+    # Strip line comments so prose documenting the old idiom (e.g. "collapsed
+    # from the dolphin_iso branch") doesn't trip the guard; only live code counts.
+    code = "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+    hits = _FORBIDDEN.findall(code)
     assert not hits, f"residual tool/mode-identity capability branch in {rel}: {hits}"
 
 
@@ -41,3 +44,48 @@ def test_bad_extension_reason_covers_non_chdman_tools():
         "dolphin", "z3ds", "nsz", "cso", "chain", "romz",
     }
     assert "chdman" not in _BAD_EXTENSION_REASON
+
+
+@pytest.mark.asyncio
+async def test_chain_compression_is_not_rejected(tmp_path, monkeypatch):
+    """A chain mode (cso_to_chd) that just ignores a stale compression preset
+    must still queue, not 400. Regression: the compression gate is scoped to
+    dolphin, so a chain with supports_compression=False isn't rejected."""
+    from unittest.mock import AsyncMock
+
+    from models import ConversionMode, JobCreateRequest
+    from routes import convert as convert_routes
+
+    source = tmp_path / "game.cso"
+    source.write_bytes(b"cso")
+    monkeypatch.setattr(convert_routes.settings, "chd_volumes", str(tmp_path))
+    monkeypatch.setattr(convert_routes.settings, "data_mount_root", str(tmp_path))
+    create_job_mock = AsyncMock()
+    monkeypatch.setattr(convert_routes.job_manager, "create_job", create_job_mock)
+
+    await convert_routes.create_job(JobCreateRequest(
+        file_path=str(source), mode=ConversionMode.CSO_TO_CHD, compression="max",
+    ))
+    create_job_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dolphin_iso_compression_keeps_specific_message(tmp_path, monkeypatch):
+    """dolphin_iso still rejects compression with its exact advisory message,
+    preserved via the data lookup rather than a mode-string branch."""
+    from fastapi import HTTPException
+
+    from models import ConversionMode, JobCreateRequest
+    from routes import convert as convert_routes
+
+    source = tmp_path / "game.rvz"
+    source.write_bytes(b"rvz")
+    monkeypatch.setattr(convert_routes.settings, "chd_volumes", str(tmp_path))
+    monkeypatch.setattr(convert_routes.settings, "data_mount_root", str(tmp_path))
+
+    with pytest.raises(HTTPException) as exc:
+        await convert_routes.create_job(JobCreateRequest(
+            file_path=str(source), mode=ConversionMode.DOLPHIN_ISO, compression="zstd",
+        ))
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Compression not applicable for ISO extraction"


### PR DESCRIPTION
## Summary

Closes #180. Collapses the design §3.1 capability branches in the dispatch/consumer sites onto `ModeSpec`/registry field reads. **Behavior-preserving** — guarded by `test_mode_parity_fixes.py`, `test_dispatch_routing.py`, `test_output_path_routing.py` (all pass unchanged). No wire-API change.

### `convert.py`
- The 6-way `is_<tool>` extension ladder → **one** generic check driven by a `tool_id → SkipReason` map (`_BAD_EXTENSION_REASON`), preserving each tool's distinct skip message. **chdman is intentionally excluded** (it validates by `.chd` presence — it drops `.chd` from `input_extensions`, the epic's "verified healthy" item); the `romz_extract` single-ROM validation is kept.
- Same-path guard: `is_dolphin` → `spec.kind != ModeKind.COPY`. Only chdman `copy` (`.chd → .chd`) is an intentional in-place recompress; every other mode changes the extension so output never equals input.
- Compression: `mode == "dolphin_iso"/"dolphin_gcz"` → `not (supports_compression or supports_compression_level)`.

### `job_manager.py`
- Output-path fallback: drop the `Z3DS_COMPRESS/DECOMPRESS` extension re-checks and generalize the `dolphin_` same-path guard to `kind != COPY`.
- Delete-on-verify gate: `startswith("extract")` → `not registry.spec(...).supports_delete_on_verify`.
- Verify message: drop the `z3ds_compress` `(zstd -t)` special-case → uniform `"Verifying output..."`.

### Frontend
- `defaultCompressionFor`'s `if (toolId === ...)` ladder → a `defaultCompression` field on each registry descriptor + `registry.forTool(id)?.defaultCompression ?? ['zlib']`.

## Two behavior-preservation traps caught by the tests (and fixed)

- **Compression**: `nsz_compress` has `supports_compression=False` but `supports_compression_level=True` (it takes `solid:18`). A bare `not spec.supports_compression` (the issue's literal suggestion) wrongly rejected it, breaking `test_nsz_compress_accepts_level_token`. The gate is `not (supports_compression or supports_compression_level)` — still rejects dolphin_iso/gcz (both False).
- **z3ds fallback**: z3ds's `output_path()` does **not** raise for bad extensions (unlike other tools), and the dolphin fallback test requires dolphin extensions *not* be validated there — so the z3ds extension gate is load-bearing and is kept (re-expressed via `spec.input_extensions`), not removed.

## Testing

- New `tests/test_modespec_branches_180.py`: a greppable-Acceptance regression guard (no `startswith("dolphin_"/"extract"/"z3ds_")` / `== "<modestring>"` capability checks survive in `convert.py`/`job_manager.py`) + the `_BAD_EXTENSION_REASON` coverage (chdman excluded).
- Acceptance grep is clean; `test_mode_parity_fixes` / `test_dispatch_routing` / `test_output_path_routing` pass unchanged.
- Frontend `conversion.svelte.js` run through the Svelte autofixer (no issues); `registry.js` `node --check` clean.
- `PYTHONPATH=app python -m pytest -q` → **994 passed** (excluding the binary-only `test_archive_conversion_e2e.py`, whose 27 failures are pre-existing — this container lacks the conversion binaries — and reproduce on the clean base). `ruff check .` clean.

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves remaining dispatch capability checks onto ModeSpec and registry data. The main changes are:

- Collapses per-tool input-extension validation into a registry-backed skip-reason map.
- Uses ModeSpec fields for same-path, compression, and delete-on-verify gates.
- Moves frontend default compression seeds into tool registry descriptors.
- Adds regression tests for ModeSpec-based branch removal and preserved compression behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The refactor appears merge-safe with no code issues identified.

The changes are behavior-preserving refactors backed by targeted regression coverage and broad test execution described for the touched dispatch and registry paths.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the dispatch-api test suite and compared the base (before) run with the head (after) run, observing matching endpoint outcomes across representative scenarios, including 400/422 rejections and 200 OK queue-reaching responses with job\_manager calls.
- Reviewed the head behavior for the monkeypatched createcd flow and z3ds verification, noting that the head rejects createcd same-path output when necessary, queues copy, rejects z3ds\_decompress delete-on-verify before verification, allows supported modes, and continues emitting Verifying output for z3ds\_compress.
- Verified frontend default compression behavior, confirming identical defaults between before and head logs and that registry descriptor defaultCompression values are present on the head; captured the harness source for reproducibility.

<a href="https://app.greptile.com/trex/runs/12053311/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(convert): scope compression rejectio..."](https://github.com/pacnpal/compressatorium/commit/40f1c6d16f3f90f2d9b199fcc7632dea629e60c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39367701)</sub>

<!-- /greptile_comment -->