### PR TITLE
Model companion/sidecar outputs on the plugin contract

### DIFF
--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -137,91 +137,55 @@ def _reject_rename_in_locked_dir(base_path: str) -> None:
         raise SkipFile(SkipReason.OUTPUT_LOCKED)
 
 
-def get_unique_output_path(base_path: str) -> str:
-    """Generate a unique output path by appending a number if the file exists."""
-    file_exists, is_locked = lock_manager.check_file_status(base_path)
-    if not file_exists and not is_locked:
-        return base_path
+def check_output_conflicts(mode: str, output_path: str) -> tuple:
+    """``(exists, locked)`` for an output path *and all of its companion outputs*.
 
-    _reject_rename_in_locked_dir(base_path)
-
-    path = Path(base_path)
-    stem = path.stem
-    suffix = path.suffix
-    parent = path.parent
-
-    counter = 1
-    while True:
-        new_path = parent / f"{stem}_{counter}{suffix}"
-        file_exists, is_locked = lock_manager.check_file_status(str(new_path))
-        if not file_exists and not is_locked:
-            return str(new_path)
-        counter += 1
-
-
-def _ps3_iso_output_taken(output_path: str) -> bool:
-    """Whether a PS3 ISO output path is occupied by a single file, a held lock,
-    *or* a prior split set (``<output>.iso.0``).
-
-    A ``-s`` build only writes ``<output>.iso.0``/``.1``/… (no plain
-    ``<output>.iso``) once it crosses 4 GB, so the bare-path check the other
-    tools use would miss it and silently clobber the set.
+    Companions (extractcd's ``.bin`` data-track sidecar, a split ``folder_to_iso``
+    build's numbered ``.iso.0``/``.1``/… parts) are enumerated from the owning
+    tool's ``companion_outputs`` hook rather than re-derived here, so every
+    duplicate/lock preflight agrees on the full set of files a mode occupies.
+    Touches the disk (a directory mode's companion lookup scans), so call it off
+    the event loop for ``folder_to_iso``.
     """
     file_exists, is_locked = lock_manager.check_file_status(output_path)
-    return file_exists or is_locked or os.path.exists(output_path + ".0")
+    exists = file_exists or is_locked
+    locked = is_locked
+    for companion in registry.for_mode(mode).companion_outputs(output_path, mode):
+        c_exists, c_locked = lock_manager.check_file_status(companion)
+        exists = exists or c_exists or c_locked
+        locked = locked or c_locked
+    return exists, locked
 
 
-def get_unique_ps3_iso_output_path(base_path: str) -> str:
-    """:func:`get_unique_output_path` that also steps past an existing split set."""
-    if not _ps3_iso_output_taken(base_path):
+def get_unique_output_path(base_path: str, mode: str | None = None) -> str:
+    """Unique output path, appending ``_N`` until the file — and, when ``mode``
+    is supplied, that mode's companion outputs — are all free.
+
+    ``mode=None`` checks the bare path only (the plain single-file case). A mode
+    routes the probe through :func:`check_output_conflicts`, so a sibling output
+    (extractcd's ``.bin``, a split ``folder_to_iso``'s numbered parts) can't be
+    silently clobbered by a rename. This subsumes the former per-mode
+    ``get_unique_*`` helpers — one companion-aware probe for every mode.
+    """
+    def _taken(candidate: str) -> bool:
+        if mode is None:
+            file_exists, is_locked = lock_manager.check_file_status(candidate)
+            return file_exists or is_locked
+        exists, _locked = check_output_conflicts(mode, candidate)
+        return exists
+
+    if not _taken(base_path):
         return base_path
+
     _reject_rename_in_locked_dir(base_path)
+
     path = Path(base_path)
     stem, suffix, parent = path.stem, path.suffix, path.parent
     counter = 1
     while True:
         candidate = str(parent / f"{stem}_{counter}{suffix}")
-        if not _ps3_iso_output_taken(candidate):
+        if not _taken(candidate):
             return candidate
-        counter += 1
-
-
-def check_output_conflicts(mode: str, output_path: str) -> tuple:
-    file_exists, is_locked = lock_manager.check_file_status(output_path)
-    exists = file_exists or is_locked
-    locked = is_locked
-
-    if mode == "extractcd":
-        bin_path = str(Path(output_path).with_suffix(".bin"))
-        bin_exists, bin_locked = lock_manager.check_file_status(bin_path)
-        exists = exists or bin_exists or bin_locked
-        locked = locked or bin_locked
-    elif mode == "folder_to_iso":
-        # A prior makeps3iso ``-s`` build over 4 GB leaves ``<output>.iso.0``
-        # (and ``.1``/…) with no plain ``<output>.iso``, so the bare-path check
-        # above would miss it. Probe the ``.0`` part so the duplicate preflight
-        # (/jobs/check-duplicates) and plan agree a split set already occupies
-        # the target.
-        if os.path.exists(output_path + ".0"):
-            exists = True
-
-    return exists, locked
-
-
-def get_unique_output_path_for_extractcd(base_path: str) -> str:
-    _reject_rename_in_locked_dir(base_path)
-    path = Path(base_path)
-    stem = path.stem
-    suffix = path.suffix or ".cue"
-    parent = path.parent
-
-    counter = 1
-    candidate = str(path)
-    while True:
-        exists, locked = check_output_conflicts("extractcd", candidate)
-        if not exists and not locked:
-            return candidate
-        candidate = str(parent / f"{stem}_{counter}{suffix}")
         counter += 1
 
 
@@ -443,8 +407,10 @@ async def _plan_directory_job(
             if is_locked:
                 raise SkipFile(SkipReason.OUTPUT_LOCKED)
         elif duplicate_action == DuplicateAction.RENAME:
+            # Companion-aware (steps past a split set's numbered parts); off the
+            # event loop because folder_to_iso's companion lookup scans the dir.
             output_path = await run_in_threadpool(
-                get_unique_ps3_iso_output_path, output_path,
+                get_unique_output_path, output_path, mode,
             )
 
     allow_overwrite = (
@@ -540,10 +506,7 @@ async def plan_job(
                 if is_locked:
                     raise SkipFile(SkipReason.OUTPUT_LOCKED)
             elif duplicate_action == DuplicateAction.RENAME:
-                if mode == "extractcd":
-                    output_path = get_unique_output_path_for_extractcd(output_path)
-                else:
-                    output_path = get_unique_output_path(output_path)
+                output_path = get_unique_output_path(output_path, mode)
 
     if "::" not in file_path and not os.path.isfile(file_path):
         raise SkipFile(SkipReason.FILE_NOT_FOUND)
@@ -635,10 +598,7 @@ async def plan_job(
                 if is_locked:
                     raise SkipFile(SkipReason.OUTPUT_LOCKED)
             elif duplicate_action == DuplicateAction.RENAME:
-                if mode == "extractcd":
-                    output_path = get_unique_output_path_for_extractcd(output_path)
-                else:
-                    output_path = get_unique_output_path(output_path)
+                output_path = get_unique_output_path(output_path, mode)
 
     if (
         is_dolphin

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -396,10 +396,13 @@ async def _plan_directory_job(
     ):
         raise SkipFile(SkipReason.PS3_OUTPUT_OUTSIDE_VOLUMES)
 
-    # check_output_conflicts is split-set aware for folder_to_iso (it probes the
-    # .0 part), so a prior split build counts as an existing output here and in
-    # the /jobs/check-duplicates preflight alike.
-    output_exists, is_locked = check_output_conflicts(mode, output_path)
+    # check_output_conflicts is split-set aware for folder_to_iso (its
+    # companion_outputs scans for numbered parts), so a prior split build counts
+    # as an existing output here and in the /jobs/check-duplicates preflight
+    # alike. Off the event loop because that companion lookup hits the disk.
+    output_exists, is_locked = await run_in_threadpool(
+        check_output_conflicts, mode, output_path,
+    )
     if output_exists or is_locked:
         if duplicate_action == DuplicateAction.SKIP:
             raise SkipFile(SkipReason.OUTPUT_EXISTS)
@@ -679,7 +682,9 @@ async def check_duplicates(request: CheckDuplicatesRequest):
             output_path = await run_in_threadpool(
                 _get_output_path, mode, actual_filename, effective_output_dir,
             )
-        exists, _ = check_output_conflicts(mode, output_path)
+        exists, _ = await run_in_threadpool(
+            check_output_conflicts, mode, output_path,
+        )
 
         results.append(
             DuplicateInfo(file_path=file_path, output_path=output_path, exists=exists),

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -680,14 +680,17 @@ class JobManager:
         if job.output_path:
             paths.append(job.output_path)
             # Companion outputs a mode writes beside its primary (extractcd's
-            # .bin). makeps3iso's split parts are queue-time-unknown and tracked
-            # by _split_output_blocks' prefix match instead, so this stays empty
-            # for it until the parts exist.
-            paths.extend(
-                registry.for_mode(job.mode.value).companion_outputs(
-                    job.output_path, job.mode.value,
+            # .bin). Directory modes are skipped: makeps3iso's split parts are
+            # queue-time-unknown, disk-probed (companion_outputs scans the dir),
+            # and already covered by _split_output_blocks' I/O-free prefix match —
+            # so this stays a pure, event-loop-safe lookup (this helper is called
+            # synchronously from async route code).
+            if job.input_kind != InputKind.DIRECTORY:
+                paths.extend(
+                    registry.for_mode(job.mode.value).companion_outputs(
+                        job.output_path, job.mode.value,
+                    )
                 )
-            )
         return paths
 
     def find_active_job_for_path(
@@ -793,14 +796,17 @@ class JobManager:
             )
             await verification_store.clear(job.output_path)
             return
-        if not os.path.exists(job.output_path):
-            return
-        if not os.path.isfile(job.output_path):
-            raise RuntimeError("Output path exists and is not a file")
-        os.remove(job.output_path)
-        await verification_store.clear(job.output_path)
-        # Clear any companion outputs the mode wrote beside the primary
-        # (extractcd's .bin), enumerated from the tool rather than re-derived.
+        # Clear the primary output if present (rejecting a non-file occupant),
+        # then every companion the mode wrote beside it — enumerated from the
+        # tool, not re-derived. Companions are cleared even when the primary is
+        # already gone: a lone companion (e.g. a stray extractcd .bin whose .cue
+        # was deleted) is what made check_output_conflicts authorize the
+        # overwrite, so it must not be left to collide with the new output.
+        if os.path.exists(job.output_path):
+            if not os.path.isfile(job.output_path):
+                raise RuntimeError("Output path exists and is not a file")
+            os.remove(job.output_path)
+            await verification_store.clear(job.output_path)
         for companion in registry.for_mode(job.mode.value).companion_outputs(
             job.output_path, job.mode.value,
         ):

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1769,7 +1769,10 @@ class JobManager:
                 # build leaves no bare .iso, so the primary getsize simply misses
                 # and the numbered parts carry the whole total.
                 total_size = 0
-                companions = registry.for_mode(job.mode.value).companion_outputs(
+                # Off the event loop: a split folder_to_iso's companion lookup
+                # scans the output dir for numbered parts.
+                companions = await run_in_threadpool(
+                    registry.for_mode(job.mode.value).companion_outputs,
                     job.output_path, job.mode.value,
                 )
                 for path in [job.output_path, *companions]:

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -679,8 +679,15 @@ class JobManager:
             paths.extend(self._track_candidate_paths(file_path))
         if job.output_path:
             paths.append(job.output_path)
-            if job.mode == ConversionMode.EXTRACTCD:
-                paths.append(str(Path(job.output_path).with_suffix(".bin")))
+            # Companion outputs a mode writes beside its primary (extractcd's
+            # .bin). makeps3iso's split parts are queue-time-unknown and tracked
+            # by _split_output_blocks' prefix match instead, so this stays empty
+            # for it until the parts exist.
+            paths.extend(
+                registry.for_mode(job.mode.value).companion_outputs(
+                    job.output_path, job.mode.value,
+                )
+            )
         return paths
 
     def find_active_job_for_path(
@@ -792,10 +799,13 @@ class JobManager:
             raise RuntimeError("Output path exists and is not a file")
         os.remove(job.output_path)
         await verification_store.clear(job.output_path)
-        if job.mode.value == "extractcd":
-            bin_path = str(Path(job.output_path).with_suffix(".bin"))
-            if os.path.isfile(bin_path):
-                os.remove(bin_path)
+        # Clear any companion outputs the mode wrote beside the primary
+        # (extractcd's .bin), enumerated from the tool rather than re-derived.
+        for companion in registry.for_mode(job.mode.value).companion_outputs(
+            job.output_path, job.mode.value,
+        ):
+            if os.path.isfile(companion):
+                os.remove(companion)
 
     def _get_queued_and_processing_jobs(self) -> tuple[list[str], list[str]]:
         """Get lists of queued and processing job IDs.
@@ -1595,12 +1605,14 @@ class JobManager:
         # clears it in _clear_existing_output.)
         if job.input_kind == InputKind.DIRECTORY and not job.allow_overwrite:
             existing_parts = await run_in_threadpool(
-                makeps3iso_service.split_parts, job.output_path,
+                registry.for_mode(job.mode.value).companion_outputs,
+                job.output_path, job.mode.value,
             )
-            # split_parts returns [base] only when the bare file exists (already
-            # rejected by acquire_lock above); a real split set is the numbered
-            # parts, so treat that as an output collision.
-            if existing_parts and existing_parts != [job.output_path]:
+            # companion_outputs returns the numbered split parts only when a real
+            # -s split set exists (a bare .iso is the primary, not a companion,
+            # and is already rejected by acquire_lock above), so any companions
+            # mean a prior split build already occupies the target.
+            if existing_parts:
                 job.status = JobStatus.FAILED
                 job.error_message = "Output file already exists"
                 job.completed_at = datetime.now(timezone.utc)
@@ -1751,36 +1763,21 @@ class JobManager:
                 self._cancelled.discard(job_id)
                 job.progress = 100
 
-                # Get output file size
-                if job.input_kind == InputKind.DIRECTORY:
-                    # makeps3iso may finish as a single .iso OR a split set
-                    # (.0/.1/…) with no bare .iso, so sum whatever was produced
-                    # (split_parts returns [base] or the numbered parts).
-                    total_size = 0
-                    for part in makeps3iso_service.split_parts(job.output_path):
-                        try:
-                            total_size += os.path.getsize(part)
-                        except OSError:
-                            pass
-                    job.output_size = total_size if total_size > 0 else None
-                elif os.path.exists(job.output_path):
-                    if job.mode.value == "extractcd":
-                        cue_size = 0
-                        bin_size = 0
-                        try:
-                            cue_size = os.path.getsize(job.output_path)
-                        except OSError:
-                            pass
-                        try:
-                            bin_path = str(Path(job.output_path).with_suffix(".bin"))
-                            if os.path.exists(bin_path):
-                                bin_size = os.path.getsize(bin_path)
-                        except OSError:
-                            pass
-                        total_size = cue_size + bin_size
-                        job.output_size = total_size if total_size > 0 else None
-                    else:
-                        job.output_size = os.path.getsize(job.output_path)
+                # Output size = the primary plus every companion the mode wrote
+                # (extractcd's .bin, a split folder_to_iso's numbered .0/.1/…),
+                # enumerated from the tool instead of re-encoded per mode. A split
+                # build leaves no bare .iso, so the primary getsize simply misses
+                # and the numbered parts carry the whole total.
+                total_size = 0
+                companions = registry.for_mode(job.mode.value).companion_outputs(
+                    job.output_path, job.mode.value,
+                )
+                for path in [job.output_path, *companions]:
+                    try:
+                        total_size += os.path.getsize(path)
+                    except OSError:
+                        pass
+                job.output_size = total_size if total_size > 0 else None
 
                 # Embed game ID / title into CHD metadata after createcd/createdvd.
                 # Uses the source file (input_path) which is still available at this

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -796,22 +796,31 @@ class JobManager:
             )
             await verification_store.clear(job.output_path)
             return
-        # Clear the primary output if present (rejecting a non-file occupant),
-        # then every companion the mode wrote beside it — enumerated from the
-        # tool, not re-derived. Companions are cleared even when the primary is
-        # already gone: a lone companion (e.g. a stray extractcd .bin whose .cue
-        # was deleted) is what made check_output_conflicts authorize the
-        # overwrite, so it must not be left to collide with the new output.
-        if os.path.exists(job.output_path):
-            if not os.path.isfile(job.output_path):
+        # Clear the primary output and every companion the mode wrote beside it
+        # (enumerated from the tool, not re-derived). Companions are cleared even
+        # when the primary is already gone: a lone companion (e.g. a stray
+        # extractcd .bin whose .cue was deleted) is what made
+        # check_output_conflicts authorize the overwrite, so it must not be left
+        # to collide with the new output. Validate the whole set first — a
+        # non-file occupant (a directory squatting on the primary or a companion
+        # name) can't be unlinked, so reject before removing anything rather than
+        # deleting the primary and then failing against the stray occupant.
+        targets = [
+            job.output_path,
+            *registry.for_mode(job.mode.value).companion_outputs(
+                job.output_path, job.mode.value,
+            ),
+        ]
+        for target in targets:
+            if os.path.exists(target) and not os.path.isfile(target):
                 raise RuntimeError("Output path exists and is not a file")
-            os.remove(job.output_path)
+        primary_removed = False
+        for target in targets:
+            if os.path.isfile(target):
+                os.remove(target)
+                primary_removed = primary_removed or target == job.output_path
+        if primary_removed:
             await verification_store.clear(job.output_path)
-        for companion in registry.for_mode(job.mode.value).companion_outputs(
-            job.output_path, job.mode.value,
-        ):
-            if os.path.isfile(companion):
-                os.remove(companion)
 
     def _get_queued_and_processing_jobs(self) -> tuple[list[str], list[str]]:
         """Get lists of queued and processing job IDs.

--- a/app/services/tools/base.py
+++ b/app/services/tools/base.py
@@ -151,6 +151,16 @@ class ToolPlugin(Protocol):
     ) -> None:
         """Optional post-processing hook after a successful conversion."""
 
+    def companion_outputs(self, output_path: str, mode: str) -> list[str]:
+        """Sibling output paths this mode writes beside ``output_path``.
+
+        A mode that produces more than one file (extractcd's ``.cue`` + ``.bin``
+        sidecar, a split makeps3iso ``.iso.0``/``.1``/…) returns the *extra*
+        paths here so conflict detection, overwrite cleanup, size accounting and
+        in-use tracking enumerate them from one place instead of each re-encoding
+        the per-mode suffix. ``output_path`` itself is never included.
+        """
+
 
 class BaseTool:
     """Shared helpers so concrete tools stay tiny."""
@@ -201,3 +211,13 @@ class BaseTool:
         self, input_path: str, output_path: str, mode: str,
     ) -> None:
         return None
+
+    def companion_outputs(self, output_path: str, mode: str) -> list[str]:
+        # Default: derive the sibling paths from the mode's ``companion_exts``
+        # as suffix swaps off ``output_path`` (e.g. extractcd ``.cue`` -> the
+        # ``.bin`` data track). Pure path math, no disk I/O, returned regardless
+        # of on-disk existence — callers guard existence/lock as needed. Tools
+        # whose companion set is dynamic (makeps3iso's size-dependent split
+        # parts) override this with their own disk-aware probe.
+        exts = self.spec(mode).companion_exts
+        return [str(Path(output_path).with_suffix(ext)) for ext in exts]

--- a/app/services/tools/chdman.py
+++ b/app/services/tools/chdman.py
@@ -24,12 +24,15 @@ _CREATE_MODES = {
     "createdvd": "Create DVD",
     "createld": "Create LD",
 }
+# mode -> (label, primary output ext, companion exts). extractcd is the only
+# multi-file extract: chdman writes the .cue track sheet plus a sibling .bin
+# data track, so its companion set is (".bin",). The rest produce one file.
 _EXTRACT_MODES = {
-    "extractraw": ("Extract Raw", ".raw"),
-    "extracthd": ("Extract HD", ".raw"),
-    "extractcd": ("Extract CD", ".cue"),
-    "extractdvd": ("Extract DVD", ".iso"),
-    "extractld": ("Extract LD", ".avi"),
+    "extractraw": ("Extract Raw", ".raw", ()),
+    "extracthd": ("Extract HD", ".raw", ()),
+    "extractcd": ("Extract CD", ".cue", (".bin",)),
+    "extractdvd": ("Extract DVD", ".iso", ()),
+    "extractld": ("Extract LD", ".avi", ()),
 }
 _CHD = frozenset({".chd"})
 
@@ -65,8 +68,9 @@ def _build_modes() -> list[ModeSpec]:
             # stays off below: recompressing a .chd straight out of an archive
             # is a pointless round trip.)
             allows_archive_input=True,
+            companion_exts=companions,
         )
-        for mode, (label, ext) in _EXTRACT_MODES.items()
+        for mode, (label, ext, companions) in _EXTRACT_MODES.items()
     ]
     modes.append(
         ModeSpec(

--- a/app/services/tools/makeps3iso.py
+++ b/app/services/tools/makeps3iso.py
@@ -110,6 +110,22 @@ class MakePs3IsoTool(BaseTool):
             input_path, output_dir, treat_as_stem=treat_as_stem,
         )
 
+    def companion_outputs(
+        self, output_path: str, mode: str,  # noqa: ARG002 - single-mode tool
+    ) -> list[str]:
+        """The numbered split parts (``<iso>.0``/``.1``/…) beside ``output_path``.
+
+        A makeps3iso ``-s`` build only splits past 4 GB and the part names aren't
+        known until it finishes, so the set is disk-probed via the service's
+        ``split_parts`` (whose ordering is deterministic, a contiguous ``.0``
+        run). Empty for a bare sub-4 GB ``.iso`` — there ``split_parts`` returns
+        just the base, which is the primary output, not a companion.
+        """
+        return [
+            part for part in self._service.split_parts(output_path)
+            if part != output_path
+        ]
+
     def convert(
         self,
         input_path: str,

--- a/app/services/tools/spec.py
+++ b/app/services/tools/spec.py
@@ -37,6 +37,14 @@ class ModeSpec:
     supports_compression_level: bool = False  # dolphin rvz/wia only
     supports_delete_on_verify: bool = False
     allows_archive_input: bool = False         # chdman create modes only
+    # Sibling outputs this mode writes beside its primary output_path, expressed
+    # as suffix swaps off the primary (e.g. extractcd's ``.cue`` -> ``.bin``
+    # data-track sidecar). Read by ``BaseTool.companion_outputs`` so conflict
+    # detection, overwrite cleanup, size accounting and in-use tracking enumerate
+    # companions from one place instead of re-hardcoding the suffix per consumer.
+    # Modes whose companion set is dynamic (makeps3iso's size-dependent split
+    # parts) leave this empty and override ``companion_outputs`` instead.
+    companion_exts: tuple[str, ...] = ()
     # Default keeps every existing mode FILE-based (zero behavior change). A
     # directory mode (folder->iso) overrides to {InputKind.DIRECTORY}.
     input_kinds: frozenset[InputKind] = frozenset({InputKind.FILE})
@@ -81,3 +89,6 @@ class ChainSpec:
     input_kinds: frozenset[InputKind] = field(
         default_factory=lambda: frozenset({InputKind.FILE})
     )
+    # Structural parity with ModeSpec.companion_exts so BaseTool.companion_outputs
+    # works for chain modes too (cso_to_chd's single .chd has no companion).
+    companion_exts: tuple[str, ...] = ()

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -208,6 +208,13 @@ class ToolPlugin(Protocol):
     # Optional post-processing hook (chdman uses it to embed disc-ID GAME/NAME
     # tags after createcd/createdvd, today hardcoded at job_manager.py:1514).
     async def post_convert(self, input_path: str, output_path: str, mode: str) -> None: ...
+
+    # Sibling outputs a multi-file mode writes beside its primary output_path
+    # (extractcd's .cue + .bin data track; a split folder_to_iso's .iso.0/.1/…).
+    # The single source conflict-check, unique-name probing, overwrite-clear,
+    # size-sum and in-use tracking enumerate, instead of each re-encoding the
+    # per-mode suffix. output_path itself is never included.
+    def companion_outputs(self, output_path: str, mode: str) -> list[str]: ...
 ```
 
 `BaseTool(ABC)` provides shared defaults so concrete tools stay tiny:
@@ -246,6 +253,12 @@ class BaseTool:
 
     async def post_convert(self, *a, **k) -> None:
         return None
+
+    # Default: suffix-swap off output_path for each ModeSpec.companion_exts
+    # (extractcd .cue -> .bin). makeps3iso overrides with its disk-probed split
+    # parts; modes with no companion_exts return [].
+    def companion_outputs(self, output_path, mode) -> list[str]:
+        return [str(Path(output_path).with_suffix(e)) for e in self.spec(mode).companion_exts]
 
     # subclasses implement: output_path, convert (via self._runner.run),
     # verify_stream, info, info_model
@@ -516,17 +529,26 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   summed size, `FileEntry.split_parts` = count, no convertible/verify
   affordances — it's a final deliverable, not a source). The recursive *search*
   path only emits convertible sources, so split parts never surface there.
-  Lifecycle completeness across the multi-file model:
-  - **Conflicts:** the split-set probe lives in `check_output_conflicts`
-    (mode `folder_to_iso`), so the `/jobs/check-duplicates` preflight and the
-    plan agree a set occupies the target.
+  Lifecycle completeness across the multi-file model — every site below
+  enumerates the extra files from the `companion_outputs` hook (§ the plugin
+  contract) rather than re-encoding the per-mode suffix, the same single source
+  extractcd's `.cue` + `.bin` flows through:
+  - **Conflicts:** `check_output_conflicts` enumerates the set via the owning
+    tool's `companion_outputs` (no per-mode `mode ==` branch), so the
+    `/jobs/check-duplicates` preflight and the plan agree a set occupies the
+    target; `get_unique_output_path(base, mode)` reuses it to step a rename past
+    the whole set.
   - **Overwrite:** `JobManager._clear_existing_output` removes the prior output
-    (single `.iso` **or** the whole split set, via `makeps3iso_service`'s
-    part-aware `remove_outputs`) **only when `allow_overwrite` was granted** — so
-    a set that appears after planning is never deleted out from under a
-    skip/rename decision (the per-path `acquire_lock` only sees the bare name).
-  - **Completed size:** the completion block sums `split_parts()` for directory
-    jobs, so a split build reports a real `output_size` instead of `None`.
+    (single `.iso` **or** the whole split set) **only when `allow_overwrite` was
+    granted** — so a set that appears after planning is never deleted out from
+    under a skip/rename decision (the per-path `acquire_lock` only sees the bare
+    name). makeps3iso's part-aware `remove_outputs` stays the directory-mode
+    cleanup primitive (it clears a mid-split base + parts that `split_parts`
+    would not), with `companion_outputs` clearing file-mode siblings.
+  - **Completed size:** the completion block sums `output_path` plus
+    `companion_outputs()`, so a split build (whose numbered parts replace the
+    bare `.iso`) and an extractcd `.cue` + `.bin` both report a real
+    `output_size` instead of `None`.
   - **Stall detection:** widened via `SubprocessRunner.run(output_growth_paths=…)`
     to the summed size of the set, so a split build isn't killed as stalled once
     the base is renamed away.

--- a/tests/test_companion_outputs_182.py
+++ b/tests/test_companion_outputs_182.py
@@ -183,3 +183,30 @@ async def test_clear_existing_output_removes_lone_companion(tmp_path):
     await job_manager._clear_existing_output(job)
 
     assert not bin_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_clear_existing_output_rejects_non_file_companion(tmp_path):
+    # A directory squatting on the .bin companion name can't be unlinked, so the
+    # overwrite-clear must reject up front — without removing the primary .cue.
+    from app.services.job_manager import job_manager
+
+    cue = tmp_path / "Game.cue"
+    cue.write_bytes(b"cue")
+    (tmp_path / "Game.bin").mkdir()  # non-file occupant on the companion name
+    job = ConversionJob(
+        id="extractcd-nonfile-companion",
+        file_path=str(tmp_path / "Game.chd"),
+        filename="Game.chd",
+        mode=ConversionMode.EXTRACTCD,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=str(cue),
+        input_kind=InputKind.FILE,
+        allow_overwrite=True,
+    )
+
+    with pytest.raises(RuntimeError):
+        await job_manager._clear_existing_output(job)
+    # Rejected before any unlink: the primary is untouched.
+    assert cue.exists()

--- a/tests/test_companion_outputs_182.py
+++ b/tests/test_companion_outputs_182.py
@@ -1,0 +1,132 @@
+"""Tests for the ``companion_outputs`` plugin hook (#182).
+
+A mode that produces more than one file declares its extra outputs in one place —
+via ``ModeSpec.companion_exts`` (a static suffix swap, e.g. extractcd's ``.bin``)
+or a tool override (makeps3iso's disk-probed split parts) — so every consumer
+(conflict-check, unique-name probing, overwrite-clear, size-sum, in-use tracking)
+enumerates them from the hook instead of re-hardcoding the suffix per site.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models import ConversionJob, ConversionMode, InputKind, JobStatus
+from app.routes import convert as convert_routes
+from app.services.tools import registry
+
+
+# --- extractcd: static .bin sidecar (BaseTool.companion_outputs default) ------
+
+def test_extractcd_companion_is_bin_sidecar():
+    assert registry.for_mode("extractcd").companion_outputs(
+        "/data/Game.cue", "extractcd",
+    ) == ["/data/Game.bin"]
+
+
+def test_extractcd_companion_tracks_renamed_stem():
+    # The .bin companion follows a renamed primary (Game_1.cue -> Game_1.bin),
+    # and is returned regardless of on-disk existence (it's a predicted path).
+    assert registry.for_mode("extractcd").companion_outputs(
+        "/data/Game_1.cue", "extractcd",
+    ) == ["/data/Game_1.bin"]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["extractdvd", "extractraw", "extracthd", "extractld",
+     "createcd", "createdvd", "copy"],
+)
+def test_modes_without_companions_return_empty(mode):
+    assert registry.for_mode(mode).companion_outputs("/data/Game.out", mode) == []
+
+
+def test_cso_to_chd_chain_has_no_companions():
+    # ChainTool uses the BaseTool default; cso_to_chd's single .chd has none.
+    assert registry.for_mode("cso_to_chd").companion_outputs(
+        "/data/Game.chd", "cso_to_chd",
+    ) == []
+
+
+# --- folder_to_iso: disk-probed split parts (MakePs3IsoTool override) ---------
+
+def test_folder_to_iso_no_companions_for_bare_iso(tmp_path):
+    out = tmp_path / "Game.iso"
+    out.write_bytes(b"iso")  # bare sub-4 GB build: the .iso *is* the primary
+    assert registry.for_mode("folder_to_iso").companion_outputs(
+        str(out), "folder_to_iso",
+    ) == []
+
+
+def test_folder_to_iso_companions_are_ordered_numbered_parts(tmp_path):
+    base = tmp_path / "Game.iso"  # a -s split build leaves no bare .iso
+    # Write parts out of order to prove the result is deterministically ordered.
+    (tmp_path / "Game.iso.1").write_bytes(b"p1")
+    (tmp_path / "Game.iso.0").write_bytes(b"p0")
+    (tmp_path / "Game.iso.2").write_bytes(b"p2")
+    assert registry.for_mode("folder_to_iso").companion_outputs(
+        str(base), "folder_to_iso",
+    ) == [
+        str(tmp_path / "Game.iso.0"),
+        str(tmp_path / "Game.iso.1"),
+        str(tmp_path / "Game.iso.2"),
+    ]
+
+
+def test_folder_to_iso_no_companions_before_anything_written(tmp_path):
+    # Queue time: neither the bare .iso nor any part exists yet.
+    base = tmp_path / "Game.iso"
+    assert registry.for_mode("folder_to_iso").companion_outputs(
+        str(base), "folder_to_iso",
+    ) == []
+
+
+# --- extractcd sibling: every consumer derives the .bin from companion_outputs.
+# (The folder_to_iso companion side is covered by test_makeps3iso.py.)
+
+def test_extractcd_conflict_detects_bin_sibling(tmp_path):
+    # Only the .bin sibling exists (the .cue primary is absent): the duplicate
+    # preflight must still report a conflict, sourced from companion_outputs.
+    (tmp_path / "Game.bin").write_bytes(b"data")
+    exists, _locked = convert_routes.check_output_conflicts(
+        "extractcd", str(tmp_path / "Game.cue"),
+    )
+    assert exists
+
+
+def test_extractcd_unique_name_steps_past_bin_sibling(tmp_path):
+    # Game.cue is free but Game.bin is taken, so a rename must advance to
+    # Game_1.cue (whose Game_1.bin is also free) instead of reusing Game.cue and
+    # clobbering the existing .bin.
+    (tmp_path / "Game.bin").write_bytes(b"data")
+    out = convert_routes.get_unique_output_path(
+        str(tmp_path / "Game.cue"), "extractcd",
+    )
+    assert out == str(tmp_path / "Game_1.cue")
+
+
+def test_extractcd_job_protects_bin_companion_in_use(tmp_path):
+    # An active extractcd job's .bin companion counts as in-use even though only
+    # the .cue is its recorded output_path — in-use tracking reads companions.
+    from app.services.job_manager import job_manager
+
+    cue = str(tmp_path / "Game.cue")
+    bin_path = str(tmp_path / "Game.bin")
+    (tmp_path / "Game.bin").write_bytes(b"data")
+    job = ConversionJob(
+        id="extractcd-sibling",
+        file_path=str(tmp_path / "Game.chd"),
+        filename="Game.chd",
+        mode=ConversionMode.EXTRACTCD,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=cue,
+        input_kind=InputKind.FILE,
+    )
+    job_manager.jobs[job.id] = job
+    try:
+        assert job_manager.find_active_job_for_path(bin_path) is job
+        assert job_manager._is_path_in_use_by_other_job("other", bin_path) is True
+    finally:
+        job_manager.jobs.pop(job.id, None)

--- a/tests/test_companion_outputs_182.py
+++ b/tests/test_companion_outputs_182.py
@@ -130,3 +130,56 @@ def test_extractcd_job_protects_bin_companion_in_use(tmp_path):
         assert job_manager._is_path_in_use_by_other_job("other", bin_path) is True
     finally:
         job_manager.jobs.pop(job.id, None)
+
+
+def test_candidate_paths_skips_directory_companion_scan(tmp_path):
+    # A folder_to_iso job's split parts must NOT be enumerated by _candidate_paths
+    # (the directory companion scan is skipped — the parts are covered I/O-free by
+    # _split_output_blocks), keeping this sync helper event-loop-safe.
+    from app.services.job_manager import job_manager
+
+    out = str(tmp_path / "Game.iso")
+    (tmp_path / "Game.iso.0").write_bytes(b"p0")
+    (tmp_path / "Game.iso.1").write_bytes(b"p1")
+    job = ConversionJob(
+        id="fti-candidates",
+        file_path=str(tmp_path / "MyGame"),
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=out,
+        input_kind=InputKind.DIRECTORY,
+    )
+
+    paths = job_manager._candidate_paths(job)
+
+    assert out in paths
+    assert str(tmp_path / "Game.iso.0") not in paths
+    assert str(tmp_path / "Game.iso.1") not in paths
+
+
+@pytest.mark.asyncio
+async def test_clear_existing_output_removes_lone_companion(tmp_path):
+    # Overwrite was authorized because a stray .bin exists even though the .cue
+    # primary is gone; the clear must still remove the lone .bin so it can't
+    # collide with the new output.
+    from app.services.job_manager import job_manager
+
+    bin_path = tmp_path / "Game.bin"
+    bin_path.write_bytes(b"data")
+    job = ConversionJob(
+        id="extractcd-lone-clear",
+        file_path=str(tmp_path / "Game.chd"),
+        filename="Game.chd",
+        mode=ConversionMode.EXTRACTCD,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=str(tmp_path / "Game.cue"),  # absent
+        input_kind=InputKind.FILE,
+        allow_overwrite=True,
+    )
+
+    await job_manager._clear_existing_output(job)
+
+    assert not bin_path.exists()

--- a/tests/test_unique_output_path_locked_dir.py
+++ b/tests/test_unique_output_path_locked_dir.py
@@ -49,11 +49,11 @@ def _call_with_watchdog(fn, *args, timeout: float = 4.0) -> dict:
     return box
 
 
-@pytest.mark.parametrize(
-    "helper_name",
-    ["get_unique_output_path", "get_unique_ps3_iso_output_path"],
-)
-def test_rename_inside_locked_subtree_rejected_not_looped(tmp_path, helper_name):
+# mode=None is the plain single-file probe; "folder_to_iso" exercises the
+# companion-aware path (a split set's numbered parts). After #182 both run
+# through the single ``get_unique_output_path`` helper.
+@pytest.mark.parametrize("mode", [None, "folder_to_iso"])
+def test_rename_inside_locked_subtree_rejected_not_looped(tmp_path, mode):
     folder = tmp_path / "MyGame"
     (folder / "PS3_GAME").mkdir(parents=True)
     lock_manager = convert_routes.lock_manager
@@ -63,9 +63,10 @@ def test_rename_inside_locked_subtree_rejected_not_looped(tmp_path, helper_name)
         # A per-file output (e.g. chdman create) that lands inside the locked
         # PS3 folder being packed.
         output_path = str(folder / "PS3_GAME" / "game.iso")
-        helper = getattr(convert_routes, helper_name)
 
-        box = _call_with_watchdog(helper, output_path)
+        box = _call_with_watchdog(
+            convert_routes.get_unique_output_path, output_path, mode,
+        )
 
         exc = box.get("exc")
         assert isinstance(exc, convert_routes.SkipFile), (


### PR DESCRIPTION
Closes #182.

## Problem

A mode that produces **more than one file** had that fact re-encoded as a literal
`mode ==` string plus a hard-coded sibling suffix in every consumer, with no
registry hook:

- **`extractcd` → `.cue` + sibling `.bin`** was re-spelled across `check_output_conflicts`,
  `get_unique_output_path_for_extractcd`, `_candidate_paths`, `_clear_existing_output`,
  and the completed-size sum.
- **`folder_to_iso` → split `.iso.0/.1/…`** was probed by literal `+ ".0"` /
  `mode == "folder_to_iso"` in conflict-check and tracked via direct `split_parts`
  calls in the size-sum and in-use rejection.

A missed site silently corrupts overwrite-cleanup, output-size, in-flight protection,
or duplicate detection — exactly for the modes that produce multiple files.

## Fix

Add **one hook** to the plugin contract:

```python
def companion_outputs(self, output_path: str, mode: str) -> list[str]: ...
```

returning the *extra* produced paths (never `output_path` itself).

- **`BaseTool` default** derives them from a new **`ModeSpec.companion_exts`** suffix
  list — a suffix swap off the primary. `ChdmanTool` sets `extractcd`'s to `(".bin",)`.
- **`MakePs3IsoTool` overrides** it with its disk-probed split parts (`split_parts`
  minus the base), whose ordering is deterministic (a contiguous `.0` run).

Every consumer now enumerates companions from the hook instead of re-deriving:

- **`convert.py`** — `check_output_conflicts` drops its `extractcd`/`.bin` +
  `folder_to_iso`/`.0` branches; the three per-mode unique-name helpers
  (`get_unique_output_path` / `…_for_extractcd` / `…_ps3_iso`) collapse into one
  companion-aware `get_unique_output_path(base, mode)`.
- **`job_manager.py`** — `_candidate_paths` (in-use), `_clear_existing_output`
  (overwrite), the completed output-size sum, and the split-set in-use rejection
  all read `companion_outputs`. The size-sum's `DIRECTORY`/`extractcd`/`else`
  branches collapse to one loop over `[output_path, *companion_outputs]`.

makeps3iso's part-aware `remove_outputs` stays the **directory-mode cleanup
primitive** (it clears a mid-split base + parts that `split_parts` would skip),
and `_split_output_blocks`' prefix match still guards a *running* split job's
queue-time-unknown parts — both are tool-abstracted, not literal `.bin`/`.0`.

No wire-API change: mode strings, endpoints and JSON shapes are untouched.

## Acceptance

- No literal `"extractcd"` / `with_suffix(".bin")` / `+ ".0"` companion logic
  remains in `convert.py` / `job_manager.py` (greppable — confirmed clean).
- Overwrite, conflict-detection, size-sum and in-use protection for `extractcd`
  **and** split `folder_to_iso` all derive from `companion_outputs`.

## Tests

- **`tests/test_companion_outputs_182.py`** (new): the hook for extractcd's `.bin`,
  single-file modes / the chain (`[]`), and makeps3iso bare-vs-split (with an
  out-of-order on-disk layout asserting deterministic part ordering); plus an
  **extractcd sibling test** covering the consumers — conflict-detection sees a lone
  `.bin`, unique-name steps a rename past a taken `.bin`, and an active extractcd
  job's `.bin` companion is protected as in-use.
- **`tests/test_unique_output_path_locked_dir.py`** updated for the unified
  `get_unique_output_path(base, mode)` (parametrized over plain + `folder_to_iso`);
  `test_makeps3iso.py` covers the folder_to_iso side unchanged.

`PYTHONPATH=app python -m pytest -q` → 1007 passed, 1 skipped (the 27
`test_archive_conversion_e2e.py` failures are pre-existing/environmental — missing
conversion binaries — and the pass/fail set is identical to base). `ruff check .` → clean.

## Docs

`docs/DESIGN_tool_plugin_architecture.md`: `companion_outputs` added to the plugin
contract (Protocol + `BaseTool` default), and the makeps3iso split lifecycle section
rewritten to point every site (conflicts, overwrite, completed-size) at the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o)_



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unified multi-file output handling for split ISO files and CD extraction with comprehensive companion-file detection across all conversion modes.

* **Bug Fixes**
  * Improved output path conflict detection and duplicate prevention accuracy.

* **Performance**
  * Duplicate and conflict checks now run asynchronously, improving responsiveness during large conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves multi-file output handling into the tool plugin contract. The main changes are:

- Adds `companion_outputs()` to the tool protocol and default mode specs.
- Models `extractcd` `.bin` sidecars and `folder_to_iso` split parts through that hook.
- Updates conflict checks, unique naming, overwrite cleanup, in-use checks, and output-size calculation to use companion outputs.
- Adds tests and documentation for the new companion-output behavior.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Mostly safe to merge after fixing the split-output conflict handling for non-file occupied paths.

The change is well-scoped and covered by tests, but one remaining edge case can still miss an occupied split target before conversion starts.

app/services/tools/makeps3iso.py
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Python repro to exercise folder\_to\_iso non-file split conflict handling and confirmed companion\_outputs was empty and get\_unique\_output\_path reused Game.iso rather than treating Game.iso.0 as occupied.
- Compared base versus head for deterministic rename around occupied .bin companions and clearing a lone .bin overwrite companion; the head now passes all five scenarios with exit code 0.
- Compared pre- and post-artifact results for folder-to-iso split companions; the head run now reports ALL\_SCENARIOS\_PASS with exit code 0 and confirms no non-file directory at Game.iso.0 was exercised.

<a href="https://app.greptile.com/trex/runs/12161439/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `app/services/job_manager.py`, line 796-797 ([link](https://github.com/pacnpal/compressatorium/blob/a952815af790e22b172896284bb8d68fef94c76b/app/services/job_manager.py#L796-L797)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Companion cleanup is skipped**

   This branch returns before clearing companion files when the primary output is absent. When only `Game.bin` exists for an `extractcd` output and the user chooses overwrite, `check_output_conflicts()` reports a conflict and planning sets `allow_overwrite=True`. The worker then sees that `Game.cue` does not exist, returns here, and leaves the stale `Game.bin` in place for the new conversion to overwrite or fail against. Please remove companions even when `job.output_path` itself is missing, and reject non-file companions the same way the primary path is rejected.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: targeted pytest invoking real overwrite cleanup with absent primary and stale companion](https://app.greptile.com/trex/artifacts/4d1bfd19-e559-4c36-a06e-1327417af2ab)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: verbose pytest output showing Game.bin remains after cleanup](https://app.greptile.com/trex/artifacts/21e77f60-a54f-49e4-b550-856606071695)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12060998/artifacts?artifact=4d1bfd19-e559-4c36-a06e-1327417af2ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fjob_manager.py%0ALine%3A%20796-797%0A%0AComment%3A%0A**Companion%20cleanup%20is%20skipped**%0A%0AThis%20branch%20returns%20before%20clearing%20companion%20files%20when%20the%20primary%20output%20is%20absent.%20When%20only%20%60Game.bin%60%20exists%20for%20an%20%60extractcd%60%20output%20and%20the%20user%20chooses%20overwrite%2C%20%60check_output_conflicts%28%29%60%20reports%20a%20conflict%20and%20planning%20sets%20%60allow_overwrite%3DTrue%60.%20The%20worker%20then%20sees%20that%20%60Game.cue%60%20does%20not%20exist%2C%20returns%20here%2C%20and%20leaves%20the%20stale%20%60Game.bin%60%20in%20place%20for%20the%20new%20conversion%20to%20overwrite%20or%20fail%20against.%20Please%20remove%20companions%20even%20when%20%60job.output_path%60%20itself%20is%20missing%2C%20and%20reject%20non-file%20companions%20the%20same%20way%20the%20primary%20path%20is%20rejected.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2F182-companion-outputs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2F182-companion-outputs%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fjob_manager.py%0ALine%3A%20796-797%0A%0AComment%3A%0A**Companion%20cleanup%20is%20skipped**%0A%0AThis%20branch%20returns%20before%20clearing%20companion%20files%20when%20the%20primary%20output%20is%20absent.%20When%20only%20%60Game.bin%60%20exists%20for%20an%20%60extractcd%60%20output%20and%20the%20user%20chooses%20overwrite%2C%20%60check_output_conflicts%28%29%60%20reports%20a%20conflict%20and%20planning%20sets%20%60allow_overwrite%3DTrue%60.%20The%20worker%20then%20sees%20that%20%60Game.cue%60%20does%20not%20exist%2C%20returns%20here%2C%20and%20leaves%20the%20stale%20%60Game.bin%60%20in%20place%20for%20the%20new%20conversion%20to%20overwrite%20or%20fail%20against.%20Please%20remove%20companions%20even%20when%20%60job.output_path%60%20itself%20is%20missing%2C%20and%20reject%20non-file%20companions%20the%20same%20way%20the%20primary%20path%20is%20rejected.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `app/routes/convert.py`, line 682 ([link](https://github.com/pacnpal/compressatorium/blob/a952815af790e22b172896284bb8d68fef94c76b/app/routes/convert.py#L682)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Duplicate checks block async work**

   `check_output_conflicts()` now calls the makeps3iso companion hook for `folder_to_iso`, and that hook scans the output directory with `split_parts()`. The `/jobs/check-duplicates` endpoint still calls it synchronously for each requested file, so a duplicate check over a slow mounted directory or a large batch can block the FastAPI event loop and stall unrelated requests or SSE updates. Please run this conflict check in the threadpool for disk-probed modes, or wrap it here generally.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: pytest harness for blocking /jobs/check-duplicates and direct handler timing](https://app.greptile.com/trex/artifacts/1bce58a9-890d-45b7-bfe8-1bd53dfa42f3)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: verbose pytest timing output with HTTP status codes and delayed async work](https://app.greptile.com/trex/artifacts/e6b3a082-359e-47bd-b0f6-b6c87ef3e9ca)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12060998/artifacts?artifact=1bce58a9-890d-45b7-bfe8-1bd53dfa42f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Froutes%2Fconvert.py%0ALine%3A%20682%0A%0AComment%3A%0A**Duplicate%20checks%20block%20async%20work**%0A%0A%60check_output_conflicts%28%29%60%20now%20calls%20the%20makeps3iso%20companion%20hook%20for%20%60folder_to_iso%60%2C%20and%20that%20hook%20scans%20the%20output%20directory%20with%20%60split_parts%28%29%60.%20The%20%60%2Fjobs%2Fcheck-duplicates%60%20endpoint%20still%20calls%20it%20synchronously%20for%20each%20requested%20file%2C%20so%20a%20duplicate%20check%20over%20a%20slow%20mounted%20directory%20or%20a%20large%20batch%20can%20block%20the%20FastAPI%20event%20loop%20and%20stall%20unrelated%20requests%20or%20SSE%20updates.%20Please%20run%20this%20conflict%20check%20in%20the%20threadpool%20for%20disk-probed%20modes%2C%20or%20wrap%20it%20here%20generally.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2F182-companion-outputs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2F182-companion-outputs%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Froutes%2Fconvert.py%0ALine%3A%20682%0A%0AComment%3A%0A**Duplicate%20checks%20block%20async%20work**%0A%0A%60check_output_conflicts%28%29%60%20now%20calls%20the%20makeps3iso%20companion%20hook%20for%20%60folder_to_iso%60%2C%20and%20that%20hook%20scans%20the%20output%20directory%20with%20%60split_parts%28%29%60.%20The%20%60%2Fjobs%2Fcheck-duplicates%60%20endpoint%20still%20calls%20it%20synchronously%20for%20each%20requested%20file%2C%20so%20a%20duplicate%20check%20over%20a%20slow%20mounted%20directory%20or%20a%20large%20batch%20can%20block%20the%20FastAPI%20event%20loop%20and%20stall%20unrelated%20requests%20or%20SSE%20updates.%20Please%20run%20this%20conflict%20check%20in%20the%20threadpool%20for%20disk-probed%20modes%2C%20or%20wrap%20it%20here%20generally.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

3. `app/routes/convert.py`, line 402 ([link](https://github.com/pacnpal/compressatorium/blob/a952815af790e22b172896284bb8d68fef94c76b/app/routes/convert.py#L402)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Directory planning blocks event loop**

   This directory-mode planning path still calls `check_output_conflicts()` directly. For `folder_to_iso`, that now calls `MakePs3IsoTool.companion_outputs()`, which scans the target directory to discover split parts. A single job creation against a slow or mounted output directory can block the event loop before reaching the already-threadpooled rename branch. Please run this initial conflict check in the threadpool for directory modes.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: async pytest harness for folder\_to\_iso event-loop blocking](https://app.greptile.com/trex/artifacts/13459e23-43af-4245-bdbf-968f2194752f)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: verbose pytest timing output showing blocked ticker and 200 OK route result](https://app.greptile.com/trex/artifacts/5eececcd-fc2e-4cba-bad4-50f04ee1d756)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12060998/artifacts?artifact=13459e23-43af-4245-bdbf-968f2194752f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Froutes%2Fconvert.py%0ALine%3A%20402%0A%0AComment%3A%0A**Directory%20planning%20blocks%20event%20loop**%0A%0AThis%20directory-mode%20planning%20path%20still%20calls%20%60check_output_conflicts%28%29%60%20directly.%20For%20%60folder_to_iso%60%2C%20that%20now%20calls%20%60MakePs3IsoTool.companion_outputs%28%29%60%2C%20which%20scans%20the%20target%20directory%20to%20discover%20split%20parts.%20A%20single%20job%20creation%20against%20a%20slow%20or%20mounted%20output%20directory%20can%20block%20the%20event%20loop%20before%20reaching%20the%20already-threadpooled%20rename%20branch.%20Please%20run%20this%20initial%20conflict%20check%20in%20the%20threadpool%20for%20directory%20modes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2F182-companion-outputs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2F182-companion-outputs%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Froutes%2Fconvert.py%0ALine%3A%20402%0A%0AComment%3A%0A**Directory%20planning%20blocks%20event%20loop**%0A%0AThis%20directory-mode%20planning%20path%20still%20calls%20%60check_output_conflicts%28%29%60%20directly.%20For%20%60folder_to_iso%60%2C%20that%20now%20calls%20%60MakePs3IsoTool.companion_outputs%28%29%60%2C%20which%20scans%20the%20target%20directory%20to%20discover%20split%20parts.%20A%20single%20job%20creation%20against%20a%20slow%20or%20mounted%20output%20directory%20can%20block%20the%20event%20loop%20before%20reaching%20the%20already-threadpooled%20rename%20branch.%20Please%20run%20this%20initial%20conflict%20check%20in%20the%20threadpool%20for%20directory%20modes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

4. `app/services/job_manager.py`, line 796-808 ([link](https://github.com/pacnpal/compressatorium/blob/c0ea4d811fb21286a7ca23483bd464e8e527e630/app/services/job_manager.py#L796-L808)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Companion-only overwrite skips cleanup.** When overwrite was authorized because only a companion exists, such as `check_output_conflicts("extractcd", "Game.cue")` seeing `Game.bin` while `Game.cue` is absent, this early return skips companion cleanup. The job then runs with `allow_overwrite=True` but leaves the stale `.bin` in place, so `extractcd` can fail on the existing sidecar or mix new output with old data instead of replacing the whole output set.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused extractcd companion cleanup harness](https://app.greptile.com/trex/artifacts/5626598c-d5b7-4b71-b850-dd38b8a8ceb5)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: harness output showing stale Game.bin remains after cleanup](https://app.greptile.com/trex/artifacts/579280c0-5cac-4e26-87dc-5a6d22033e88)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12062626/artifacts?artifact=5626598c-d5b7-4b71-b850-dd38b8a8ceb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fjob_manager.py%0ALine%3A%20796-808%0A%0AComment%3A%0A**Companion-only%20overwrite%20skips%20cleanup.**%20When%20overwrite%20was%20authorized%20because%20only%20a%20companion%20exists%2C%20such%20as%20%60check_output_conflicts%28%22extractcd%22%2C%20%22Game.cue%22%29%60%20seeing%20%60Game.bin%60%20while%20%60Game.cue%60%20is%20absent%2C%20this%20early%20return%20skips%20companion%20cleanup.%20The%20job%20then%20runs%20with%20%60allow_overwrite%3DTrue%60%20but%20leaves%20the%20stale%20%60.bin%60%20in%20place%2C%20so%20%60extractcd%60%20can%20fail%20on%20the%20existing%20sidecar%20or%20mix%20new%20output%20with%20old%20data%20instead%20of%20replacing%20the%20whole%20output%20set.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2F182-companion-outputs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2F182-companion-outputs%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fjob_manager.py%0ALine%3A%20796-808%0A%0AComment%3A%0A**Companion-only%20overwrite%20skips%20cleanup.**%20When%20overwrite%20was%20authorized%20because%20only%20a%20companion%20exists%2C%20such%20as%20%60check_output_conflicts%28%22extractcd%22%2C%20%22Game.cue%22%29%60%20seeing%20%60Game.bin%60%20while%20%60Game.cue%60%20is%20absent%2C%20this%20early%20return%20skips%20companion%20cleanup.%20The%20job%20then%20runs%20with%20%60allow_overwrite%3DTrue%60%20but%20leaves%20the%20stale%20%60.bin%60%20in%20place%2C%20so%20%60extractcd%60%20can%20fail%20on%20the%20existing%20sidecar%20or%20mix%20new%20output%20with%20old%20data%20instead%20of%20replacing%20the%20whole%20output%20set.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fservices%2Ftools%2Fmakeps3iso.py%3A125-128%0A**Non-file%20split%20conflicts%20are%20skipped**%0A%0A%60companion_outputs%28%29%60%20now%20drives%20the%20%60folder_to_iso%60%20conflict%20checks%2C%20but%20it%20only%20returns%20parts%20from%20%60split_parts%28%29%60%2C%20which%20filters%20numbered%20paths%20through%20%60is_file%28%29%60.%20If%20%60Game.iso%60%20is%20absent%20and%20a%20directory%20already%20exists%20at%20%60Game.iso.0%60%2C%20the%20old%20%60os.path.exists%28output_path%20%2B%20%22.0%22%29%60%20branch%20treated%20that%20as%20occupied%2C%20while%20this%20hook%20returns%20no%20companion.%20Skip%2Frename%20preflight%20and%20the%20worker's%20non-overwrite%20split-set%20rejection%20can%20then%20miss%20the%20occupied%20target%20and%20let%20makeps3iso%20fail%20later%20when%20it%20tries%20to%20create%20the%20first%20split%20part.%0A%0A&repo=pacnpal%2Fcompressatorium&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2F182-companion-outputs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2F182-companion-outputs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapp%2Fservices%2Ftools%2Fmakeps3iso.py%3A125-128%0A**Non-file%20split%20conflicts%20are%20skipped**%0A%0A%60companion_outputs%28%29%60%20now%20drives%20the%20%60folder_to_iso%60%20conflict%20checks%2C%20but%20it%20only%20returns%20parts%20from%20%60split_parts%28%29%60%2C%20which%20filters%20numbered%20paths%20through%20%60is_file%28%29%60.%20If%20%60Game.iso%60%20is%20absent%20and%20a%20directory%20already%20exists%20at%20%60Game.iso.0%60%2C%20the%20old%20%60os.path.exists%28output_path%20%2B%20%22.0%22%29%60%20branch%20treated%20that%20as%20occupied%2C%20while%20this%20hook%20returns%20no%20companion.%20Skip%2Frename%20preflight%20and%20the%20worker's%20non-overwrite%20split-set%20rejection%20can%20then%20miss%20the%20occupied%20target%20and%20let%20makeps3iso%20fail%20later%20when%20it%20tries%20to%20create%20the%20first%20split%20part.%0A%0A&repo=pacnpal%2Fcompressatorium&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/lat..."](https://github.com/pacnpal/compressatorium/commit/abe5eca0553828ba94c481ed23365c33b8e7ac7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39390154)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->