### PR TITLE
De-duplicate backend request validation, constants & info models

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -268,48 +268,37 @@ class DolphinDiscInfo(BaseModel):
     raw_data: str = ""
 
 
-class Z3DSInfo(BaseModel):
+class BasicFileInfo(BaseModel):
+    """Shared shape for the simple per-file info models: identity, size, and the
+    format/compression summary.
+
+    The five tools whose /info just reports "what is this file" (z3ds, nsz, cso,
+    romz, makeps3iso) return this exact shape; the two that add fields (romz's
+    archive ratio, makeps3iso's title) subclass it instead of repeating it.
+    """
+    file: str
+    size: int
+    size_display: str
+    format: str | None = None
+    extension: str
+    compressed: bool
+    compression_type: str | None = None
+
+
+class Z3DSInfo(BasicFileInfo):
     """Information about a Nintendo 3DS ROM file."""
-    file: str
-    size: int
-    size_display: str
-    format: str | None = None
-    extension: str
-    compressed: bool
-    compression_type: str | None = None
 
 
-class NszInfo(BaseModel):
+class NszInfo(BasicFileInfo):
     """Information about a Nintendo Switch NSP/XCI/NSZ/XCZ file."""
-    file: str
-    size: int
-    size_display: str
-    format: str | None = None
-    extension: str
-    compressed: bool
-    compression_type: str | None = None
 
 
-class CsoInfo(BaseModel):
+class CsoInfo(BasicFileInfo):
     """Information about a PSP/PS2 ISO/CSO/ZSO/DAX file."""
-    file: str
-    size: int
-    size_display: str
-    format: str | None = None
-    extension: str
-    compressed: bool
-    compression_type: str | None = None
 
 
-class RomzInfo(BaseModel):
+class RomzInfo(BasicFileInfo):
     """Information about a handheld ROM (GB/GBC/GBA/NDS) or its .7z/.zip archive."""
-    file: str
-    size: int
-    size_display: str
-    format: str | None = None
-    extension: str
-    compressed: bool
-    compression_type: str | None = None
     # Archive-only extras: the single ROM inside, its uncompressed size, and the
     # archive-to-original size ratio (None for a loose ROM source).
     contained_name: str | None = None
@@ -317,15 +306,8 @@ class RomzInfo(BaseModel):
     ratio: str | None = None
 
 
-class Ps3IsoInfo(BaseModel):
+class Ps3IsoInfo(BasicFileInfo):
     """Information about a decrypted PS3 disc/JB folder (makeps3iso source)."""
-    file: str
-    size: int
-    size_display: str
-    format: str | None = None
-    extension: str
-    compressed: bool
-    compression_type: str | None = None
     title: str | None = None
     title_id: str | None = None
 

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -89,6 +89,66 @@ def supports_delete_on_verify(mode: str) -> bool:
         return False
 
 
+# Confirmation tokens for the destructive queue actions. The frontend mirrors
+# these in src/lib/api/client.js (CONFIRM); keeping one backend definition each
+# means a rename can't silently break the X-CHD-Action-Confirm guard.
+ACTION_CONFIRM_HEADER = "x-chd-action-confirm"
+CONFIRM_CANCEL_ALL_JOBS = "cancel-all-jobs"
+CONFIRM_CLEAR_COMPLETED_JOBS = "clear-completed-jobs"
+
+# Which modes support delete-on-verify is a registry fact
+# (spec.supports_delete_on_verify); this is the single human-readable
+# enumeration reused by every "unsupported" 400 (single create, batch, delete-plan).
+_DELETE_ON_VERIFY_UNSUPPORTED_DETAIL = (
+    "Delete-on-verify is only supported for "
+    "create/copy/Dolphin/3DS/Switch-compress/CSO/CSO2/ZSO/DAX-compress modes"
+)
+
+
+def _validate_request_compression(spec, mode: str, compression: str | None) -> None:
+    """Reject a compression request a mode can't honor (shared by single + batch).
+
+    Raises ``HTTPException(400)`` with the mode-specific message; a no-op when no
+    compression was requested or the mode accepts it.
+    """
+    if not compression:
+        return
+    if spec.tool_id == "chdman" and spec.kind == ModeKind.EXTRACT:
+        raise HTTPException(
+            status_code=400,
+            detail="Compression is only supported for CHD creation/copy",
+        )
+    if ":" in compression and not spec.supports_compression_level:
+        raise HTTPException(
+            status_code=400,
+            detail="Compression levels are only supported for Dolphin and Switch formats",
+        )
+    if mode == "dolphin_iso":
+        raise HTTPException(
+            status_code=400,
+            detail="Compression not applicable for ISO extraction",
+        )
+    if mode == "dolphin_gcz":
+        raise HTTPException(
+            status_code=400,
+            detail="GCZ uses fixed internal compression",
+        )
+    if spec.tool_id == "dolphin" and "," in compression:
+        raise HTTPException(
+            status_code=400,
+            detail="Dolphin compression supports only one codec at a time",
+        )
+
+
+def _validate_delete_on_verify(spec, delete_on_verify: bool) -> None:
+    """Reject delete-on-verify on a mode that doesn't support it (single + batch)."""
+    if delete_on_verify and not spec.supports_delete_on_verify:
+        raise HTTPException(
+            status_code=400,
+            detail=_DELETE_ON_VERIFY_UNSUPPORTED_DETAIL,
+        )
+
+
 def _get_output_path(mode, input_path, output_dir, *, treat_as_stem=False):
     return registry.for_mode(mode).output_path(
         mode, input_path, output_dir, treat_as_stem=treat_as_stem,
@@ -738,10 +798,7 @@ async def delete_plan(request: DeletePlanRequest) -> dict:
     if not supports_delete_on_verify(mode):
         raise HTTPException(
             status_code=400,
-            detail=(
-                "Delete-on-verify is only supported for "
-                "create/copy/Dolphin/3DS/Switch-compress/CSO/CSO2/ZSO/DAX-compress modes"
-            ),
+            detail=_DELETE_ON_VERIFY_UNSUPPORTED_DETAIL,
         )
 
     disallowed_archives = get_disallowed_archive_paths(request.file_paths)
@@ -795,40 +852,8 @@ async def create_job(request: JobCreateRequest):
     mode = request.mode.value
     output_dir = normalize_output_dir(request.output_dir)
     spec = registry.spec(mode)
-    is_dolphin = spec.tool_id == "dolphin"
-    if compression and spec.tool_id == "chdman" and spec.kind == ModeKind.EXTRACT:
-        raise HTTPException(
-            status_code=400,
-            detail="Compression is only supported for CHD creation/copy",
-        )
-    if compression and ":" in compression and not spec.supports_compression_level:
-        raise HTTPException(
-            status_code=400,
-            detail="Compression levels are only supported for Dolphin and Switch formats",
-        )
-    if compression and mode == "dolphin_iso":
-        raise HTTPException(
-            status_code=400,
-            detail="Compression not applicable for ISO extraction",
-        )
-    if compression and mode == "dolphin_gcz":
-        raise HTTPException(
-            status_code=400,
-            detail="GCZ uses fixed internal compression",
-        )
-    if compression and is_dolphin and "," in compression:
-        raise HTTPException(
-            status_code=400,
-            detail="Dolphin compression supports only one codec at a time",
-        )
-    if request.delete_on_verify and not spec.supports_delete_on_verify:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "Delete-on-verify is only supported for "
-                "create/copy/Dolphin/3DS/Switch-compress/CSO/CSO2/ZSO/DAX-compress modes"
-            ),
-        )
+    _validate_request_compression(spec, mode, compression)
+    _validate_delete_on_verify(spec, request.delete_on_verify)
     if not is_within_configured_volumes(request.file_path):
         raise HTTPException(
             status_code=403,
@@ -901,41 +926,9 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
     compression = normalize_compression(request.compression)
     mode = request.mode.value
     spec = registry.spec(mode)
-    is_dolphin = spec.tool_id == "dolphin"
     output_dir = normalize_output_dir(request.output_dir)
-    if compression and spec.tool_id == "chdman" and spec.kind == ModeKind.EXTRACT:
-        raise HTTPException(
-            status_code=400,
-            detail="Compression is only supported for CHD creation/copy",
-        )
-    if compression and ":" in compression and not spec.supports_compression_level:
-        raise HTTPException(
-            status_code=400,
-            detail="Compression levels are only supported for Dolphin and Switch formats",
-        )
-    if compression and mode == "dolphin_iso":
-        raise HTTPException(
-            status_code=400,
-            detail="Compression not applicable for ISO extraction",
-        )
-    if compression and mode == "dolphin_gcz":
-        raise HTTPException(
-            status_code=400,
-            detail="GCZ uses fixed internal compression",
-        )
-    if compression and is_dolphin and "," in compression:
-        raise HTTPException(
-            status_code=400,
-            detail="Dolphin compression supports only one codec at a time",
-        )
-    if request.delete_on_verify and not spec.supports_delete_on_verify:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "Delete-on-verify is only supported for "
-                "create/copy/Dolphin/3DS/Switch-compress/CSO/CSO2/ZSO/DAX-compress modes"
-            ),
-        )
+    _validate_request_compression(spec, mode, compression)
+    _validate_delete_on_verify(spec, request.delete_on_verify)
     if request.delete_on_verify:
         disallowed_archives = get_disallowed_archive_paths(request.file_paths)
         if disallowed_archives:
@@ -1155,8 +1148,8 @@ async def get_job(job_id: str):
 @router.delete("/jobs/completed")
 async def delete_completed_jobs(request: Request):
     """Delete all completed, failed, and cancelled jobs."""
-    confirmation = request.headers.get("x-chd-action-confirm", "")
-    if confirmation != "clear-completed-jobs":
+    confirmation = request.headers.get(ACTION_CONFIRM_HEADER, "")
+    if confirmation != CONFIRM_CLEAR_COMPLETED_JOBS:
         raise HTTPException(
             status_code=400,
             detail="Missing confirmation header for clear-completed action",
@@ -1179,8 +1172,8 @@ async def delete_completed_jobs(request: Request):
 @router.post("/jobs/cancel-all")
 async def cancel_all_jobs(request: Request):
     """Cancel all queued and processing jobs."""
-    confirmation = request.headers.get("x-chd-action-confirm", "")
-    if confirmation != "cancel-all-jobs":
+    confirmation = request.headers.get(ACTION_CONFIRM_HEADER, "")
+    if confirmation != CONFIRM_CANCEL_ALL_JOBS:
         raise HTTPException(
             status_code=400,
             detail="Missing confirmation header for cancel-all action",

--- a/app/services/archive.py
+++ b/app/services/archive.py
@@ -146,10 +146,18 @@ class ArchiveService:
         """
         from services.tools import registry
 
-        return (
+        exts = (
             registry.convertible_extensions()
             | registry.archive_input_extensions()
         ) - ARCHIVE_EXTENSIONS
+        if not exts:
+            # An empty union means the registry is unloaded/broken, not that
+            # nothing is convertible. Fail loudly so the archive listing surfaces
+            # the bug rather than silently rendering an "empty archive".
+            raise RuntimeError(
+                "Tool registry produced no listable extensions — registry not loaded?"
+            )
+        return exts
 
     @staticmethod
     def _convert_gate_extensions() -> frozenset:
@@ -163,7 +171,12 @@ class ArchiveService:
         """
         from services.tools import registry
 
-        return registry.archive_input_extensions()
+        exts = registry.archive_input_extensions()
+        if not exts:
+            raise RuntimeError(
+                "Tool registry produced no archive-input extensions — registry not loaded?"
+            )
+        return exts
 
     def list_archive_contents(
         self, archive_path: str, *, include_meta: bool = False,

--- a/app/services/archive.py
+++ b/app/services/archive.py
@@ -28,20 +28,12 @@ except ImportError:
 
 
 ARCHIVE_EXTENSIONS = {".zip", ".7z", ".rar"}
-# Fallback set of listable archive-member extensions, used only when the tool
-# registry can't be consulted. The authoritative list comes from the registry:
-# ``_listable_extensions()`` (browse) uses ``convertible_extensions()`` minus the
-# archive containers, every known source extension; ``_convert_gate_extensions()``
-# (search) uses ``archive_input_extensions()``. Historically this was hardcoded to
-# CHDMAN's sources, which silently hid 3DS members inside archives (issue #113)
-# and romz ROMs (the .zip "Empty folder" bug).
-CONVERTIBLE_EXTENSIONS = {
-    ".gdi", ".iso", ".cue", ".bin",          # chdman create modes
-    ".gcz", ".wia", ".rvz", ".wbfs",         # Dolphin (.iso shared above)
-    ".cci", ".cia", ".3ds", ".cxi", ".3dsx", # 3DS (z3ds compress)
-    ".zcci", ".zcia", ".z3ds", ".zcxi", ".z3dsx",  # 3DS (z3ds decompress)
-    ".gb", ".gbc", ".gba", ".nds",           # handheld ROMs (romz, listing only)
-}
+# The listable / convert-gate extension sets come *only* from the tool registry
+# (``_listable_extensions`` browse, ``_convert_gate_extensions`` search). There is
+# deliberately no hand-maintained fallback copy: a stale literal silently hid new
+# tools' members (3DS issue #113, romz's .zip "Empty folder" bug), so the registry
+# is the single source of truth and an empty union surfaces a real bug loudly
+# instead of being masked.
 
 logger = get_logger("archive")
 
@@ -148,24 +140,16 @@ class ArchiveService:
         that are visible-only — a romz ROM appears when you browse into its
         archive even though no mode will re-convert it in place (its
         ``convertible_by`` stays empty, see ``tools_accepting_archive_member``).
-        Falls back to the static set if the registry can't be imported
-        (defensive, it always loads).
+        The registry is the single source of truth (it always loads in-app), so
+        an empty union surfaces a registry bug loudly instead of being masked by
+        a stale hardcoded fallback.
         """
-        try:
-            from services.tools import registry
+        from services.tools import registry
 
-            exts = (
-                registry.convertible_extensions()
-                | registry.archive_input_extensions()
-            ) - ARCHIVE_EXTENSIONS
-            if exts:
-                return exts
-        except Exception:  # pragma: no cover - registry always loads in-app
-            logger.debug(
-                "Tool registry unavailable; using static convertible extensions",
-                exc_info=True,
-            )
-        return frozenset(CONVERTIBLE_EXTENSIONS)
+        return (
+            registry.convertible_extensions()
+            | registry.archive_input_extensions()
+        ) - ARCHIVE_EXTENSIONS
 
     @staticmethod
     def _convert_gate_extensions() -> frozenset:
@@ -177,18 +161,9 @@ class ArchiveService:
         browse listing — so list-only members (romz ROMs) never count toward the
         per-archive entry cap before a genuine convertible member is reached.
         """
-        try:
-            from services.tools import registry
+        from services.tools import registry
 
-            exts = registry.archive_input_extensions()
-            if exts:
-                return exts
-        except Exception:  # pragma: no cover - registry always loads in-app
-            logger.debug(
-                "Tool registry unavailable; using static convertible extensions",
-                exc_info=True,
-            )
-        return frozenset(CONVERTIBLE_EXTENSIONS)
+        return registry.archive_input_extensions()
 
     def list_archive_contents(
         self, archive_path: str, *, include_meta: bool = False,

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -815,14 +815,15 @@ class JobManager:
         Returns:
             Tuple of (queued_job_ids, processing_job_ids)
         """
-        queued_job_ids = [
-            job.id for job in self.jobs.values()
-            if _is_conversion_job(job) and job.status == JobStatus.QUEUED
-        ]
-        processing_job_ids = [
-            job.id for job in self.jobs.values()
-            if _is_conversion_job(job) and job.status == JobStatus.PROCESSING
-        ]
+        queued_job_ids: list[str] = []
+        processing_job_ids: list[str] = []
+        for job in self.jobs.values():
+            if not _is_conversion_job(job):
+                continue
+            if job.status == JobStatus.QUEUED:
+                queued_job_ids.append(job.id)
+            elif job.status == JobStatus.PROCESSING:
+                processing_job_ids.append(job.id)
         return queued_job_ids, processing_job_ids
 
     def is_stuck(self) -> bool:
@@ -834,15 +835,16 @@ class JobManager:
         Returns:
             True if conversion jobs are queued but none are processing, False otherwise
         """
-        has_queued = any(
-            _is_conversion_job(job) and job.status == JobStatus.QUEUED
-            for job in self.jobs.values()
-        )
-        has_processing = any(
-            _is_conversion_job(job) and job.status == JobStatus.PROCESSING
-            for job in self.jobs.values()
-        )
-        return has_queued and not has_processing
+        has_queued = False
+        for job in self.jobs.values():
+            if not _is_conversion_job(job):
+                continue
+            if job.status == JobStatus.PROCESSING:
+                # Any processing conversion means the queue isn't stuck; bail early.
+                return False
+            if job.status == JobStatus.QUEUED:
+                has_queued = True
+        return has_queued
 
     def get_stuck_state_info(self) -> Dict[str, object]:
         """Get information about the stuck state.

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -43,6 +43,23 @@ _EXTERNAL_JOB_MODES = frozenset({
 })
 
 
+def _is_conversion_job(job) -> bool:
+    """A real conversion job, not external bookkeeping (metadata scan / DAT match).
+
+    The single definition of "counts toward the conversion queue", used by every
+    backpressure / queue-depth / stuck-detection surface so they can't drift.
+    """
+    return job.mode not in _EXTERNAL_JOB_MODES
+
+
+def _is_active_conversion(job) -> bool:
+    """A conversion job currently occupying the queue (queued or processing)."""
+    return (
+        job.status in (JobStatus.QUEUED, JobStatus.PROCESSING)
+        and _is_conversion_job(job)
+    )
+
+
 def _paths_collide(path_a: str, path_b: str) -> bool:
     try:
         return os.path.realpath(path_a) == os.path.realpath(path_b)
@@ -118,10 +135,7 @@ class JobManager:
 
         needed = max(1, int(additional_jobs))
         current_depth = sum(
-            1
-            for job in self.jobs.values()
-            if job.status in (JobStatus.QUEUED, JobStatus.PROCESSING)
-            and job.mode not in _EXTERNAL_JOB_MODES
+            1 for job in self.jobs.values() if _is_active_conversion(job)
         )
         if current_depth + needed > max_depth:
             raise QueueBackpressureError(
@@ -528,10 +542,7 @@ class JobManager:
         consume queue capacity or trigger false backpressure errors.
         """
         return sum(
-            1
-            for job in self.jobs.values()
-            if job.status in (JobStatus.QUEUED, JobStatus.PROCESSING)
-            and job.mode not in _EXTERNAL_JOB_MODES
+            1 for job in self.jobs.values() if _is_active_conversion(job)
         )
 
     def get_active_job_candidates(self) -> List[Tuple[str, List[str]]]:
@@ -724,9 +735,7 @@ class JobManager:
         for job in self.jobs.values():
             if job.id == job_id:
                 continue
-            if job.status not in (JobStatus.QUEUED, JobStatus.PROCESSING):
-                continue
-            if job.mode in _EXTERNAL_JOB_MODES:
+            if not _is_active_conversion(job):
                 continue
             # Reject a delete that targets a path inside another active
             # directory job's source folder (its whole subtree is in use).
@@ -808,11 +817,11 @@ class JobManager:
         """
         queued_job_ids = [
             job.id for job in self.jobs.values()
-            if job.status == JobStatus.QUEUED and job.mode not in _EXTERNAL_JOB_MODES
+            if _is_conversion_job(job) and job.status == JobStatus.QUEUED
         ]
         processing_job_ids = [
             job.id for job in self.jobs.values()
-            if job.status == JobStatus.PROCESSING and job.mode not in _EXTERNAL_JOB_MODES
+            if _is_conversion_job(job) and job.status == JobStatus.PROCESSING
         ]
         return queued_job_ids, processing_job_ids
 
@@ -826,11 +835,11 @@ class JobManager:
             True if conversion jobs are queued but none are processing, False otherwise
         """
         has_queued = any(
-            job.status == JobStatus.QUEUED and job.mode not in _EXTERNAL_JOB_MODES
+            _is_conversion_job(job) and job.status == JobStatus.QUEUED
             for job in self.jobs.values()
         )
         has_processing = any(
-            job.status == JobStatus.PROCESSING and job.mode not in _EXTERNAL_JOB_MODES
+            _is_conversion_job(job) and job.status == JobStatus.PROCESSING
             for job in self.jobs.values()
         )
         return has_queued and not has_processing

--- a/app/services/tools/base.py
+++ b/app/services/tools/base.py
@@ -179,6 +179,26 @@ class BaseTool:
                 return m
         raise KeyError(mode)
 
+    @staticmethod
+    def _basic_info_fields(raw: dict) -> dict:
+        """The shared ``BasicFileInfo`` fields pulled from a tool's raw info dict.
+
+        The five "what is this file" tools (z3ds, nsz, cso, romz, makeps3iso)
+        build their info model from this, so the identical ``raw[...] -> field``
+        mapping lives in one place. Required fields are indexed directly (the
+        services always populate them); the optional pair uses ``.get`` so a
+        missing key becomes ``None`` rather than a KeyError.
+        """
+        return {
+            "file": raw["file"],
+            "size": raw["size"],
+            "size_display": raw["size_display"],
+            "format": raw.get("format"),
+            "extension": raw["extension"],
+            "compressed": raw["compressed"],
+            "compression_type": raw.get("compression_type"),
+        }
+
     def detect_output(self, input_path: str) -> OutputStatus | None:
         return None
 

--- a/app/services/tools/makeps3iso.py
+++ b/app/services/tools/makeps3iso.py
@@ -133,13 +133,7 @@ class MakePs3IsoTool(BaseTool):
 
     def info_model(self, raw: dict, path: str) -> Ps3IsoInfo:
         return Ps3IsoInfo(
-            file=raw["file"],
-            size=raw["size"],
-            size_display=raw["size_display"],
-            format=raw.get("format"),
-            extension=raw["extension"],
-            compressed=raw["compressed"],
-            compression_type=raw.get("compression_type"),
+            **self._basic_info_fields(raw),
             title=raw.get("title"),
             title_id=raw.get("title_id"),
         )

--- a/app/services/tools/maxcso.py
+++ b/app/services/tools/maxcso.py
@@ -164,17 +164,7 @@ class MaxcsoTool(BaseTool):
         return await run_in_threadpool(self._service.info, path)
 
     def info_model(self, raw: dict, path: str) -> CsoInfo:
-        # Direct indexing mirrors z3ds/nsz: maxcso_service.info() always
-        # populates the required fields, so a bare .get() would inject None.
-        return CsoInfo(
-            file=raw["file"],
-            size=raw["size"],
-            size_display=raw["size_display"],
-            format=raw.get("format"),
-            extension=raw["extension"],
-            compressed=raw["compressed"],
-            compression_type=raw.get("compression_type"),
-        )
+        return CsoInfo(**self._basic_info_fields(raw))
 
     def active_pids(self) -> list[int]:
         return self._service.active_pids()

--- a/app/services/tools/nsz.py
+++ b/app/services/tools/nsz.py
@@ -124,17 +124,7 @@ class NszTool(BaseTool):
         return await run_in_threadpool(self._service.info, path)
 
     def info_model(self, raw: dict, path: str) -> NszInfo:
-        # Direct indexing mirrors z3ds: nsz_service.info() always populates the
-        # required fields, so a bare .get() would inject None for them.
-        return NszInfo(
-            file=raw["file"],
-            size=raw["size"],
-            size_display=raw["size_display"],
-            format=raw.get("format"),
-            extension=raw["extension"],
-            compressed=raw["compressed"],
-            compression_type=raw.get("compression_type"),
-        )
+        return NszInfo(**self._basic_info_fields(raw))
 
     def active_pids(self) -> list[int]:
         return self._service.active_pids()

--- a/app/services/tools/romz.py
+++ b/app/services/tools/romz.py
@@ -167,13 +167,7 @@ class RomzTool(BaseTool):
 
     def info_model(self, raw: dict, path: str) -> RomzInfo:
         return RomzInfo(
-            file=raw["file"],
-            size=raw["size"],
-            size_display=raw["size_display"],
-            format=raw.get("format"),
-            extension=raw["extension"],
-            compressed=raw["compressed"],
-            compression_type=raw.get("compression_type"),
+            **self._basic_info_fields(raw),
             contained_name=raw.get("contained_name"),
             original_size=raw.get("original_size"),
             ratio=raw.get("ratio"),

--- a/app/services/tools/z3ds.py
+++ b/app/services/tools/z3ds.py
@@ -125,19 +125,7 @@ class Z3dsTool(BaseTool):
         return await run_in_threadpool(self._service.info, path)
 
     def info_model(self, raw: dict, path: str) -> Z3DSInfo:
-        # Direct indexing is intentional: Z3DSInfo's fields are required and
-        # z3ds_compress_service.info() always populates them (mirrors the
-        # /z3ds-info route). Unlike CHDInfo/DolphinDiscInfo (all-optional),
-        # a bare .get() here would inject None for required fields.
-        return Z3DSInfo(
-            file=raw["file"],
-            size=raw["size"],
-            size_display=raw["size_display"],
-            format=raw.get("format"),
-            extension=raw["extension"],
-            compressed=raw["compressed"],
-            compression_type=raw.get("compression_type"),
-        )
+        return Z3DSInfo(**self._basic_info_fields(raw))
 
     def active_pids(self) -> list[int]:
         return self._service.active_pids()

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -191,6 +191,11 @@ class ToolPlugin(Protocol):
     def verify_stream(self, path: str) -> AsyncGenerator[dict, None]: ...
     async def info(self, path: str) -> dict: ...                    # raw dict
     def info_model(self, raw: dict, path: str) -> BaseModel: ...    # typed model for the API
+    # The five simple "what is this file" models (z3ds/nsz/cso/romz/makeps3iso)
+    # subclass models.BasicFileInfo (file/size/size_display/format/extension/
+    # compressed/compression_type); their info_model() builds the shared fields
+    # via BaseTool._basic_info_fields(raw) and adds only their extras, so the
+    # raw->model mapping is defined once.
 
     # DAT-match fast path: (sha1, match_type) pairs the tool can report
     # cheaply (chdman header/data SHA1 from the metadata cache, dolphin disc

--- a/tests/test_ssot_dedup_185.py
+++ b/tests/test_ssot_dedup_185.py
@@ -134,6 +134,20 @@ def test_convert_gate_extensions_from_registry():
     assert ArchiveService._convert_gate_extensions() == registry.archive_input_extensions()
 
 
+def test_listable_extensions_fails_loudly_on_empty_registry(monkeypatch):
+    # A broken/unloaded registry (empty union) must raise, not silently return an
+    # empty set that renders as an "empty archive". (archive.py uses the
+    # no-app-prefix ``services.tools.registry``, so patch that one.)
+    from services.tools import registry as reg
+
+    monkeypatch.setattr(reg, "convertible_extensions", frozenset)
+    monkeypatch.setattr(reg, "archive_input_extensions", frozenset)
+    with pytest.raises(RuntimeError):
+        ArchiveService._listable_extensions()
+    with pytest.raises(RuntimeError):
+        ArchiveService._convert_gate_extensions()
+
+
 # --- Item 6: the single live-conversion predicate -----------------------------
 
 def _job(mode, status):

--- a/tests/test_ssot_dedup_185.py
+++ b/tests/test_ssot_dedup_185.py
@@ -1,0 +1,160 @@
+"""Tests for the #185 SSOT de-duplication seams.
+
+Each backend fact that was defined in 2-5 places now has one definition; these
+lock that in. The broad behavior is covered by the existing route/queue suites
+(which stay green because the refactor is behavior-preserving).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+
+from app.models import (
+    BasicFileInfo,
+    ConversionJob,
+    ConversionMode,
+    CsoInfo,
+    JobStatus,
+    NszInfo,
+    Ps3IsoInfo,
+    RomzInfo,
+    Z3DSInfo,
+)
+from app.routes import convert as convert_routes
+from app.services.archive import ARCHIVE_EXTENSIONS, ArchiveService
+from app.services.job_manager import _is_active_conversion, _is_conversion_job
+from app.services.tools import registry
+from app.services.tools.base import BaseTool
+
+
+# --- Item 1: shared request validation (single + batch use one path) ----------
+
+def test_validate_request_compression_rejects_unsupported():
+    spec = registry.spec("dolphin_iso")
+    with pytest.raises(HTTPException) as ei:
+        convert_routes._validate_request_compression(spec, "dolphin_iso", "zstd")
+    assert ei.value.status_code == 400
+    # no compression requested -> no-op
+    convert_routes._validate_request_compression(spec, "dolphin_iso", None)
+
+
+def test_validate_request_compression_allows_supported():
+    # chdman create accepts a codec -> no raise.
+    convert_routes._validate_request_compression(registry.spec("createcd"), "createcd", "zlib")
+
+
+def test_validate_delete_on_verify():
+    unsupported = registry.spec("romz_extract")  # supports_delete_on_verify=False
+    with pytest.raises(HTTPException) as ei:
+        convert_routes._validate_delete_on_verify(unsupported, True)
+    assert ei.value.status_code == 400
+    assert ei.value.detail == convert_routes._DELETE_ON_VERIFY_UNSUPPORTED_DETAIL
+    # a supported mode, or delete_on_verify not requested -> no-op
+    convert_routes._validate_delete_on_verify(registry.spec("createcd"), True)
+    convert_routes._validate_delete_on_verify(unsupported, False)
+
+
+# --- Items 2 & 3: single-definition strings / tokens --------------------------
+
+def test_delete_on_verify_detail_is_single_constant():
+    assert "Delete-on-verify is only supported" in (
+        convert_routes._DELETE_ON_VERIFY_UNSUPPORTED_DETAIL
+    )
+
+
+def test_confirmation_tokens_match_frontend():
+    # Must equal the values the frontend mirrors in src/lib/api/client.js (CONFIRM).
+    assert convert_routes.ACTION_CONFIRM_HEADER == "x-chd-action-confirm"
+    assert convert_routes.CONFIRM_CANCEL_ALL_JOBS == "cancel-all-jobs"
+    assert convert_routes.CONFIRM_CLEAR_COMPLETED_JOBS == "clear-completed-jobs"
+
+
+# --- Item 4: BasicFileInfo base + shared raw->model mapping -------------------
+
+@pytest.mark.parametrize("cls", [Z3DSInfo, NszInfo, CsoInfo, RomzInfo, Ps3IsoInfo])
+def test_simple_info_models_subclass_basic(cls):
+    assert issubclass(cls, BasicFileInfo)
+    base_fields = {
+        "file", "size", "size_display", "format",
+        "extension", "compressed", "compression_type",
+    }
+    assert base_fields <= set(cls.model_fields)
+
+
+def test_info_model_extras_preserved():
+    assert {"contained_name", "original_size", "ratio"} <= set(RomzInfo.model_fields)
+    assert {"title", "title_id"} <= set(Ps3IsoInfo.model_fields)
+
+
+def test_basic_info_fields_maps_required_and_optional():
+    raw = {
+        "file": "/g.cso", "size": 5, "size_display": "5 B", "format": "CSO",
+        "extension": ".cso", "compressed": True, "compression_type": "cso",
+    }
+    assert BaseTool._basic_info_fields(raw) == raw
+    # Required fields are indexed directly; absent optionals become None.
+    out = BaseTool._basic_info_fields(
+        {"file": "/g", "size": 1, "size_display": "1 B",
+         "extension": ".x", "compressed": False},
+    )
+    assert out["format"] is None
+    assert out["compression_type"] is None
+
+
+def test_tool_info_model_uses_shared_fields():
+    raw = {
+        "file": "/g.cso", "size": 5, "size_display": "5 B", "format": "CSO",
+        "extension": ".cso", "compressed": True, "compression_type": "cso",
+    }
+    model = registry.for_mode("cso_compress").info_model(raw, "/g.cso")
+    # (class identity is checked structurally — under PYTHONPATH=app the tool
+    # builds ``models.CsoInfo`` while the test imports ``app.models.CsoInfo``,
+    # two distinct objects, so compare by name + the shared-field values.)
+    assert type(model).__name__ == "CsoInfo"
+    assert (model.file, model.size, model.compressed) == ("/g.cso", 5, True)
+    assert model.format == "CSO"
+    assert model.compression_type == "cso"
+
+
+# --- Item 5: registry-authoritative archive extensions (no static fallback) ---
+
+def test_listable_extensions_from_registry():
+    expected = (
+        registry.convertible_extensions()
+        | registry.archive_input_extensions()
+    ) - ARCHIVE_EXTENSIONS
+    assert ArchiveService._listable_extensions() == expected
+    # Archive containers are never listable members.
+    assert not (ArchiveService._listable_extensions() & ARCHIVE_EXTENSIONS)
+
+
+def test_convert_gate_extensions_from_registry():
+    assert ArchiveService._convert_gate_extensions() == registry.archive_input_extensions()
+
+
+# --- Item 6: the single live-conversion predicate -----------------------------
+
+def _job(mode, status):
+    return ConversionJob(
+        id="x", file_path="/f", filename="f", mode=mode, status=status,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_is_conversion_job_excludes_external():
+    assert _is_conversion_job(
+        _job(ConversionMode.METADATA_SCAN, JobStatus.PROCESSING)
+    ) is False
+    assert _is_conversion_job(_job(ConversionMode.CREATECD, JobStatus.QUEUED)) is True
+
+
+def test_is_active_conversion():
+    assert _is_active_conversion(_job(ConversionMode.CREATECD, JobStatus.QUEUED)) is True
+    assert _is_active_conversion(_job(ConversionMode.CREATECD, JobStatus.PROCESSING)) is True
+    # A finished conversion, or any external job, is not an active conversion.
+    assert _is_active_conversion(_job(ConversionMode.CREATECD, JobStatus.COMPLETED)) is False
+    assert _is_active_conversion(
+        _job(ConversionMode.METADATA_SCAN, JobStatus.PROCESSING)
+    ) is False


### PR DESCRIPTION
Closes #185.

A cluster of backend facts each defined in 2–5 places, collapsed to one definition each. **No behavior change** — the existing route/queue suites stay green.

## Changes

1. **Shared request validation** (`convert.py`). `create_job` and `create_batch_jobs` copy-pasted the compression / `dolphin_iso` / `dolphin_gcz` / delete-on-verify checks (Phase 4 merged the *per-file* pipeline but left these request-level checks duplicated). Extracted **`_validate_request_compression(spec, mode, compression)`** + **`_validate_delete_on_verify(spec, delete_on_verify)`**, called by both endpoints.

2. **Delete-on-verify "supported modes" prose** was written 3× (single create, batch, delete-plan). Now one **`_DELETE_ON_VERIFY_UNSUPPORTED_DETAIL`** constant — the support fact already lives on `spec.supports_delete_on_verify`.

3. **Confirmation tokens** (`cancel-all-jobs` / `clear-completed-jobs` / the `X-CHD-Action-Confirm` header) were bare literals in `convert.py`. Now module constants (**`ACTION_CONFIRM_HEADER`**, **`CONFIRM_CANCEL_ALL_JOBS`**, **`CONFIRM_CLEAR_COMPLETED_JOBS`**), so a rename can't silently break the guard. (The frontend already centralizes its side in `client.js`'s `CONFIRM`; the values are asserted to match.)

4. **Five info models repeated the same 7-field shape** (`Z3DSInfo`/`NszInfo`/`CsoInfo`/`RomzInfo`/`Ps3IsoInfo`), and each tool's `info_model()` repeated the same `raw[...] → model` mapping. Added a **`BasicFileInfo`** base the five subclass (romz/ps3iso add their extras) and a **`BaseTool._basic_info_fields(raw)`** helper for the shared mapping.

5. **`archive.py` `CONVERTIBLE_EXTENSIONS`** was a hand-maintained copy of every tool's source set, used as a silent fallback that hid new tools' members. Removed it; `_listable_extensions` / `_convert_gate_extensions` now read the registry directly (it always loads in-app), so an empty union **fails loudly** instead of masking a bug.

6. **Repeated "live conversion job" predicate** (`status in (QUEUED, PROCESSING) and mode not in _EXTERNAL_JOB_MODES`) appeared ~5× across backpressure, `get_queue_depth`, `_get_queued_and_processing_jobs`, `is_stuck`, and a job loop. Factored **`_is_conversion_job(job)`** + **`_is_active_conversion(job)`**.

## Acceptance

- Single and batch create share one validation path; the supported-modes string and the confirmation tokens each have one definition. ✅
- `BasicFileInfo` base in place. ✅
- `pytest -q` green. ✅

## Tests

`tests/test_ssot_dedup_185.py` (new) covers each seam: the validators (reject/allow/no-op), the detail + token constants (token values asserted against the frontend's), the `BasicFileInfo` subclassing + `_basic_info_fields` mapping (required indexed, optionals → `None`), the registry-authoritative archive sets, and the `_is_conversion_job` / `_is_active_conversion` predicate. The existing route/queue/info suites (`test_mode_parity_fixes`, `test_external_job_api`, …) stay green, confirming the refactor is behavior-preserving.

`PYTHONPATH=app python -m pytest -q` → 1008 passed, 1 skipped (the 27 `test_archive_conversion_e2e.py` failures are pre-existing/environmental — missing conversion binaries). `ruff check .` → clean.

## Docs

`docs/DESIGN_tool_plugin_architecture.md`: note the `BasicFileInfo` / `_basic_info_fields` `info_model` seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR de-duplicates backend validation, shared constants, info model fields, archive extension sources, and queue predicates. The main changes are:

- Shared request validation helpers for compression and delete-on-verify checks.
- Central backend constants for destructive queue confirmation tokens and delete-on-verify prose.
- A new `BasicFileInfo` base model and shared raw-info mapping helper for simple tool info models.
- Registry-derived archive extension sets instead of a hand-maintained fallback set.
- Shared conversion-job predicates for queue depth, backpressure, active-job checks, and stuck detection.
- Tests covering the new single-source-of-truth seams.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The refactor appears merge-safe with no code issues identified.

The changes are focused on consolidating duplicate backend logic and shared model shapes while preserving existing behavior, with targeted tests covering the new shared seams and reported full test and lint runs passing aside from noted environment-dependent conversion-binary cases.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran runtime comparison for before/after scenarios and verified HTTP statuses and JSON bodies are identical across exercised cases; differences observed only in commit, temporary path, and timestamp.
- Compared cancel-all and clear-completed endpoints; before-state showed expected 400s for missing/wrong and 200s for correct, and after-state head responses and full JSON bodies matched the same method/path/header matrix; both runs exited with code 0.
- Validated archive-registry behavior; before-run showed empty-union calls using fallback extensions, and after-run head normal sets remained aligned while empty-union calls raised registry-not-loaded messages; the registry validation script was created and executed.
- Checked queue-predicates behavior; outputs matched between before and after runs, with no behavioral diff; the only observed change was the command header in the after-run checkout, as confirmed by the diff artifact.

<a href="https://app.greptile.com/trex/runs/12160170/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/services/job_manager.py`, line 551-554 ([link](https://github.com/pacnpal/compressatorium/blob/164d4cd60426ccd0d352eb59ddb18d8adf143a7f/app/services/job_manager.py#L551-L554)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **External jobs still leak**

   This remaining active-job helper still includes every queued or processing job, including `METADATA_SCAN` and `DAT_MATCH`. `routes/files.py` uses these candidates to reject rename/delete operations, so an external bookkeeping job can still be treated as an active conversion path even though the new `_is_active_conversion()` predicate excludes those modes everywhere else. Use the shared predicate here too so file operations only block on real conversion jobs.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fjob_manager.py%0ALine%3A%20551-554%0A%0AComment%3A%0A**External%20jobs%20still%20leak**%0A%0AThis%20remaining%20active-job%20helper%20still%20includes%20every%20queued%20or%20processing%20job%2C%20including%20%60METADATA_SCAN%60%20and%20%60DAT_MATCH%60.%20%60routes%2Ffiles.py%60%20uses%20these%20candidates%20to%20reject%20rename%2Fdelete%20operations%2C%20so%20an%20external%20bookkeeping%20job%20can%20still%20be%20treated%20as%20an%20active%20conversion%20path%20even%20though%20the%20new%20%60_is_active_conversion%28%29%60%20predicate%20excludes%20those%20modes%20everywhere%20else.%20Use%20the%20shared%20predicate%20here%20too%20so%20file%20operations%20only%20block%20on%20real%20conversion%20jobs.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20job%20in%20self.jobs.values%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20not%20_is_active_conversion%28job%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20continue%0A%20%20%20%20%20%20%20%20%20%20%20%20candidates.append%28%28job.id%2C%20self._candidate_paths%28job%29%29%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2F185-ssot-dedup%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2F185-ssot-dedup%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fjob_manager.py%0ALine%3A%20551-554%0A%0AComment%3A%0A**External%20jobs%20still%20leak**%0A%0AThis%20remaining%20active-job%20helper%20still%20includes%20every%20queued%20or%20processing%20job%2C%20including%20%60METADATA_SCAN%60%20and%20%60DAT_MATCH%60.%20%60routes%2Ffiles.py%60%20uses%20these%20candidates%20to%20reject%20rename%2Fdelete%20operations%2C%20so%20an%20external%20bookkeeping%20job%20can%20still%20be%20treated%20as%20an%20active%20conversion%20path%20even%20though%20the%20new%20%60_is_active_conversion%28%29%60%20predicate%20excludes%20those%20modes%20everywhere%20else.%20Use%20the%20shared%20predicate%20here%20too%20so%20file%20operations%20only%20block%20on%20real%20conversion%20jobs.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20job%20in%20self.jobs.values%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20not%20_is_active_conversion%28job%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20continue%0A%20%20%20%20%20%20%20%20%20%20%20%20candidates.append%28%28job.id%2C%20self._candidate_paths%28job%29%29%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=192&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/lat..."](https://github.com/pacnpal/compressatorium/commit/9cd5fd1cef12b3c77bf57aa1ca3ee01284f61a2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39397544)</sub>

<!-- /greptile_comment -->