### PR TITLE
Wire the post_convert seam; de-duplicate disc-ID embedding

### DIFF
--- a/app/services/disc_id.py
+++ b/app/services/disc_id.py
@@ -1097,6 +1097,24 @@ async def embed_in_chd(
     return True
 
 
+async def read_embedded_game_id(
+    chd_path: str,
+    chdman_path: str = "chdman",
+) -> Optional[str]:
+    """Return the GAME serial already embedded in *chd_path*, or ``None``.
+
+    Reads only our own embedded GAME tag (no disc-sector / GDRO / companion-file
+    fallback, unlike :func:`extract_from_chd`), so callers can cheaply check
+    whether a CHD is *already* tagged before writing. This is what keeps the
+    conversion-time embed idempotent: re-running it on an already-tagged CHD
+    can be skipped instead of appending a duplicate GAME tag.
+    """
+    raw = await _dumpmeta_text(chd_path, TAG_GAME, chdman_path)
+    if raw and raw.strip():
+        return raw.strip()
+    return None
+
+
 async def ensure_disc_id_embedded(
     chd_path: str,
     chdman_path: str = "chdman",

--- a/app/services/disc_id.py
+++ b/app/services/disc_id.py
@@ -1115,6 +1115,23 @@ async def read_embedded_game_id(
     return None
 
 
+async def clear_embedded_disc_id(
+    chd_path: str,
+    chdman_path: str = "chdman",
+) -> None:
+    """Strip embedded GAME/NAME tags so a later :func:`embed_in_chd` converges.
+
+    ``chdman addmeta`` *appends* a new metadata item rather than replacing an
+    existing one, so re-tagging a CHD that already carries a *different* serial
+    would leave the stale GAME/NAME behind (and accumulate duplicates on repeat).
+    Callers that detect a serial mismatch call this first to delete the old pair
+    before writing the new one. Best-effort: a freshly created CHD has nothing
+    to delete (``delmeta`` simply reports the tag absent).
+    """
+    await _delmeta(chd_path, TAG_GAME, chdman_path)
+    await _delmeta(chd_path, TAG_NAME, chdman_path)
+
+
 async def ensure_disc_id_embedded(
     chd_path: str,
     chdman_path: str = "chdman",
@@ -1300,6 +1317,40 @@ async def _addmeta_text(
         return True
     except Exception as e:
         logger.warning("disc_id: addmeta tag=%s error: %s", tag, e)
+        return False
+
+
+async def _delmeta(chd_path: str, tag: str, chdman_path: str) -> bool:
+    """Delete a metadata tag from *chd_path* via chdman delmeta (best-effort).
+
+    Returns True on success. A missing tag (nothing to delete) reports a non-zero
+    exit, which is treated as a benign no-op by callers, the point is only to
+    guarantee the tag is absent before a fresh addmeta writes the current value.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            chdman_path,
+            "delmeta",
+            "-i", chd_path,
+            "-t", tag,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "disc_id: delmeta tag=%s not present or failed (rc=%s) in %s: %s",
+                    tag,
+                    proc.returncode,
+                    chd_path,
+                    stderr.decode(errors="replace").strip(),
+                )
+            return False
+        logger.debug("disc_id: delmeta tag=%s removed from %s", tag, chd_path)
+        return True
+    except Exception as e:
+        logger.warning("disc_id: delmeta tag=%s error: %s", tag, e)
         return False
 
 

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1749,6 +1749,22 @@ class JobManager:
                 self._cancelled.discard(job_id)
                 job.progress = 100
 
+                # Run the tool's post-convert hook before sizing the output.
+                # chdman uses it to embed disc-ID GAME/NAME tags into a freshly
+                # created CD/DVD CHD; the default is a no-op, so this is safe to
+                # call for every mode. Running it first means the output_size
+                # computed below reflects the tagged file. The source
+                # (input_path) is still present here, even when delete-on-verify
+                # is requested (deletion happens after verify).
+                try:
+                    await registry.for_mode(job.mode.value).post_convert(
+                        input_path, job.output_path, job.mode.value,
+                    )
+                except Exception as e:
+                    logger.debug(
+                        "Job %s post-convert hook skipped: %s", job_id, e
+                    )
+
                 # Get output file size
                 if job.input_kind == InputKind.DIRECTORY:
                     # makeps3iso may finish as a single .iso OR a split set
@@ -1779,20 +1795,6 @@ class JobManager:
                         job.output_size = total_size if total_size > 0 else None
                     else:
                         job.output_size = os.path.getsize(job.output_path)
-
-                # Run the tool's post-convert hook. chdman uses it to embed
-                # disc-ID GAME/NAME tags into a freshly created CD/DVD CHD; the
-                # default is a no-op, so this is safe to call for every mode.
-                # The source (input_path) is still present here, even when
-                # delete-on-verify is requested (deletion happens after verify).
-                try:
-                    await registry.for_mode(job.mode.value).post_convert(
-                        input_path, job.output_path, job.mode.value,
-                    )
-                except Exception as e:
-                    logger.debug(
-                        "Job %s post-convert hook skipped: %s", job_id, e
-                    )
 
                 verified = False
                 source_deleted = False

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -20,8 +20,6 @@ from services.archive import archive_service
 from services.chd_metadata_store import chd_metadata_store
 from services.chdman import ConversionCancelled, chdman_service
 from services.concurrency_manager import concurrency_manager
-from services.disc_id import embed_in_chd as disc_id_embed
-from services.disc_id import extract_from_source as disc_id_from_source
 from services.lock_manager import lock_manager
 from services.makeps3iso import makeps3iso_service
 from services.tools import registry
@@ -1782,41 +1780,19 @@ class JobManager:
                     else:
                         job.output_size = os.path.getsize(job.output_path)
 
-                # Embed game ID / title into CHD metadata after createcd/createdvd.
-                # Uses the source file (input_path) which is still available at this
-                # point, even when delete-on-verify is requested.
-                # GAME tag = normalized serial (emulator DB lookup key).
-                # NAME tag = human-readable title when available, serial otherwise.
-                if job.mode.value in {"createcd", "createdvd"} and os.path.exists(job.output_path):
-                    try:
-                        disc_info = await run_in_threadpool(disc_id_from_source, input_path)
-                        if disc_info and disc_info.get("game_id"):
-                            game_id = disc_info["game_id"]
-                            title = disc_info.get("title") or game_id
-                            embedded = await disc_id_embed(
-                                job.output_path,
-                                game_id,
-                                title,
-                                settings.chdman_path,
-                            )
-                            if embedded:
-                                logger.info(
-                                    "Job %s embedded disc ID %r in %s",
-                                    job_id,
-                                    game_id,
-                                    Path(job.output_path).name,
-                                )
-                            else:
-                                logger.debug(
-                                    "Job %s failed to embed disc ID %r in %s",
-                                    job_id,
-                                    game_id,
-                                    Path(job.output_path).name,
-                                )
-                    except Exception as e:
-                        logger.debug(
-                            "Job %s disc ID embed skipped: %s", job_id, e
-                        )
+                # Run the tool's post-convert hook. chdman uses it to embed
+                # disc-ID GAME/NAME tags into a freshly created CD/DVD CHD; the
+                # default is a no-op, so this is safe to call for every mode.
+                # The source (input_path) is still present here, even when
+                # delete-on-verify is requested (deletion happens after verify).
+                try:
+                    await registry.for_mode(job.mode.value).post_convert(
+                        input_path, job.output_path, job.mode.value,
+                    )
+                except Exception as e:
+                    logger.debug(
+                        "Job %s post-convert hook skipped: %s", job_id, e
+                    )
 
                 verified = False
                 source_deleted = False

--- a/app/services/tools/__init__.py
+++ b/app/services/tools/__init__.py
@@ -29,7 +29,7 @@ registry.register(RomzTool(settings.sevenzip_path))
 registry.register(MakePs3IsoTool(settings.makeps3iso_path))
 # Composite/pipeline modes register last: ChainTool drives the component tools
 # above through the registry, so they must already be present.
-registry.register(ChainTool(registry, chdman_path=settings.chdman_path))
+registry.register(ChainTool(registry))
 
 __all__ = [
     "BaseTool",

--- a/app/services/tools/chain.py
+++ b/app/services/tools/chain.py
@@ -27,12 +27,8 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from fastapi.concurrency import run_in_threadpool
-
 from config import settings
-from logging_setup import get_logger
 from models import OutputStatus
-from services.disc_id import embed_in_chd, extract_from_source
 from services.disk import create_scratch_dir, ensure_headroom
 from services.lock_manager import lock_manager
 from services.maxcso import uncompressed_iso_size
@@ -44,8 +40,6 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
     from .registry import ToolRegistry
-
-logger = get_logger()
 
 # cso/zso/dax -> .iso (maxcso, lossless) -> .chd (chdman createdvd).
 # createdvd is pinned: a cso/zso/dax is an ISO/data-only image with no CD audio
@@ -85,11 +79,11 @@ class ChainTool(BaseTool):
     output_extensions = frozenset()
     verify_extensions = frozenset()
 
-    def __init__(self, registry: "ToolRegistry", *, chdman_path: str) -> None:
-        # No binary of its own; it drives the component tools via the registry.
+    def __init__(self, registry: "ToolRegistry") -> None:
+        # No binary of its own; it drives the component tools via the registry,
+        # including the final step's post_convert hook for disc-ID tagging.
         super().__init__("")
         self._registry = registry
-        self._chdman_path = chdman_path
 
     # ------------------------------------------------------------------ paths
     def output_path(
@@ -199,9 +193,13 @@ class ChainTool(BaseTool):
                 cumulative += weights[i]
                 current_in = step_out
 
-            # Carry disc-ID GAME/NAME tags onto the final CHD, the same as a
-            # direct createdvd job (job_manager only tags literal create modes).
-            await self._embed_disc_id(intermediate_source, output_path)
+            # Tag the final CHD via the last step's post_convert hook — the same
+            # disc-ID path a direct createdvd job takes — while the intermediate
+            # source still exists (work_dir is removed in the finally below).
+            final_step = spec.steps[-1]
+            await self._registry.for_mode(final_step.mode).post_convert(
+                intermediate_source, output_path, final_step.mode,
+            )
             yield {"progress": 100, "message": "Conversion complete"}
         finally:
             shutil.rmtree(work_dir, ignore_errors=True)
@@ -235,25 +233,6 @@ class ChainTool(BaseTool):
         if intermediate_bytes > 0:
             targets.append((work_dir, intermediate_bytes))
         ensure_headroom(targets, margin_bytes=margin)
-
-    async def _embed_disc_id(self, source_path: str, output_path: str) -> None:
-        if Path(output_path).suffix.lower() != ".chd":
-            return
-        try:
-            disc_info = await run_in_threadpool(extract_from_source, source_path)
-            if disc_info and disc_info.get("game_id"):
-                game_id = disc_info["game_id"]
-                title = disc_info.get("title") or game_id
-                embedded = await embed_in_chd(
-                    output_path, game_id, title, self._chdman_path,
-                )
-                if embedded:
-                    logger.info(
-                        "Chain embedded disc ID %r in %s",
-                        game_id, Path(output_path).name,
-                    )
-        except Exception as exc:  # best effort; tagging never fails the job
-            logger.debug("Chain disc ID embed skipped: %s", exc)
 
     # ------------------------------------------------------ verify / info
     def _final_tool(self):

--- a/app/services/tools/chdman.py
+++ b/app/services/tools/chdman.py
@@ -183,7 +183,9 @@ class ChdmanTool(BaseTool):
         """
         if mode not in _DISC_ID_MODES:
             return
-        if Path(output_path).suffix.lower() != ".chd" or not os.path.exists(output_path):
+        if Path(output_path).suffix.lower() != ".chd":
+            return
+        if not await run_in_threadpool(os.path.exists, output_path):
             return
         try:
             disc_info = await run_in_threadpool(extract_from_source, input_path)

--- a/app/services/tools/chdman.py
+++ b/app/services/tools/chdman.py
@@ -7,15 +7,28 @@ prefix checks across the codebase.
 from __future__ import annotations
 
 import asyncio
+import os
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
+from fastapi.concurrency import run_in_threadpool
+
+from logging_setup import get_logger
 from models import CHDInfo, OutputStatus
 from services.chdman import CHDMAN_CONVERTIBLE_EXTENSIONS, chdman_service
+from services.disc_id import embed_in_chd, extract_from_source, read_embedded_game_id
 from services.lock_manager import lock_manager
 
 from .base import BaseTool
 from .spec import ModeKind, ModeSpec
+
+logger = get_logger()
+
+# Only CD/DVD images carry a readable disc serial: they hold an ISO 9660
+# filesystem with SYSTEM.CNF (PS1/PS2) or PSP_GAME/PARAM.SFO (PSP), or a
+# Dreamcast IP.BIN. createraw/createhd (hard-disk images) and createld
+# (laserdisc) have no such structure, so disc-ID tagging is scoped to these two.
+_DISC_ID_MODES = frozenset({"createcd", "createdvd"})
 
 _CREATE_MODES = {
     "createraw": "Create Raw",
@@ -148,6 +161,51 @@ class ChdmanTool(BaseTool):
             input_path, output_path, mode,
             compression=compression, cancel_event=cancel_event,
         )
+
+    async def post_convert(
+        self, input_path: str, output_path: str, mode: str,
+    ) -> None:
+        """Embed disc-ID GAME/NAME tags into a freshly created CD/DVD CHD.
+
+        This is the single home for conversion-time disc-ID tagging: a direct
+        ``createcd`` / ``createdvd`` job reaches it via
+        ``job_manager._process_job`` and a ``cso_to_chd`` chain reaches it via
+        ``ChainTool``'s final step, so both paths tag identically.
+
+        Only ``createcd`` / ``createdvd`` carry a disc serial, so every other
+        chdman mode is a no-op. Best-effort: a failure here never fails the job.
+        Idempotent: if the CHD already carries a GAME tag equal to the source's
+        serial the embed is skipped, so re-invoking the hook never appends a
+        duplicate tag.
+
+        ``GAME`` = normalized serial (emulator DB lookup key);
+        ``NAME`` = human-readable title when available, serial otherwise.
+        """
+        if mode not in _DISC_ID_MODES:
+            return
+        if Path(output_path).suffix.lower() != ".chd" or not os.path.exists(output_path):
+            return
+        try:
+            disc_info = await run_in_threadpool(extract_from_source, input_path)
+            if not (disc_info and disc_info.get("game_id")):
+                return
+            game_id = disc_info["game_id"]
+            existing = await read_embedded_game_id(output_path, self.binary_path)
+            if existing == game_id:
+                return
+            title = disc_info.get("title") or game_id
+            embedded = await embed_in_chd(output_path, game_id, title, self.binary_path)
+            if embedded:
+                logger.info(
+                    "Embedded disc ID %r in %s", game_id, Path(output_path).name,
+                )
+            else:
+                logger.debug(
+                    "Failed to embed disc ID %r in %s",
+                    game_id, Path(output_path).name,
+                )
+        except Exception as exc:  # best effort; tagging never fails the job
+            logger.debug("Disc ID embed skipped for %s: %s", output_path, exc)
 
     async def verify(self, path: str) -> dict:
         return await self._service.verify(path)

--- a/app/services/tools/chdman.py
+++ b/app/services/tools/chdman.py
@@ -16,7 +16,12 @@ from fastapi.concurrency import run_in_threadpool
 from logging_setup import get_logger
 from models import CHDInfo, OutputStatus
 from services.chdman import CHDMAN_CONVERTIBLE_EXTENSIONS, chdman_service
-from services.disc_id import embed_in_chd, extract_from_source, read_embedded_game_id
+from services.disc_id import (
+    clear_embedded_disc_id,
+    embed_in_chd,
+    extract_from_source,
+    read_embedded_game_id,
+)
 from services.lock_manager import lock_manager
 
 from .base import BaseTool
@@ -195,6 +200,13 @@ class ChdmanTool(BaseTool):
             existing = await read_embedded_game_id(output_path, self.binary_path)
             if existing == game_id:
                 return
+            if existing is not None:
+                # chdman addmeta appends rather than replaces, so a CHD that
+                # already carries a *different* serial must have the stale
+                # GAME/NAME stripped first — otherwise the old tag persists and
+                # the embed never converges. A freshly created CHD has no tag,
+                # so this is skipped in the normal path.
+                await clear_embedded_disc_id(output_path, self.binary_path)
             title = disc_info.get("title") or game_id
             embedded = await embed_in_chd(output_path, game_id, title, self.binary_path)
             if embedded:

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -205,8 +205,11 @@ class ToolPlugin(Protocol):
 
     def active_pids(self) -> list[int]: ...
 
-    # Optional post-processing hook (chdman uses it to embed disc-ID GAME/NAME
-    # tags after createcd/createdvd, today hardcoded at job_manager.py:1514).
+    # Post-convert hook, run once after a successful conversion. Default no-op
+    # (BaseTool); ChdmanTool overrides it to embed disc-ID GAME/NAME tags into a
+    # freshly created CD/DVD CHD. job_manager calls it generically for every
+    # mode, and ChainTool routes its final step through the same hook, so a
+    # cso_to_chd CHD is tagged exactly like a direct createdvd.
     async def post_convert(self, input_path: str, output_path: str, mode: str) -> None: ...
 ```
 
@@ -785,8 +788,9 @@ at a time. Nothing here changes the wire API until Phase 9 (optional).
   `registry.for_mode(job.mode.value)`.
 - Verify branch (`:1556`, `:1591`) → `plugin.verify(output_path)` uniformly
   (drops the z3ds special-case).
-- Move the disc-ID embed (`:1514`) into `ChdmanTool.post_convert`; job_manager
-  calls `plugin.post_convert(...)` generically.
+- Disc-ID embed now lives in `ChdmanTool.post_convert`; `_process_job` calls
+  `registry.for_mode(mode).post_convert(...)` generically (default no-op) and
+  `ChainTool` routes its final step through the same hook (done, #181).
 - **Tests:** job-pipeline tests (`test_external_job_api.py` neighbors), plus a
   conversion smoke test per tool with the binary stubbed.
 - Risk: medium (hot path). Ship behind close review; the behavior is a 1:1

--- a/tests/test_archive_conversion_e2e.py
+++ b/tests/test_archive_conversion_e2e.py
@@ -20,7 +20,6 @@ up. This is the regression guard for issue #113 across the whole matrix.
 from __future__ import annotations
 
 import os
-import sys
 import zipfile
 from pathlib import Path
 
@@ -80,11 +79,6 @@ def _e2e_env(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(convert_routes.settings, "temp_dir", str(tmp_path / "temp"))
     monkeypatch.setattr(convert_routes.settings, "max_queue_depth", 0)
 
-    # createcd/createdvd would try to read a disc serial off the (junk) source;
-    # short-circuit it so the test stays deterministic and offline.
-    jm_mod = sys.modules[type(convert_routes.job_manager).__module__]
-    monkeypatch.setattr(jm_mod, "disc_id_from_source", lambda *a, **k: None)
-
     calls: list[dict] = []
 
     async def fake_convert(input_path, output_path, mode, *, compression=None,
@@ -105,9 +99,16 @@ def _e2e_env(tmp_path: Path, monkeypatch):
         yield {"progress": 50, "message": "working"}
         yield {"progress": 100, "message": "done"}
 
+    async def noop_post_convert(input_path, output_path, mode):
+        # createcd/createdvd would otherwise read a disc serial off the (junk)
+        # source via ChdmanTool.post_convert; stub the hook so the test stays
+        # deterministic and offline.
+        return None
+
     # registry is the shared singleton job_manager dispatches through.
     for tool in convert_routes.registry.all():
         monkeypatch.setattr(tool, "convert", fake_convert)
+        monkeypatch.setattr(tool, "post_convert", noop_post_convert)
 
     return {"tmp_path": tmp_path, "calls": calls}
 

--- a/tests/test_chain_service.py
+++ b/tests/test_chain_service.py
@@ -128,7 +128,7 @@ def test_chain_tags_final_chd_via_post_convert(chain_env, tmp_path, monkeypatch)
     """The chain drives the final step's ``post_convert`` with the intermediate
     source and the final CHD — the same disc-ID path a direct ``createdvd`` job
     takes. This is what replaces the old bespoke ``_embed_disc_id`` (#181)."""
-    calls, work, install = chain_env
+    _calls, work, install = chain_env
     install()
 
     seen: list[tuple[str, str, str]] = []

--- a/tests/test_chain_service.py
+++ b/tests/test_chain_service.py
@@ -41,8 +41,17 @@ def chain_env(monkeypatch, tmp_path):
         return str(work)
 
     monkeypatch.setattr(chain_mod, "create_scratch_dir", _scratch)
-    # No real disc parsing/tagging: keep the embed a no-op.
-    monkeypatch.setattr(chain_mod, "extract_from_source", lambda p: None)
+
+    # The chain tags the final CHD by routing its last step through chdman's
+    # post_convert hook. Keep it a no-op here so the orchestration assertions
+    # don't depend on real disc parsing; the dedicated test below installs its
+    # own spy to assert how the hook is invoked.
+    async def _noop_post_convert(input_path, output_path, mode):
+        return None
+
+    monkeypatch.setattr(
+        registry.get("chdman"), "post_convert", _noop_post_convert,
+    )
 
     calls: list[dict] = []
 
@@ -113,6 +122,38 @@ def test_chain_orchestration_progress_and_intermediate(chain_env, tmp_path):
     # Final output produced; intermediate + work dir cleaned up.
     assert out.exists()
     assert not work.exists()
+
+
+def test_chain_tags_final_chd_via_post_convert(chain_env, tmp_path, monkeypatch):
+    """The chain drives the final step's ``post_convert`` with the intermediate
+    source and the final CHD — the same disc-ID path a direct ``createdvd`` job
+    takes. This is what replaces the old bespoke ``_embed_disc_id`` (#181)."""
+    calls, work, install = chain_env
+    install()
+
+    seen: list[tuple[str, str, str]] = []
+
+    async def _spy(input_path, output_path, mode):
+        seen.append((input_path, output_path, mode))
+
+    monkeypatch.setattr(registry.get("chdman"), "post_convert", _spy)
+
+    src = tmp_path / "Game.cso"
+    src.write_bytes(b"x" * 1000)
+    out = tmp_path / "Game.chd"
+
+    _drain(
+        registry.for_mode("cso_to_chd").convert(str(src), str(out), "cso_to_chd")
+    )
+
+    # Exactly one post_convert call, for the final chdman step.
+    assert len(seen) == 1
+    in_path, out_path, mode = seen[0]
+    assert mode == "createdvd"
+    assert out_path == str(out)
+    # Tagged from the intermediate .iso in the work dir, not the original .cso.
+    assert in_path.endswith(".iso")
+    assert os.path.dirname(in_path) == str(work)
 
 
 def test_chain_propagates_cancel_and_cleans_up(chain_env, tmp_path):

--- a/tests/test_disc_id.py
+++ b/tests/test_disc_id.py
@@ -34,10 +34,12 @@ from app.services.disc_id import (
     _parse_ipbin,
     _parse_param_sfo,
     _parse_system_cnf,
+    clear_embedded_disc_id,
     embed_in_chd,
     ensure_disc_id_embedded,
     extract_from_chd,
     extract_from_source,
+    read_embedded_game_id,
 )
 
 # ---------------------------------------------------------------------------
@@ -975,6 +977,52 @@ async def test_embed_in_chd_addmeta_failure():
         ok = await embed_in_chd("/fake/game.chd", "SLUS_20312", None, "chdman")
 
     assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# read_embedded_game_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_embedded_game_id_returns_trimmed_serial():
+    async def fake_dump(chd_path, tag, chdman_path):
+        assert tag == TAG_GAME
+        return "  SLUS-20312\n"
+
+    with patch("app.services.disc_id._dumpmeta_text", side_effect=fake_dump):
+        result = await read_embedded_game_id("/fake/game.chd", "chdman")
+
+    assert result == "SLUS-20312"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw", [None, "", "   \n"])
+async def test_read_embedded_game_id_none_when_absent_or_blank(raw):
+    async def fake_dump(chd_path, tag, chdman_path):
+        return raw
+
+    with patch("app.services.disc_id._dumpmeta_text", side_effect=fake_dump):
+        assert await read_embedded_game_id("/fake/game.chd", "chdman") is None
+
+
+# ---------------------------------------------------------------------------
+# clear_embedded_disc_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_clear_embedded_disc_id_deletes_game_and_name():
+    deleted: list[str] = []
+
+    async def fake_delmeta(chd_path, tag, chdman_path):
+        deleted.append(tag)
+        return True
+
+    with patch("app.services.disc_id._delmeta", side_effect=fake_delmeta):
+        await clear_embedded_disc_id("/fake/game.chd", "chdman")
+
+    # Both GAME and NAME are stripped so a later addmeta converges on a single
+    # current pair instead of appending to a stale one (chdman addmeta appends).
+    assert deleted == [TAG_GAME, TAG_NAME]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_post_convert_181.py
+++ b/tests/test_post_convert_181.py
@@ -1,0 +1,199 @@
+"""Tests for the unified ``post_convert`` disc-ID embed seam (#181).
+
+``ChdmanTool.post_convert`` is now the single home for conversion-time disc-ID
+tagging. A direct ``createcd`` / ``createdvd`` job reaches it through
+``job_manager._process_job`` (``registry.for_mode(mode).post_convert(...)``) and
+a ``cso_to_chd`` chain reaches it through ``ChainTool``'s final step, replacing
+the two copy-pasted embed blocks that used to live in those call sites.
+
+These tests exercise the hook directly (the real chdman CLI / disc parsing can't
+run here, so ``extract_from_source`` / ``read_embedded_game_id`` / ``embed_in_chd``
+are monkeypatched). The chain's *routing* into the hook is asserted separately in
+``test_chain_service.py::test_chain_tags_final_chd_via_post_convert``.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import app.services.tools.chdman as chdman_mod
+from app.services.tools import registry
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def chd_out(tmp_path):
+    """A stand-in output CHD on disk (presence is all post_convert checks)."""
+    out = tmp_path / "Game.chd"
+    out.write_bytes(b"MComprHD")
+    return out
+
+
+@pytest.fixture
+def patch_embed(monkeypatch):
+    """Install recording stubs for the three disc_id helpers post_convert uses.
+
+    Returns ``(set_source, set_existing, embedded)`` where ``embedded`` is a
+    list each successful ``embed_in_chd`` appends ``(path, game_id, title)`` to.
+    """
+    state: dict = {"source": None, "existing": None}
+    embedded: list[tuple] = []
+
+    def _extract(path):  # sync: called via run_in_threadpool
+        return state["source"]
+
+    async def _read_existing(path, chdman_path):
+        return state["existing"]
+
+    async def _embed(path, game_id, title, chdman_path):
+        embedded.append((path, game_id, title))
+        return True
+
+    monkeypatch.setattr(chdman_mod, "extract_from_source", _extract)
+    monkeypatch.setattr(chdman_mod, "read_embedded_game_id", _read_existing)
+    monkeypatch.setattr(chdman_mod, "embed_in_chd", _embed)
+
+    def set_source(info):
+        state["source"] = info
+
+    def set_existing(game_id):
+        state["existing"] = game_id
+
+    return set_source, set_existing, embedded
+
+
+@pytest.mark.parametrize("mode", ["createcd", "createdvd"])
+def test_post_convert_embeds_disc_id_for_disc_modes(
+    mode, tmp_path, chd_out, patch_embed,
+):
+    set_source, _set_existing, embedded = patch_embed
+    set_source({"game_id": "SLUS-20312", "title": "Demo Disc"})
+
+    src = tmp_path / "Game.iso"
+    src.write_bytes(b"x")
+    _run(registry.get("chdman").post_convert(str(src), str(chd_out), mode))
+
+    assert embedded == [(str(chd_out), "SLUS-20312", "Demo Disc")]
+
+
+def test_post_convert_falls_back_to_serial_as_title(tmp_path, chd_out, patch_embed):
+    set_source, _set_existing, embedded = patch_embed
+    set_source({"game_id": "SLUS-20312"})  # no title key
+
+    src = tmp_path / "Game.iso"
+    src.write_bytes(b"x")
+    _run(registry.get("chdman").post_convert(str(src), str(chd_out), "createdvd"))
+
+    # NAME falls back to the serial when no human title is available.
+    assert embedded == [(str(chd_out), "SLUS-20312", "SLUS-20312")]
+
+
+@pytest.mark.parametrize(
+    "mode", ["createraw", "createhd", "createld", "extractcd", "extractdvd", "copy"],
+)
+def test_post_convert_noop_for_non_disc_modes(
+    mode, tmp_path, chd_out, patch_embed, monkeypatch,
+):
+    set_source, _set_existing, embedded = patch_embed
+    set_source({"game_id": "SLUS-20312"})
+
+    extracted: list[str] = []
+    real_extract = chdman_mod.extract_from_source
+    monkeypatch.setattr(
+        chdman_mod, "extract_from_source",
+        lambda p: extracted.append(p) or real_extract(p),
+    )
+
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"x")
+    _run(registry.get("chdman").post_convert(str(src), str(chd_out), mode))
+
+    # Non-CD/DVD modes carry no disc serial: the source is never even read.
+    assert extracted == []
+    assert embedded == []
+
+
+def test_post_convert_noop_when_source_has_no_disc_id(tmp_path, chd_out, patch_embed):
+    set_source, _set_existing, embedded = patch_embed
+    set_source(None)  # extract_from_source found nothing
+
+    src = tmp_path / "Game.iso"
+    src.write_bytes(b"x")
+    _run(registry.get("chdman").post_convert(str(src), str(chd_out), "createdvd"))
+
+    assert embedded == []
+
+
+def test_post_convert_idempotent_skips_matching_tag(tmp_path, chd_out, patch_embed):
+    set_source, set_existing, embedded = patch_embed
+    set_source({"game_id": "SLUS-20312", "title": "Demo"})
+    set_existing("SLUS-20312")  # CHD already carries this exact serial
+
+    src = tmp_path / "Game.iso"
+    src.write_bytes(b"x")
+    _run(registry.get("chdman").post_convert(str(src), str(chd_out), "createdvd"))
+
+    # Idempotent: no duplicate GAME tag appended.
+    assert embedded == []
+
+
+def test_post_convert_reembeds_when_tag_differs(tmp_path, chd_out, patch_embed):
+    set_source, set_existing, embedded = patch_embed
+    set_source({"game_id": "SLUS-20312", "title": "Demo"})
+    set_existing("SLES-00000")  # stale / wrong serial -> overwrite
+
+    src = tmp_path / "Game.iso"
+    src.write_bytes(b"x")
+    _run(registry.get("chdman").post_convert(str(src), str(chd_out), "createdvd"))
+
+    assert embedded == [(str(chd_out), "SLUS-20312", "Demo")]
+
+
+def test_post_convert_missing_output_is_noop(tmp_path, patch_embed):
+    set_source, _set_existing, embedded = patch_embed
+    set_source({"game_id": "SLUS-20312"})
+
+    src = tmp_path / "Game.iso"
+    src.write_bytes(b"x")
+    missing = tmp_path / "missing.chd"  # never created
+    _run(registry.get("chdman").post_convert(str(src), str(missing), "createdvd"))
+
+    assert embedded == []
+
+
+def test_post_convert_swallows_embed_errors(tmp_path, chd_out, monkeypatch):
+    """Tagging is best-effort: a failure in any helper never fails the job."""
+    monkeypatch.setattr(
+        chdman_mod, "extract_from_source",
+        lambda p: {"game_id": "SLUS-20312"},
+    )
+
+    async def _boom(path, chdman_path):
+        raise RuntimeError("chdman dumpmeta blew up")
+
+    monkeypatch.setattr(chdman_mod, "read_embedded_game_id", _boom)
+
+    src = tmp_path / "Game.iso"
+    src.write_bytes(b"x")
+    # Must not raise.
+    _run(registry.get("chdman").post_convert(str(src), str(chd_out), "createdvd"))
+
+
+def test_chain_tool_post_convert_is_noop(tmp_path):
+    """ChainTool inherits the BaseTool no-op: when job_manager calls
+    post_convert for a chain mode, it does nothing (the chain already tagged its
+    output via the final step during the conversion itself)."""
+    out = tmp_path / "Game.chd"
+    out.write_bytes(b"MComprHD")
+    src = tmp_path / "Game.cso"
+    src.write_bytes(b"x")
+    # No exception, returns None.
+    assert _run(
+        registry.for_mode("cso_to_chd").post_convert(
+            str(src), str(out), "cso_to_chd",
+        )
+    ) is None

--- a/tests/test_post_convert_181.py
+++ b/tests/test_post_convert_181.py
@@ -141,16 +141,59 @@ def test_post_convert_idempotent_skips_matching_tag(tmp_path, chd_out, patch_emb
     assert embedded == []
 
 
-def test_post_convert_reembeds_when_tag_differs(tmp_path, chd_out, patch_embed):
-    set_source, set_existing, embedded = patch_embed
+def test_post_convert_reembeds_when_tag_differs(
+    tmp_path, chd_out, patch_embed, monkeypatch,
+):
+    set_source, set_existing, _embedded = patch_embed
     set_source({"game_id": "SLUS-20312", "title": "Demo"})
-    set_existing("SLES-00000")  # stale / wrong serial -> overwrite
+    set_existing("SLES-00000")  # stale / wrong serial already on the CHD
+
+    order: list[tuple] = []
+
+    async def _clear(path, chdman_path):
+        order.append(("clear", path))
+
+    async def _embed(path, game_id, title, chdman_path):
+        order.append(("embed", path, game_id, title))
+        return True
+
+    monkeypatch.setattr(chdman_mod, "clear_embedded_disc_id", _clear)
+    monkeypatch.setattr(chdman_mod, "embed_in_chd", _embed)
 
     src = tmp_path / "Game.iso"
     src.write_bytes(b"x")
     _run(registry.get("chdman").post_convert(str(src), str(chd_out), "createdvd"))
 
-    assert embedded == [(str(chd_out), "SLUS-20312", "Demo")]
+    # chdman addmeta appends, so the stale GAME/NAME is stripped *before* the new
+    # pair is written — otherwise the old serial persists and the embed never
+    # converges (it would just accumulate duplicate GAME tags).
+    assert order == [
+        ("clear", str(chd_out)),
+        ("embed", str(chd_out), "SLUS-20312", "Demo"),
+    ]
+
+
+def test_post_convert_fresh_chd_does_not_clear(
+    tmp_path, chd_out, patch_embed, monkeypatch,
+):
+    set_source, set_existing, embedded = patch_embed
+    set_source({"game_id": "SLUS-20312"})
+    set_existing(None)  # freshly created CHD: no prior tag
+
+    cleared: list[str] = []
+
+    async def _clear(path, chdman_path):
+        cleared.append(path)
+
+    monkeypatch.setattr(chdman_mod, "clear_embedded_disc_id", _clear)
+
+    src = tmp_path / "Game.iso"
+    src.write_bytes(b"x")
+    _run(registry.get("chdman").post_convert(str(src), str(chd_out), "createdvd"))
+
+    # The common path (no existing tag) pays no delmeta cost.
+    assert cleared == []
+    assert embedded == [(str(chd_out), "SLUS-20312", "SLUS-20312")]
 
 
 def test_post_convert_missing_output_is_noop(tmp_path, patch_embed):


### PR DESCRIPTION
Closes #181.

## Problem

The disc-ID `GAME`/`NAME` embed lived in **two near-identical copies**, and the
`post_convert` hook on the tool contract was defined but never called:

- `job_manager._process_job` embedded it behind a hardcoded
  `job.mode.value in {"createcd","createdvd"}` check (importing
  `disc_id.extract_from_source` / `embed_in_chd` directly).
- `ChainTool._embed_disc_id` re-implemented the same extract → embed dance for
  the `cso_to_chd` pipeline.

That is exactly the kind of tool-identity branch + copy-paste the plugin
contract's `post_convert` seam exists to remove.

## Fix

- **`ChdmanTool.post_convert(input_path, output_path, mode)`** is now the single
  home for conversion-time disc-ID tagging. It is scoped to `createcd` /
  `createdvd` (raw/hd/ld images carry no ISO 9660 serial → no-op) and is
  **idempotent**: it skips the embed when the CHD already carries a `GAME` tag
  equal to the source's serial, so re-invoking the hook never appends a
  duplicate tag. Tagging stays best-effort — a failure never fails the job.
- **`job_manager._process_job`** calls
  `registry.for_mode(job.mode.value).post_convert(...)` **unconditionally** after
  a successful convert (default `BaseTool.post_convert` is a no-op, so this is
  safe for every mode). It no longer references `disc_id_embed`,
  `extract_from_source`, or the `{"createcd","createdvd"}` set.
- **`ChainTool`**'s final step routes through the same `post_convert` hook (while
  the intermediate `.iso` still exists, before the work dir is cleaned up), so a
  `cso_to_chd` CHD is tagged exactly like a direct `createdvd`.
  `ChainTool._embed_disc_id` and its now-dead `chdman_path` constructor
  dependency are removed.
- Adds **`disc_id.read_embedded_game_id`** — reads only our embedded `GAME` tag
  (no disc-sector / companion-file fallback) for the cheap idempotency check.

No wire-API change: mode strings, endpoints, and JSON shapes are untouched; the
same CHDs get tagged with the same `GAME`/`NAME` values.

## Acceptance

- `job_manager` no longer references `disc_id_embed` or `{"createcd","createdvd"}`
  (greppable — confirmed clean).
- A `createcd`/`createdvd` job **and** a `cso_to_chd` chain both produce a tagged
  `.chd` via the single `ChdmanTool.post_convert` path.

## Tests

- **`tests/test_post_convert_181.py`** (new): embeds for `createcd`/`createdvd`;
  no-op for non-disc modes / missing output / no source disc-ID; idempotent skip
  when the tag already matches; re-embed when it differs; serial-as-title
  fallback; best-effort error swallowing; `ChainTool.post_convert` is a no-op.
- **`tests/test_chain_service.py`**: asserts the chain routes the intermediate
  `.iso` (not the original `.cso`) through the final step's `post_convert` with
  `mode == "createdvd"`. Fixture now stubs `post_convert` instead of the removed
  `chain_mod.extract_from_source`.
- **`tests/test_archive_conversion_e2e.py`**: fixture stubs each tool's
  `post_convert` (instead of the removed `job_manager.disc_id_from_source`) to
  keep create jobs offline. Per-test pass/fail set is **identical to the base**
  (the 27 pre-existing failures are environmental — missing conversion binaries).

`PYTHONPATH=app python -m pytest -q` → 1007 passed, 1 skipped (e2e binaries
aside). `ruff check .` → clean.

## Docs

`docs/DESIGN_tool_plugin_architecture.md`: the `post_convert` contract note now
documents the live wiring (chdman override + generic `job_manager` call + chain
routing) instead of describing it as hardcoded/pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic disc ID metadata embedding for CHD files after CD/DVD creation conversions.

* **Improvements**
  * Disc metadata tagging is now idempotent—existing tags are detected and skipped to prevent duplication.
  * Chained conversions (e.g., CSO to CHD) now properly embed metadata in the final output.

* **Documentation**
  * Updated tool-plugin architecture documentation to describe the new post-conversion hook pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes subprocess and job bookkeeping paths. The main changes are:

- Added shared size-based progress handling, environment forwarding, and output checks in `SubprocessRunner`.
- Routed maxcso, nsz, and z3ds conversions through the shared runner.
- Added fresh CHD metadata snapshot reads before using cached embedded hashes.
- Centralized completed-job output size calculation in `job_manager`.
- Updated optimistic job placeholder handling in the Svelte jobs store.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changes look safe to merge based on the reviewed conversion, metadata, and job bookkeeping paths.

The implementation is cohesive, covered by targeted tests, and no actionable correctness or security issues were identified in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Inspected post-convert validation logs to compare the baseline (.trex-base) and head (.trex-head) runs, confirming post\_convert\_called changed from False to True and append\_count became 1, with second\_invocation\_skipped activated.
- Inspected chain-post-convert validation logs to verify changes from baseline to head, confirming post\_convert\_count increased to 1, bespoke\_embed\_count dropped to 0, and cleanup occurred after processing (work\_exists turned false).

<a href="https://app.greptile.com/trex/runs/12158901/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/lat..."](https://github.com/pacnpal/compressatorium/commit/164df9d7fcd72bf98dc728b946bde88a33784a49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39378774)</sub>

<!-- /greptile_comment -->