### PR TITLE
Finish the SubprocessRunner migration: z3ds / maxcso / nsz (#179)

### DIFF
--- a/app/services/maxcso.py
+++ b/app/services/maxcso.py
@@ -242,12 +242,16 @@ class MaxcsoService:
                 nice_via_wrapper=True,
             ):
                 yield update
-        except (ConversionCancelled, RuntimeError):
-            # maxcso writes straight to output_path, so a cancel or a runner-phase
-            # failure (non-zero exit / stall -> RuntimeError) can leave a partial.
-            # Drop it so a retry isn't blocked by, or silently trusts, a truncated
-            # file. Setup/spawn errors before maxcso writes propagate untouched,
-            # so a pre-existing output is never removed for a no-op failure.
+        except (ConversionCancelled, RuntimeError, asyncio.CancelledError, GeneratorExit):
+            # maxcso writes straight to output_path. These are exactly the
+            # abnormal exits the runner can raise *after* it spawned the child — a
+            # mid-run cancel, a non-zero/stall RuntimeError, or a task-cancellation
+            # / generator close — so a partial may be on disk. Remove it
+            # *synchronously* (a local unlink; awaiting during a cancellation could
+            # be re-cancelled and skip cleanup). A setup error (build_command,
+            # above this try) or a pre-spawn failure (FileNotFoundError from the
+            # runner) is NOT caught here, so a pre-existing output is never deleted
+            # for a conversion that wrote nothing.
             if os.path.exists(output_path):
                 with contextlib.suppress(OSError):
                     os.remove(output_path)

--- a/app/services/maxcso.py
+++ b/app/services/maxcso.py
@@ -204,33 +204,37 @@ class MaxcsoService:
     ) -> AsyncGenerator[dict, None]:
         decompress = mode == "cso_decompress"
         verb = "decompression" if decompress else "compression"
+        # Build the argv and size estimate up front, outside the cleanup guard:
+        # a setup failure (e.g. _build_command rejecting the mode) must never
+        # delete a pre-existing output_path, since maxcso has written nothing.
+        cmd = self._build_command(input_path, output_path, mode, compression)
+
         try:
-            cmd = self._build_command(input_path, output_path, mode, compression)
+            input_size = os.path.getsize(input_path)
+        except OSError:
+            input_size = 0
+        ratio = _DECOMPRESS_RATIO if decompress else _COMPRESS_RATIO
+        expected_size = max(1, int(input_size * ratio))
 
-            try:
-                input_size = os.path.getsize(input_path)
-            except OSError:
-                input_size = 0
-            ratio = _DECOMPRESS_RATIO if decompress else _COMPRESS_RATIO
-            expected_size = max(1, int(input_size * ratio))
+        def _size_progress(size: int) -> dict:
+            return {
+                "progress": output_size_progress(size, expected_size),
+                "message": f"Working... ({size // (1024 * 1024)} MB)",
+            }
 
-            def _size_progress(size: int) -> dict:
-                return {
-                    "progress": output_size_progress(size, expected_size),
-                    "message": f"Working... ({size // (1024 * 1024)} MB)",
-                }
+        yield {"progress": 1, "message": f"Starting CSO {verb}..."}
 
-            yield {"progress": 1, "message": f"Starting CSO {verb}..."}
-
-            # maxcso applies nice/ionice as command wrappers in _build_command
-            # (nice_via_wrapper) to avoid preexec_fn, and prints no parseable
-            # percent (its TTY bar goes silent on a pipe), so size_progress
-            # estimates the bar from the growing -o file.
+        # maxcso applies nice/ionice as command wrappers in _build_command
+        # (nice_via_wrapper) to avoid preexec_fn, and prints no parseable percent
+        # (its TTY bar goes silent on a pipe), so size_progress estimates the bar
+        # from the growing -o file.
+        try:
             async for update in self._runner.run(
                 cmd,
                 input_path=input_path,
                 output_path=output_path,
                 parse_progress=lambda _line: None,
+                initial_progress=1,
                 cancel_event=cancel_event,
                 fail_label="maxcso",
                 complete_message=f"CSO {verb} complete",
@@ -238,23 +242,15 @@ class MaxcsoService:
                 nice_via_wrapper=True,
             ):
                 yield update
-
-        except ConversionCancelled:
-            # maxcso writes straight to output_path, so a cancel can leave a
-            # partial; drop it so a retry isn't blocked by a truncated file.
-            logger.info("maxcso conversion cancelled")
+        except (ConversionCancelled, RuntimeError):
+            # maxcso writes straight to output_path, so a cancel or a runner-phase
+            # failure (non-zero exit / stall -> RuntimeError) can leave a partial.
+            # Drop it so a retry isn't blocked by, or silently trusts, a truncated
+            # file. Setup/spawn errors before maxcso writes propagate untouched,
+            # so a pre-existing output is never removed for a no-op failure.
             if os.path.exists(output_path):
                 with contextlib.suppress(OSError):
                     os.remove(output_path)
-            raise
-        except Exception:
-            # Any other failure (non-zero exit, stall) likewise leaves a partial
-            # behind; remove it so a retry isn't blocked by, or silently trusts,
-            # a truncated file.
-            if os.path.exists(output_path):
-                with contextlib.suppress(OSError):
-                    os.remove(output_path)
-            logger.exception("Error in maxcso.convert")
             raise
 
     # ----- info -------------------------------------------------------------

--- a/app/services/maxcso.py
+++ b/app/services/maxcso.py
@@ -23,19 +23,21 @@ intact (the analog of nsz ``-V`` / z3ds ``zstd -t``).
 """
 import asyncio
 import contextlib
-import logging
 import os
 import struct
-import threading
-import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from config import settings
 from logging_setup import get_logger
 from services.chdman import ConversionCancelled
-from services.subprocess_runner import ioprio_prefix, nice_prefix, verify_timeout
-from services.timeout_policy import compute_progress_stall_timeout
+from services.subprocess_runner import (
+    SubprocessRunner,
+    ioprio_prefix,
+    nice_prefix,
+    output_size_progress,
+    verify_timeout,
+)
 
 # SubprocessRunner "owner" for the shared priority/timeout policy. An optional
 # COMPRESSATORIUM_MAXCSO_* override takes precedence over the tool-neutral
@@ -124,8 +126,10 @@ class MaxcsoService:
 
     def __init__(self):
         self.maxcso_path = settings.maxcso_path
-        self._active_pids: set[int] = set()
-        self._pid_lock = threading.Lock()
+        # convert() delegates its streaming loop to the runner; verify_stream()
+        # still spawns maxcso --crc directly but tracks its PID in the same set,
+        # so active_pids() reflects both.
+        self._runner = SubprocessRunner(owner=_OWNER)
 
     # ----- command ----------------------------------------------------------
 
@@ -156,17 +160,8 @@ class MaxcsoService:
         prefix = nice_prefix(_OWNER) + ioprio_prefix(_OWNER)
         return prefix + cmd
 
-    def _track_pid(self, pid: int):
-        with self._pid_lock:
-            self._active_pids.add(pid)
-
-    def _untrack_pid(self, pid: int):
-        with self._pid_lock:
-            self._active_pids.discard(pid)
-
     def active_pids(self) -> list[int]:
-        with self._pid_lock:
-            return list(self._active_pids)
+        return self._runner.active_pids()
 
     # ----- output paths -----------------------------------------------------
 
@@ -210,33 +205,8 @@ class MaxcsoService:
         decompress = mode == "cso_decompress"
         verb = "decompression" if decompress else "compression"
         try:
-            output_dir = os.path.dirname(output_path)
-            if output_dir:
-                await asyncio.to_thread(os.makedirs, output_dir, exist_ok=True)
-
             cmd = self._build_command(input_path, output_path, mode, compression)
 
-            # cmd is built from validated settings paths (no shell interpretation);
-            # args are a fixed list, never shell-expanded. nice/ionice are applied
-            # as command wrappers in _build_command, so there's no preexec_fn.
-            process = await asyncio.create_subprocess_exec(  # nosemgrep
-                cmd[0], *cmd[1:],
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-            )
-            if process.stdout is None:
-                raise RuntimeError("maxcso stdout is not available")
-
-            self._track_pid(process.pid)
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug("Starting maxcso pid=%s cmd=%s", process.pid, " ".join(cmd))
-
-            stall_timeout = compute_progress_stall_timeout(
-                input_path=input_path,
-                base_timeout=getattr(settings, "progress_timeout", 0),
-                timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
-                timeout_cap=getattr(settings, "progress_timeout_cap", 0),
-            )
             try:
                 input_size = os.path.getsize(input_path)
             except OSError:
@@ -244,117 +214,47 @@ class MaxcsoService:
             ratio = _DECOMPRESS_RATIO if decompress else _COMPRESS_RATIO
             expected_size = max(1, int(input_size * ratio))
 
-            last_output_size: int | None = None
-            last_activity_at = time.monotonic()
+            def _size_progress(size: int) -> dict:
+                return {
+                    "progress": output_size_progress(size, expected_size),
+                    "message": f"Working... ({size // (1024 * 1024)} MB)",
+                }
 
-            cancelled_by_request = False
-            cancel_task = None
-            if cancel_event:
+            yield {"progress": 1, "message": f"Starting CSO {verb}..."}
 
-                async def _cancel_watcher():
-                    nonlocal cancelled_by_request
-                    await cancel_event.wait()
-                    cancelled_by_request = True
-                    try:
-                        process.terminate()
-                        await asyncio.wait_for(process.wait(), timeout=5)
-                    except asyncio.TimeoutError:
-                        process.kill()
-                    except ProcessLookupError:
-                        pass
+            # maxcso applies nice/ionice as command wrappers in _build_command
+            # (nice_via_wrapper) to avoid preexec_fn, and prints no parseable
+            # percent (its TTY bar goes silent on a pipe), so size_progress
+            # estimates the bar from the growing -o file.
+            async for update in self._runner.run(
+                cmd,
+                input_path=input_path,
+                output_path=output_path,
+                parse_progress=lambda _line: None,
+                cancel_event=cancel_event,
+                fail_label="maxcso",
+                complete_message=f"CSO {verb} complete",
+                size_progress=_size_progress,
+                nice_via_wrapper=True,
+            ):
+                yield update
 
-                cancel_task = asyncio.create_task(_cancel_watcher())
-
-            output_tail: list[str] = []
-
-            try:
-                yield {"progress": 1, "message": f"Starting CSO {verb}..."}
-
-                while True:
-                    try:
-                        chunk = await asyncio.wait_for(process.stdout.read(256), timeout=2.0)
-                    except asyncio.TimeoutError:
-                        chunk = None
-
-                    if chunk == b"":
-                        break
-
-                    if chunk:
-                        text = chunk.decode("utf-8", errors="replace").strip()
-                        if text:
-                            output_tail.append(text)
-                            if len(output_tail) > 30:
-                                output_tail.pop(0)
-                        last_activity_at = time.monotonic()
-
-                    # Estimate progress from the growing output file.
-                    if os.path.exists(output_path):
-                        try:
-                            current = os.path.getsize(output_path)
-                        except OSError:
-                            current = None
-                        if current is not None and current != last_output_size:
-                            last_output_size = current
-                            last_activity_at = time.monotonic()
-                            pct = min(95, max(1, int(current / expected_size * 90) + 5))
-                            yield {
-                                "progress": pct,
-                                "message": f"Working... ({current // (1024 * 1024)} MB)",
-                            }
-
-                    if process.returncode is not None:
-                        break
-
-                    if stall_timeout > 0 and (time.monotonic() - last_activity_at) > stall_timeout:
-                        logger.warning(
-                            "maxcso pid=%s stalled (no progress for %ds), killing",
-                            process.pid, stall_timeout,
-                        )
-                        with contextlib.suppress(ProcessLookupError):
-                            process.kill()
-                        raise TimeoutError(
-                            f"Conversion stalled (no progress for {stall_timeout}s)",
-                        )
-
-                await process.wait()
-            finally:
-                if cancel_task:
-                    cancel_task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await cancel_task
-                if process.returncode is None:
-                    with contextlib.suppress(ProcessLookupError):
-                        process.kill()
-                    with contextlib.suppress(Exception):
-                        await process.wait()
-                self._untrack_pid(process.pid)
-
-            if cancelled_by_request:
-                if os.path.exists(output_path):
-                    with contextlib.suppress(OSError):
-                        os.remove(output_path)
-                raise ConversionCancelled("Conversion cancelled by user")
-
-            if process.returncode != 0:
-                tail = "\n".join(output_tail[-10:]) if output_tail else "Unknown error"
-                raise RuntimeError(
-                    f"maxcso failed with exit code {process.returncode}: {tail}",
-                )
-
-            yield {"progress": 100, "message": f"CSO {verb} complete"}
-
-        except ConversionCancelled as e:
-            logger.info("maxcso conversion cancelled: %s", e)
-            raise
-        except Exception as e:
-            # Any failure (nonzero exit, stall timeout, etc.) leaves a partial
-            # output on disk because maxcso writes straight to output_path.
-            # Remove it so a retry isn't blocked by, or silently trusts, a
-            # truncated file. (The cancel path above already cleans up.)
+        except ConversionCancelled:
+            # maxcso writes straight to output_path, so a cancel can leave a
+            # partial; drop it so a retry isn't blocked by a truncated file.
+            logger.info("maxcso conversion cancelled")
             if os.path.exists(output_path):
                 with contextlib.suppress(OSError):
                     os.remove(output_path)
-            logger.exception("Error in maxcso.convert: %s", e)
+            raise
+        except Exception:
+            # Any other failure (non-zero exit, stall) likewise leaves a partial
+            # behind; remove it so a retry isn't blocked by, or silently trusts,
+            # a truncated file.
+            if os.path.exists(output_path):
+                with contextlib.suppress(OSError):
+                    os.remove(output_path)
+            logger.exception("Error in maxcso.convert")
             raise
 
     # ----- info -------------------------------------------------------------
@@ -450,7 +350,7 @@ class MaxcsoService:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )
-            self._track_pid(process.pid)
+            self._runner.track_pid(process.pid)
             try:
                 yield {"type": "progress", "progress": 0, "message": "Verifying integrity..."}
                 # Bound a hung/very-slow --crc by the shared verify timeout
@@ -502,7 +402,7 @@ class MaxcsoService:
                         process.kill()
                     with contextlib.suppress(Exception):
                         await process.wait()
-                self._untrack_pid(process.pid)
+                self._runner.untrack_pid(process.pid)
         except Exception as e:
             logger.exception("Error during CSO verification: %s", e)
             yield {"type": "error", "valid": False, "message": f"Verification error: {e}"}

--- a/app/services/nsz.py
+++ b/app/services/nsz.py
@@ -21,20 +21,21 @@ keeps duplicate handling in the job layer where it belongs.
 """
 import asyncio
 import contextlib
-import logging
 from logging_setup import get_logger
 import os
 import shutil
 import tempfile
-import threading
-import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from config import settings
-from services.chdman import ConversionCancelled
-from services.subprocess_runner import ioprio_prefix, nice_prefix, verify_timeout
-from services.timeout_policy import compute_progress_stall_timeout
+from services.subprocess_runner import (
+    SubprocessRunner,
+    ioprio_prefix,
+    nice_prefix,
+    output_size_progress,
+    verify_timeout,
+)
 from utils.junk import is_junk_entry
 
 # Input -> output extension, both directions. The four extensions are distinct,
@@ -66,8 +67,10 @@ class NszService:
 
     def __init__(self):
         self.nsz_path = settings.nsz_path
-        self._active_pids: set[int] = set()
-        self._pid_lock = threading.Lock()
+        # _run_convert() delegates its streaming loop to the runner; verify_stream()
+        # still spawns nsz -V directly but tracks its PID in the same set, so
+        # active_pids() reflects both.
+        self._runner = SubprocessRunner(owner="nsz")
 
     # ----- keys -------------------------------------------------------------
 
@@ -258,17 +261,8 @@ class NszService:
         prefix = nice_prefix("nsz") + ioprio_prefix("nsz")
         return prefix + cmd
 
-    def _track_pid(self, pid: int):
-        with self._pid_lock:
-            self._active_pids.add(pid)
-
-    def _untrack_pid(self, pid: int):
-        with self._pid_lock:
-            self._active_pids.discard(pid)
-
     def active_pids(self) -> list[int]:
-        with self._pid_lock:
-            return list(self._active_pids)
+        return self._runner.active_pids()
 
     # ----- output paths -----------------------------------------------------
 
@@ -353,29 +347,6 @@ class NszService:
                            env, cancel_event, compression=None) -> AsyncGenerator[dict, None]:
         cmd = self._build_command(input_path, work_dir, mode, compression)
 
-        # cmd is built from validated settings paths (no shell interpretation);
-        # args are a fixed list, never shell-expanded. nice/ionice are applied
-        # as command wrappers in _build_command, so there's no preexec_fn.
-        process = await asyncio.create_subprocess_exec(  # nosemgrep
-            cmd[0], *cmd[1:],
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            env=env,
-        )
-        if process.stdout is None:
-            raise RuntimeError("nsz stdout is not available")
-
-        self._track_pid(process.pid)
-        if logger.isEnabledFor(logging.DEBUG):
-            # Log the argv only; never the keys path contents.
-            logger.debug("Starting nsz pid=%s cmd=%s", process.pid, " ".join(cmd))
-
-        stall_timeout = compute_progress_stall_timeout(
-            input_path=input_path,
-            base_timeout=getattr(settings, "progress_timeout", 0),
-            timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
-            timeout_cap=getattr(settings, "progress_timeout_cap", 0),
-        )
         try:
             input_size = os.path.getsize(input_path)
         except OSError:
@@ -383,101 +354,38 @@ class NszService:
         ratio = _DECOMPRESS_RATIO if mode == "nsz_decompress" else _COMPRESS_RATIO
         expected_size = max(1, int(input_size * ratio))
 
-        last_output_size: int | None = None
-        last_activity_at = time.monotonic()
+        def _size_progress(size: int) -> dict:
+            return {
+                "progress": output_size_progress(size, expected_size),
+                "message": f"Working... ({size // (1024 * 1024)} MB)",
+            }
 
-        cancelled_by_request = False
-        cancel_task = None
-        if cancel_event:
+        yield {"progress": 1, "message": f"Starting Switch {verb}..."}
 
-            async def _cancel_watcher():
-                nonlocal cancelled_by_request
-                await cancel_event.wait()
-                cancelled_by_request = True
-                try:
-                    process.terminate()
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except asyncio.TimeoutError:
-                    process.kill()
-                except ProcessLookupError:
-                    pass
-
-            cancel_task = asyncio.create_task(_cancel_watcher())
-
-        output_tail: list[str] = []
-
-        try:
-            yield {"progress": 1, "message": f"Starting Switch {verb}..."}
-
-            while True:
-                try:
-                    chunk = await asyncio.wait_for(process.stdout.read(256), timeout=2.0)
-                except asyncio.TimeoutError:
-                    chunk = None
-
-                if chunk == b"":
-                    break
-
-                if chunk:
-                    text = chunk.decode("utf-8", errors="replace").strip()
-                    if text:
-                        output_tail.append(text)
-                        if len(output_tail) > 30:
-                            output_tail.pop(0)
-                    last_activity_at = time.monotonic()
-
-                # Estimate progress from the growing output file.
-                if os.path.exists(produced_path):
-                    try:
-                        current = os.path.getsize(produced_path)
-                    except OSError:
-                        current = None
-                    if current is not None and current != last_output_size:
-                        last_output_size = current
-                        last_activity_at = time.monotonic()
-                        pct = min(95, max(1, int(current / expected_size * 90) + 5))
-                        yield {
-                            "progress": pct,
-                            "message": f"Working... ({current // (1024 * 1024)} MB)",
-                        }
-
-                if process.returncode is not None:
-                    break
-
-                if stall_timeout > 0 and (time.monotonic() - last_activity_at) > stall_timeout:
-                    logger.warning(
-                        "nsz pid=%s stalled (no progress for %ds), killing",
-                        process.pid, stall_timeout,
-                    )
-                    with contextlib.suppress(ProcessLookupError):
-                        process.kill()
-                    raise TimeoutError(
-                        f"Conversion stalled (no progress for {stall_timeout}s)",
-                    )
-
-            await process.wait()
-        finally:
-            if cancel_task:
-                cancel_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await cancel_task
-            if process.returncode is None:
-                with contextlib.suppress(ProcessLookupError):
-                    process.kill()
-                with contextlib.suppress(Exception):
-                    await process.wait()
-            self._untrack_pid(process.pid)
-
-        if cancelled_by_request:
-            raise ConversionCancelled("Conversion cancelled by user")
-
-        if process.returncode != 0:
-            tail = "\n".join(output_tail[-10:]) if output_tail else "Unknown error"
-            raise RuntimeError(f"nsz failed with exit code {process.returncode}: {tail}")
+        # nsz names the file itself inside work_dir, so the runner watches
+        # produced_path for growth/stall. nice/ionice are command wrappers in
+        # _build_command (nice_via_wrapper) and the private keys-home env is
+        # forwarded; nsz prints no parseable percent, so size_progress drives the
+        # bar. The terminal 100% is held back — convert() emits it after the
+        # os.replace onto the real output_path.
+        async for update in self._runner.run(
+            cmd,
+            input_path=input_path,
+            output_path=produced_path,
+            parse_progress=lambda _line: None,
+            cancel_event=cancel_event,
+            fail_label="nsz",
+            complete_message=f"Switch {verb} complete",
+            size_progress=_size_progress,
+            nice_via_wrapper=True,
+            env=env,
+        ):
+            if update.get("progress", 0) >= 100:
+                continue
+            yield update
 
         if not os.path.exists(produced_path):
-            tail = "\n".join(output_tail[-10:]) if output_tail else ""
-            raise RuntimeError(f"nsz produced no output file. {tail}".strip())
+            raise RuntimeError("nsz produced no output file")
 
     # ----- info -------------------------------------------------------------
 
@@ -571,7 +479,7 @@ class NszService:
                     stderr=asyncio.subprocess.STDOUT,
                     env=env,
                 )
-                self._track_pid(process.pid)
+                self._runner.track_pid(process.pid)
                 overall_timeout = verify_timeout("nsz")
                 try:
                     yield {"type": "progress", "progress": 0, "message": "Verifying integrity..."}
@@ -618,7 +526,7 @@ class NszService:
                             process.kill()
                         with contextlib.suppress(Exception):
                             await process.wait()
-                    self._untrack_pid(process.pid)
+                    self._runner.untrack_pid(process.pid)
         except Exception as e:
             logger.exception("Error during Switch verification: %s", e)
             yield {"type": "error", "valid": False, "message": f"Verification error: {e}"}

--- a/app/services/nsz.py
+++ b/app/services/nsz.py
@@ -373,6 +373,7 @@ class NszService:
             input_path=input_path,
             output_path=produced_path,
             parse_progress=lambda _line: None,
+            initial_progress=1,
             cancel_event=cancel_event,
             fail_label="nsz",
             complete_message=f"Switch {verb} complete",

--- a/app/services/nsz.py
+++ b/app/services/nsz.py
@@ -321,6 +321,10 @@ class NszService:
     ) -> AsyncGenerator[dict, None]:
         verb = "decompression" if mode == "nsz_decompress" else "compression"
         out_dir = os.path.dirname(output_path) or "."
+        # Resolve the produced filename before creating the temp dir, so an
+        # unexpected input extension (KeyError) surfaces here rather than
+        # orphaning an empty .nsz-* work dir.
+        produced_name = self._produced_name(input_path)
         await asyncio.to_thread(os.makedirs, out_dir, exist_ok=True)
 
         # Private temp dir on the same filesystem as the destination, so moving
@@ -328,7 +332,7 @@ class NszService:
         work_dir = await asyncio.to_thread(
             tempfile.mkdtemp, prefix=".nsz-", dir=out_dir,
         )
-        produced_path = os.path.join(work_dir, self._produced_name(input_path))
+        produced_path = os.path.join(work_dir, produced_name)
 
         try:
             with self._keys_home() as env:

--- a/app/services/nsz.py
+++ b/app/services/nsz.py
@@ -371,7 +371,9 @@ class NszService:
         # _build_command (nice_via_wrapper) and the private keys-home env is
         # forwarded; nsz prints no parseable percent, so size_progress drives the
         # bar. The terminal 100% is held back — convert() emits it after the
-        # os.replace onto the real output_path.
+        # os.replace onto the real output_path. require_output makes the runner
+        # raise (with the stdout tail) when nsz exits 0 but leaves no produced
+        # file, so the reason it printed isn't lost.
         async for update in self._runner.run(
             cmd,
             input_path=input_path,
@@ -384,13 +386,11 @@ class NszService:
             size_progress=_size_progress,
             nice_via_wrapper=True,
             env=env,
+            require_output=True,
         ):
             if update.get("progress", 0) >= 100:
                 continue
             yield update
-
-        if not os.path.exists(produced_path):
-            raise RuntimeError("nsz produced no output file")
 
     # ----- info -------------------------------------------------------------
 

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -392,11 +392,18 @@ class SubprocessRunner:
                         self._logger.debug(
                             "Cancelling %s pid=%s", self._owner, process.pid,
                         )
-                    process.terminate()
                     try:
+                        process.terminate()
                         await asyncio.wait_for(process.wait(), timeout=5)
                     except asyncio.TimeoutError:
-                        process.kill()
+                        with contextlib.suppress(ProcessLookupError):
+                            process.kill()
+                    except ProcessLookupError:
+                        # The child exited between the returncode check and
+                        # terminate(); the cancel is already recorded, so swallow
+                        # it. Otherwise the watcher task ends in an exception that
+                        # the finally re-raises, masking the run's real result.
+                        pass
 
                 cancel_task = asyncio.create_task(_cancel_watcher())
 
@@ -479,11 +486,14 @@ class SubprocessRunner:
                     f" output_size={last_output_size})"
                 )
                 if process.returncode is None:
-                    process.terminate()
                     try:
+                        process.terminate()
                         await asyncio.wait_for(process.wait(), timeout=5)
                     except asyncio.TimeoutError:
-                        process.kill()
+                        with contextlib.suppress(ProcessLookupError):
+                            process.kill()
+                    except ProcessLookupError:
+                        pass
                 return True
 
             while True:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -496,6 +496,12 @@ class SubprocessRunner:
                     )
                 except asyncio.TimeoutError:
                     if cancel_event and cancel_event.is_set():
+                        # Breaking because the event is set means this run
+                        # observed the cancellation; record it so the post-loop
+                        # check raises ConversionCancelled even if the child has
+                        # since exited 0 (the watcher skips marking the request
+                        # once returncode is set).
+                        cancelled_by_request = True
                         break
                     now = time.monotonic()
                     update = _size_update(now)

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -131,7 +131,7 @@ def verify_timeout(owner: str | None = None) -> int:
 
 
 def output_size_progress(current: int, expected_size: int) -> int:
-    """Estimate a 5–95% progress value from output-file growth.
+    """Estimate a 5-95% progress value from output-file growth.
 
     The shared progress estimate for tools whose subprocess draws a TTY
     progress bar that falls silent on a pipe (``maxcso``, ``nsz``, ``z3ds``):
@@ -271,6 +271,7 @@ class SubprocessRunner:
         input_path: str,
         output_path: str,
         parse_progress: Callable[[str], int | None],
+        initial_progress: int = 0,
         cancel_event: asyncio.Event | None = None,
         heartbeat: bool = False,
         fail_label: str = "process",
@@ -301,10 +302,12 @@ class SubprocessRunner:
         ``size_progress(output_size) -> dict | None`` turns the measured output
         size into a progress update for tools whose CLI prints no parseable
         percent (its TTY bar goes silent on a pipe): on each output-growth tick
-        the runner calls it and yields its ``{"progress", "message"}`` (and
-        raises the progress floor so a later non-parseable line cannot reset the
-        bar). ``parse_progress`` still wins when it returns a percent. See
-        :func:`output_size_progress` for the shared estimate.
+        the runner calls it and yields its ``{"progress", "message"}``, clamped
+        to never drop below the current floor. ``parse_progress`` still wins when
+        it returns a percent. See :func:`output_size_progress` for the shared
+        estimate. ``initial_progress`` seeds that floor with the caller's preamble
+        (e.g. a service's "Starting..." yield at 1/5%) so an early non-parseable
+        line cannot drop the bar below it.
 
         ``nice_via_wrapper`` skips the ``preexec_fn`` renice when the caller has
         already prefixed ``cmd`` with ``nice``/``ionice`` command wrappers
@@ -359,7 +362,11 @@ class SubprocessRunner:
                 timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
                 timeout_cap=getattr(settings, "progress_timeout_cap", 0),
             )
-            last_progress_value = 0
+            # Seed the progress floor with the caller's preamble (e.g. the
+            # service's "Starting..." yield at 1/5%) so an early non-parseable
+            # stdout line — which emits last_progress_value — can't drop the bar
+            # below it before the first size-growth tick.
+            last_progress_value = initial_progress
             last_output_size: int | None = None
             last_activity_at = time.monotonic()
             start = last_activity_at
@@ -427,10 +434,11 @@ class SubprocessRunner:
             def _size_update(now: float) -> dict | None:
                 # Size-based progress for tools whose CLI prints no parseable
                 # percent (maxcso/nsz/z3ds): on each output-growth tick, refresh
-                # the stall clock, raise the progress floor so a later
-                # non-parseable line can't reset the bar, and return the tool's
-                # {"progress","message"} update to yield. No-op (returns None)
-                # for every existing caller, which leaves size_progress unset.
+                # the stall clock, advance the progress floor, and return the
+                # tool's {"progress","message"} update to yield. The emitted
+                # progress is clamped to the floor so a size estimate can never
+                # drop the bar below a higher parsed/seeded value. No-op (returns
+                # None) for every existing caller, which leaves size_progress unset.
                 nonlocal last_output_size, last_activity_at, last_progress_value
                 if size_progress is None:
                     return None
@@ -444,8 +452,11 @@ class SubprocessRunner:
                 update = size_progress(size)
                 if update is not None:
                     pct = update.get("progress")
-                    if isinstance(pct, int) and pct > last_progress_value:
-                        last_progress_value = pct
+                    if isinstance(pct, int):
+                        if pct < last_progress_value:
+                            update = {**update, "progress": last_progress_value}
+                        elif pct > last_progress_value:
+                            last_progress_value = pct
                 return update
 
             async def _check_stall(now: float) -> bool:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -496,12 +496,14 @@ class SubprocessRunner:
                     )
                 except asyncio.TimeoutError:
                     if cancel_event and cancel_event.is_set():
-                        # Breaking because the event is set means this run
-                        # observed the cancellation; record it so the post-loop
-                        # check raises ConversionCancelled even if the child has
-                        # since exited 0 (the watcher skips marking the request
-                        # once returncode is set).
-                        cancelled_by_request = True
+                        # Stop reading once cancellation is requested. A child
+                        # that is still running is terminated by the watcher
+                        # (-> cancelled_by_request -> ConversionCancelled); a
+                        # child that has already exited 0 finished in that instant
+                        # and is reported complete. A cancel that races a clean
+                        # exit delivers the result rather than discarding it (a
+                        # deliberate product choice for this inherently ambiguous
+                        # race).
                         break
                     now = time.monotonic()
                     update = _size_update(now)

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -563,7 +563,16 @@ class SubprocessRunner:
             if stall_error:
                 raise RuntimeError(stall_error)
 
-            if cancelled_by_request:
+            # Treat a set cancel_event as cancellation even when the child
+            # already exited 0 before the watcher marked the request: the
+            # watcher returns early once ``returncode`` is set, so on that race
+            # ``cancelled_by_request`` can stay False. Without this, a cancelled
+            # job whose process happened to finish first would be reported
+            # complete — publishing the output and skipping the caller's cancel
+            # cleanup — instead of raising ConversionCancelled.
+            if cancelled_by_request or (
+                cancel_event is not None and cancel_event.is_set()
+            ):
                 raise ConversionCancelled("Conversion cancelled")
 
             if process.returncode != 0:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -281,6 +281,7 @@ class SubprocessRunner:
         size_progress: Callable[[int], dict | None] | None = None,
         nice_via_wrapper: bool = False,
         env: Mapping[str, str] | None = None,
+        require_output: bool = False,
     ) -> AsyncGenerator[dict, None]:
         """Spawn ``cmd``, stream stdout, and yield ``{"progress", "message"}``.
 
@@ -314,6 +315,13 @@ class SubprocessRunner:
         (maxcso/nsz avoid ``preexec_fn``: forking a Python callable in this
         multithreaded process can deadlock the child before ``exec``).  ``env``
         is forwarded to the subprocess (nsz runs with a private keys-home env).
+
+        ``require_output`` makes a clean exit (return code 0) that left no file
+        at ``output_path`` a failure, raised as a ``RuntimeError`` carrying the
+        same stdout tail as the non-zero-exit path — so a tool that exits 0
+        without producing output still reports the reason it printed first,
+        rather than a bare "no output" message. Used by nsz, whose ``output_path``
+        is the temp file the runner already watches.
         """
         output_dir = os.path.dirname(output_path)
         if output_dir:
@@ -589,6 +597,19 @@ class SubprocessRunner:
                 raise RuntimeError(
                     f"{fail_label} failed with return code {process.returncode}",
                 )
+
+            # A clean exit that left no file at output_path is an anomaly the
+            # caller asked us to enforce (require_output): surface it with the
+            # recorded stdout tail, since a tool that exits 0 without producing
+            # output usually printed the reason first (e.g. nsz, whose output is
+            # the temp file the runner already watches).
+            if require_output and not os.path.exists(output_path):
+                tail = "\n".join(output_lines[-6:])
+                if tail:
+                    raise RuntimeError(
+                        f"{fail_label} produced no output file.\nLast output:\n{tail}",
+                    )
+                raise RuntimeError(f"{fail_label} produced no output file")
 
             yield {"progress": 100, "message": complete_message}
         finally:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -525,14 +525,10 @@ class SubprocessRunner:
                             continue
                         _record_line(line)
                         now = time.monotonic()
-                        # Non-empty stdout is activity: refresh the stall clock so
-                        # a tool that logs status without yet growing its output
-                        # (the size-progress tools, whose parse_progress is a
-                        # no-op) is not killed as stalled.
-                        last_activity_at = now
                         progress = parse_progress(line)
                         if progress is not None and progress > last_progress_value:
                             last_progress_value = progress
+                            last_activity_at = now
                         # Clamp to the running floor (incl. initial_progress) so a
                         # parsed value below it can't move the bar backward.
                         yield {"progress": last_progress_value, "message": line}
@@ -548,10 +544,10 @@ class SubprocessRunner:
                 line = buffer.strip()
                 _record_line(line)
                 now = time.monotonic()
-                last_activity_at = now
                 progress = parse_progress(line)
                 if progress is not None and progress > last_progress_value:
                     last_progress_value = progress
+                    last_activity_at = now
                 yield {"progress": last_progress_value, "message": line}
                 update = _size_update(time.monotonic())
                 if update is not None:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -315,13 +315,6 @@ class SubprocessRunner:
         multithreaded process can deadlock the child before ``exec``).  ``env``
         is forwarded to the subprocess (nsz runs with a private keys-home env).
         """
-        # A job already cancelled before this run begins is a no-op: don't spawn
-        # the tool, so it can never write (and have a caller then delete) an
-        # output. Cancellation that arrives mid-run is handled by the watcher
-        # below; a process that finishes before cancellation is observed is
-        # reported complete (its output stands) rather than falsely cancelled.
-        if cancel_event is not None and cancel_event.is_set():
-            raise ConversionCancelled("Conversion cancelled")
         output_dir = os.path.dirname(output_path)
         if output_dir:
             await run_in_threadpool(os.makedirs, output_dir, exist_ok=True)
@@ -532,18 +525,17 @@ class SubprocessRunner:
                             continue
                         _record_line(line)
                         now = time.monotonic()
+                        # Non-empty stdout is activity: refresh the stall clock so
+                        # a tool that logs status without yet growing its output
+                        # (the size-progress tools, whose parse_progress is a
+                        # no-op) is not killed as stalled.
+                        last_activity_at = now
                         progress = parse_progress(line)
                         if progress is not None and progress > last_progress_value:
                             last_progress_value = progress
-                            last_activity_at = now
-                        yield {
-                            "progress": (
-                                progress
-                                if progress is not None
-                                else last_progress_value
-                            ),
-                            "message": line,
-                        }
+                        # Clamp to the running floor (incl. initial_progress) so a
+                        # parsed value below it can't move the bar backward.
+                        yield {"progress": last_progress_value, "message": line}
                     buffer = parts[-1]
                 now = time.monotonic()
                 update = _size_update(now)
@@ -556,16 +548,11 @@ class SubprocessRunner:
                 line = buffer.strip()
                 _record_line(line)
                 now = time.monotonic()
+                last_activity_at = now
                 progress = parse_progress(line)
                 if progress is not None and progress > last_progress_value:
                     last_progress_value = progress
-                    last_activity_at = now
-                yield {
-                    "progress": (
-                        progress if progress is not None else last_progress_value
-                    ),
-                    "message": line,
-                }
+                yield {"progress": last_progress_value, "message": line}
                 update = _size_update(time.monotonic())
                 if update is not None:
                     yield update

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -36,7 +36,7 @@ import os
 import shutil
 import threading
 import time
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Callable, Mapping
 
 from config import settings
 from fastapi.concurrency import run_in_threadpool
@@ -128,6 +128,23 @@ def info_timeout(owner: str | None = None) -> int:
 def verify_timeout(owner: str | None = None) -> int:
     """Effective ``verify`` subprocess timeout in seconds (0 disables)."""
     return max(0, int(_resolve_policy("verify_timeout", owner) or 0))
+
+
+def output_size_progress(current: int, expected_size: int) -> int:
+    """Estimate a 5–95% progress value from output-file growth.
+
+    The shared progress estimate for tools whose subprocess draws a TTY
+    progress bar that falls silent on a pipe (``maxcso``, ``nsz``, ``z3ds``):
+    with no parseable percent in stdout, the growing output file *is* the
+    progress signal, scored against an expected size (the input size times a
+    per-direction ratio — roughly 0.5 for compress, 2.0 for decompress). The
+    ratio only smooths the bar, so an inexact guess affects perceived
+    smoothness, not correctness. Clamped to ``[5, 95]``; :meth:`SubprocessRunner.run`
+    emits the terminal 100% on a clean exit. ``expected_size`` is floored at 1
+    to avoid a divide-by-zero on a zero-byte input.
+    """
+    expected = expected_size if expected_size > 0 else 1
+    return min(95, max(1, int(current / expected * 90) + 5))
 
 
 class SubprocessRunner:
@@ -260,6 +277,9 @@ class SubprocessRunner:
         complete_message: str = "Conversion complete",
         cwd: str | None = None,
         output_growth_paths: Callable[[], list[str]] | None = None,
+        size_progress: Callable[[int], dict | None] | None = None,
+        nice_via_wrapper: bool = False,
+        env: Mapping[str, str] | None = None,
     ) -> AsyncGenerator[dict, None]:
         """Spawn ``cmd``, stream stdout, and yield ``{"progress", "message"}``.
 
@@ -277,6 +297,20 @@ class SubprocessRunner:
         changes mid-run uses it so the probe keeps following the write — e.g.
         makeps3iso ``-s`` renames the base ``.iso`` to ``.iso.0`` and then writes
         ``.iso.1``/…, which the bare ``output_path`` probe would stop seeing.
+
+        ``size_progress(output_size) -> dict | None`` turns the measured output
+        size into a progress update for tools whose CLI prints no parseable
+        percent (its TTY bar goes silent on a pipe): on each output-growth tick
+        the runner calls it and yields its ``{"progress", "message"}`` (and
+        raises the progress floor so a later non-parseable line cannot reset the
+        bar). ``parse_progress`` still wins when it returns a percent. See
+        :func:`output_size_progress` for the shared estimate.
+
+        ``nice_via_wrapper`` skips the ``preexec_fn`` renice when the caller has
+        already prefixed ``cmd`` with ``nice``/``ionice`` command wrappers
+        (maxcso/nsz avoid ``preexec_fn``: forking a Python callable in this
+        multithreaded process can deadlock the child before ``exec``).  ``env``
+        is forwarded to the subprocess (nsz runs with a private keys-home env).
         """
         output_dir = os.path.dirname(output_path)
         if output_dir:
@@ -284,6 +318,14 @@ class SubprocessRunner:
 
         def _preexec():
             apply_nice(self._owner)
+
+        # nice/ionice: by default renice the forked child via ``preexec_fn``
+        # (ionice, when used, is folded into ``cmd`` by the caller's
+        # ``_build_command``). ``nice_via_wrapper`` callers have instead prefixed
+        # ``cmd`` with ``nice``/``ionice`` command wrappers and must NOT also be
+        # reniced via preexec — forking a Python callable in this multithreaded
+        # process can deadlock the child before ``exec``.
+        use_preexec = os.name == "posix" and not nice_via_wrapper
 
         # cmd is built from validated settings paths (no shell interpretation);
         # create_subprocess_exec passes the arg list directly (shell=False), so
@@ -294,8 +336,9 @@ class SubprocessRunner:
             cmd[0], *cmd[1:],
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
-            preexec_fn=_preexec if os.name == "posix" else None,
+            preexec_fn=_preexec if use_preexec else None,
             cwd=cwd,
+            env=env,
         )
         self.track_pid(process.pid)
         # Everything below runs under try/finally so that if the caller stops
@@ -381,6 +424,30 @@ class SubprocessRunner:
                     last_output_size = size
                     last_activity_at = now
 
+            def _size_update(now: float) -> dict | None:
+                # Size-based progress for tools whose CLI prints no parseable
+                # percent (maxcso/nsz/z3ds): on each output-growth tick, refresh
+                # the stall clock, raise the progress floor so a later
+                # non-parseable line can't reset the bar, and return the tool's
+                # {"progress","message"} update to yield. No-op (returns None)
+                # for every existing caller, which leaves size_progress unset.
+                nonlocal last_output_size, last_activity_at, last_progress_value
+                if size_progress is None:
+                    return None
+                size = _measure_output()
+                if size is None:
+                    return None
+                if last_output_size is not None and size <= last_output_size:
+                    return None
+                last_output_size = size
+                last_activity_at = now
+                update = size_progress(size)
+                if update is not None:
+                    pct = update.get("progress")
+                    if isinstance(pct, int) and pct > last_progress_value:
+                        last_progress_value = pct
+                return update
+
             async def _check_stall(now: float) -> bool:
                 nonlocal stall_error
                 if stall_timeout <= 0:
@@ -410,6 +477,9 @@ class SubprocessRunner:
                     if cancel_event and cancel_event.is_set():
                         break
                     now = time.monotonic()
+                    update = _size_update(now)
+                    if update is not None:
+                        yield update
                     if await _check_stall(now):
                         break
                     if heartbeat and now - last_heartbeat_at >= 2:
@@ -447,7 +517,11 @@ class SubprocessRunner:
                             "message": line,
                         }
                     buffer = parts[-1]
-                if await _check_stall(time.monotonic()):
+                now = time.monotonic()
+                update = _size_update(now)
+                if update is not None:
+                    yield update
+                if await _check_stall(now):
                     break
 
             if buffer.strip():
@@ -464,6 +538,9 @@ class SubprocessRunner:
                     ),
                     "message": line,
                 }
+                update = _size_update(time.monotonic())
+                if update is not None:
+                    yield update
                 await _check_stall(time.monotonic())
 
             await process.wait()

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -315,6 +315,13 @@ class SubprocessRunner:
         multithreaded process can deadlock the child before ``exec``).  ``env``
         is forwarded to the subprocess (nsz runs with a private keys-home env).
         """
+        # A job already cancelled before this run begins is a no-op: don't spawn
+        # the tool, so it can never write (and have a caller then delete) an
+        # output. Cancellation that arrives mid-run is handled by the watcher
+        # below; a process that finishes before cancellation is observed is
+        # reported complete (its output stands) rather than falsely cancelled.
+        if cancel_event is not None and cancel_event.is_set():
+            raise ConversionCancelled("Conversion cancelled")
         output_dir = os.path.dirname(output_path)
         if output_dir:
             await run_in_threadpool(os.makedirs, output_dir, exist_ok=True)
@@ -563,16 +570,12 @@ class SubprocessRunner:
             if stall_error:
                 raise RuntimeError(stall_error)
 
-            # Treat a set cancel_event as cancellation even when the child
-            # already exited 0 before the watcher marked the request: the
-            # watcher returns early once ``returncode`` is set, so on that race
-            # ``cancelled_by_request`` can stay False. Without this, a cancelled
-            # job whose process happened to finish first would be reported
-            # complete — publishing the output and skipping the caller's cancel
-            # cleanup — instead of raising ConversionCancelled.
-            if cancelled_by_request or (
-                cancel_event is not None and cancel_event.is_set()
-            ):
+            # Only raise when this run actually observed cancellation while the
+            # process was still running (the watcher sets the flag only if
+            # returncode was None when the event fired). A child that finished
+            # before cancellation took effect is reported complete — its output
+            # is valid and must not be deleted as a false cancellation.
+            if cancelled_by_request:
                 raise ConversionCancelled("Conversion cancelled")
 
             if process.returncode != 0:

--- a/app/services/z3ds_compress.py
+++ b/app/services/z3ds_compress.py
@@ -176,26 +176,26 @@ class Z3DSCompressService:
         # bar (z3ds_compressor prints no parseable percent): compressed output is
         # ~50% of the source, a decompressed ROM ~2x the compressed container.
         expected_ratio = 2.0 if decompress else 0.5
+        input_size = (
+            os.path.getsize(input_path) if os.path.exists(input_path) else 0
+        )
+        expected_size = max(1, int(input_size * expected_ratio))
+
+        def _size_progress(size: int) -> dict:
+            return {
+                "progress": output_size_progress(size, expected_size),
+                "message": f"{verb_ing}... ({size // (1024 * 1024)} MB)",
+            }
+
+        cmd = self._build_command(input_path, output_path, mode)
+        yield {"progress": 5, "message": f"Starting 3DS {verb}..."}
+
+        # Delegate the streaming spawn / stall / cancel / PID loop to the shared
+        # runner. z3ds keeps preexec nice (owner "z3ds") and folds ionice into
+        # _build_command, so nice_via_wrapper stays False. parse_progress is a
+        # no-op — there is no parseable percent — so size_progress drives the bar
+        # from the growing output file.
         try:
-            input_size = (
-                os.path.getsize(input_path) if os.path.exists(input_path) else 0
-            )
-            expected_size = max(1, int(input_size * expected_ratio))
-
-            def _size_progress(size: int) -> dict:
-                return {
-                    "progress": output_size_progress(size, expected_size),
-                    "message": f"{verb_ing}... ({size // (1024 * 1024)} MB)",
-                }
-
-            cmd = self._build_command(input_path, output_path, mode)
-            yield {"progress": 5, "message": f"Starting 3DS {verb}..."}
-
-            # Delegate the streaming spawn / stall / cancel / PID loop to the
-            # shared runner. z3ds keeps preexec nice (owner "z3ds") and folds
-            # ionice into _build_command, so nice_via_wrapper stays False.
-            # parse_progress is a no-op — there is no parseable percent — so
-            # size_progress drives the bar from the growing output file.
             async for update in self._runner.run(
                 cmd,
                 input_path=input_path,
@@ -208,11 +208,15 @@ class Z3DSCompressService:
                 size_progress=_size_progress,
             ):
                 yield update
-        except ConversionCancelled:
-            # z3ds_compressor writes the container in place, so a cancel can
-            # leave a partial; drop it so a retry isn't blocked by a truncated
-            # file. (A non-zero exit / stall keeps the prior behavior of leaving
-            # the partial in place for inspection.)
+        except (ConversionCancelled, RuntimeError, asyncio.CancelledError, GeneratorExit):
+            # z3ds_compressor writes the container in place. These are the
+            # abnormal exits the runner can raise after it spawned the child — a
+            # mid-run cancel, a non-zero/stall RuntimeError, or a task-cancellation
+            # / generator close — so a partial may be on disk. Remove it
+            # synchronously so a retry isn't blocked by a truncated file. Setup
+            # (above this try) and pre-spawn failures are not caught here, so a
+            # pre-existing output is never deleted for a conversion that wrote
+            # nothing.
             with contextlib.suppress(OSError):
                 if os.path.exists(output_path):
                     os.remove(output_path)

--- a/app/services/z3ds_compress.py
+++ b/app/services/z3ds_compress.py
@@ -5,8 +5,6 @@ from logging_setup import get_logger
 import os
 import shutil
 import struct
-import threading
-import time
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
@@ -14,8 +12,12 @@ import aiofiles
 from config import settings
 from fastapi.concurrency import run_in_threadpool
 from services.chdman import ConversionCancelled
-from services.subprocess_runner import apply_nice, ioprio_prefix, verify_timeout
-from services.timeout_policy import compute_progress_stall_timeout
+from services.subprocess_runner import (
+    SubprocessRunner,
+    ioprio_prefix,
+    output_size_progress,
+    verify_timeout,
+)
 
 # Compress inputs (raw 3DS ROMs). The upstream fork
 # (https://github.com/pacnpal/z3ds_compress) added .cxi/.3dsx alongside the
@@ -52,8 +54,10 @@ class Z3DSCompressService:
 
     def __init__(self):
         self.z3ds_compressor_path = settings.z3ds_compressor_path
-        self._active_pids: set[int] = set()
-        self._pid_lock = threading.Lock()
+        # convert() and verify_stream() share the runner's PID set so a single
+        # active_pids() sees both; convert() delegates its whole streaming loop
+        # to the runner (verify_stream still spawns zstd directly).
+        self._runner = SubprocessRunner(owner="z3ds")
 
     def _build_command(
         self,
@@ -83,17 +87,8 @@ class Z3DSCompressService:
 
         return cmd
 
-    def _track_pid(self, pid: int):
-        with self._pid_lock:
-            self._active_pids.add(pid)
-
-    def _untrack_pid(self, pid: int):
-        with self._pid_lock:
-            self._active_pids.discard(pid)
-
     def active_pids(self) -> list[int]:
-        with self._pid_lock:
-            return list(self._active_pids)
+        return self._runner.active_pids()
 
     @staticmethod
     async def _get_verify_payload_offset(file_path: str) -> int:
@@ -177,202 +172,49 @@ class Z3DSCompressService:
         decompress = mode == "z3ds_decompress"
         verb = "decompression" if decompress else "compression"
         verb_ing = "Decompressing" if decompress else "Compressing"
-        # Rough output:input size ratio, used only to smooth the progress bar:
-        # compressed output is ~50% of the source, a decompressed ROM ~2x the
-        # compressed container.
+        # Rough output:input size ratio, only to smooth the size-based progress
+        # bar (z3ds_compressor prints no parseable percent): compressed output is
+        # ~50% of the source, a decompressed ROM ~2x the compressed container.
         expected_ratio = 2.0 if decompress else 0.5
         try:
-            # Ensure output directory exists
-            output_dir = os.path.dirname(output_path)
-            if output_dir:
-                await run_in_threadpool(os.makedirs, output_dir, exist_ok=True)
+            input_size = (
+                os.path.getsize(input_path) if os.path.exists(input_path) else 0
+            )
+            expected_size = max(1, int(input_size * expected_ratio))
+
+            def _size_progress(size: int) -> dict:
+                return {
+                    "progress": output_size_progress(size, expected_size),
+                    "message": f"{verb_ing}... ({size // (1024 * 1024)} MB)",
+                }
 
             cmd = self._build_command(input_path, output_path, mode)
-
-            def _preexec():
-                apply_nice("z3ds")
-
-            # cmd is built from validated settings paths (no shell interpretation);
-            # create_subprocess_exec passes args directly without shell expansion.
-            process = await asyncio.create_subprocess_exec(
-                cmd[0], *cmd[1:],
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                preexec_fn=_preexec if os.name == "posix" else None,
-            )
-            if process.stdout is None:
-                raise RuntimeError("z3ds_compressor stdout is not available")
-
-            self._track_pid(process.pid)
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug(
-                    "Starting z3ds_compressor pid=%s cmd=%s",
-                    process.pid,
-                    " ".join(cmd),
-                )
-
-            stall_timeout = compute_progress_stall_timeout(
-                input_path=input_path,
-                base_timeout=getattr(settings, "progress_timeout", 0),
-                timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
-                timeout_cap=getattr(settings, "progress_timeout_cap", 0),
-            )
-            last_output_size: int | None = None
-            last_activity_at = time.monotonic()
-
-            cancelled_by_request = False
-            cancel_task = None
-            if cancel_event:
-
-                async def _cancel_watcher():
-                    nonlocal cancelled_by_request
-                    await cancel_event.wait()
-                    cancelled_by_request = True
-                    try:
-                        process.terminate()
-                        await asyncio.wait_for(process.wait(), timeout=5)
-                    except asyncio.TimeoutError:
-                        process.kill()
-                    except ProcessLookupError:
-                        pass
-
-                cancel_task = asyncio.create_task(_cancel_watcher())
-
             yield {"progress": 5, "message": f"Starting 3DS {verb}..."}
 
-            output_lines: list[str] = []
-            buffer = ""
-
-            def _record_line(raw: str) -> None:
-                line = raw.strip()
-                if not line:
-                    return
-                if not output_lines or output_lines[-1] != line:
-                    output_lines.append(line)
-                    if len(output_lines) > 30:
-                        output_lines.pop(0)
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug("z3ds_compressor output: %s", line)
-
-            try:
-                while True:
-                    try:
-                        chunk = await asyncio.wait_for(process.stdout.read(256), timeout=2.0)
-                    except asyncio.TimeoutError:
-                        chunk = None
-
-                    if chunk == b"":
-                        break
-
-                    if chunk:
-                        buffer += chunk.decode("utf-8", errors="replace")
-                        last_activity_at = time.monotonic()
-
-                        while True:
-                            sep_positions = [
-                                i for i in (buffer.find("\r"), buffer.find("\n")) if i >= 0
-                            ]
-                            if not sep_positions:
-                                break
-                            sep_index = min(sep_positions)
-                            _record_line(buffer[:sep_index])
-                            buffer = buffer[sep_index + 1:]
-                            last_activity_at = time.monotonic()
-
-                    # Check output file size for progress
-                    if os.path.exists(output_path):
-                        try:
-                            current_size = os.path.getsize(output_path)
-                            if last_output_size is None or current_size != last_output_size:
-                                last_output_size = current_size
-                                last_activity_at = time.monotonic()
-                                # Estimate progress from the growing output file
-                                # against an expected output size (input * the
-                                # direction's `expected_ratio`: ~0.5 for compress,
-                                # ~2.0 for decompress). This is *only* for the
-                                # progress bar; the real ratio varies per ROM and
-                                # settings, so deviations affect perceived
-                                # smoothness, not correctness. If progress
-                                # consistently jumps to 100% early or lingers high,
-                                # tune `expected_ratio` (set in `convert`).
-                                if os.path.exists(input_path):
-                                    input_size = os.path.getsize(input_path)
-                                    if input_size > 0:
-                                        expected_output_size = input_size * expected_ratio
-                                        progress = min(
-                                            95,
-                                            int((current_size / expected_output_size) * 90 + 5),
-                                        )
-                                        yield {
-                                            "progress": progress,
-                                            "message": (
-                                                f"{verb_ing}... "
-                                                f"({current_size // (1024*1024)} MB)"
-                                            ),
-                                        }
-                        except OSError:
-                            pass
-
-                    if process.returncode is not None:
-                        break
-
-                    # Check for stalls
-                    if stall_timeout > 0:
-                        elapsed_since_activity = time.monotonic() - last_activity_at
-                        if elapsed_since_activity > stall_timeout:
-                            logger.warning(
-                                "z3ds_compressor pid=%s stalled (no progress for %ds), killing",
-                                process.pid, int(elapsed_since_activity),
-                            )
-                            try:
-                                process.kill()
-                            except ProcessLookupError:
-                                pass
-                            raise TimeoutError(
-                                f"{verb.capitalize()} stalled (no progress for {stall_timeout}s)",
-                            )
-
-                await process.wait()
-
-                if buffer.strip():
-                    _record_line(buffer)
-
-            finally:
-                if cancel_task:
-                    cancel_task.cancel()
-                    try:
-                        await cancel_task
-                    except asyncio.CancelledError:
-                        pass
-                if process.returncode is None:
-                    with contextlib.suppress(ProcessLookupError):
-                        process.kill()
-                    with contextlib.suppress(Exception):
-                        await process.wait()
-                self._untrack_pid(process.pid)
-
-            if cancelled_by_request:
-                # Clean up partial output
+            # Delegate the streaming spawn / stall / cancel / PID loop to the
+            # shared runner. z3ds keeps preexec nice (owner "z3ds") and folds
+            # ionice into _build_command, so nice_via_wrapper stays False.
+            # parse_progress is a no-op — there is no parseable percent — so
+            # size_progress drives the bar from the growing output file.
+            async for update in self._runner.run(
+                cmd,
+                input_path=input_path,
+                output_path=output_path,
+                parse_progress=lambda _line: None,
+                cancel_event=cancel_event,
+                fail_label="z3ds_compressor",
+                complete_message=f"3DS {verb} complete",
+                size_progress=_size_progress,
+            ):
+                yield update
+        except ConversionCancelled:
+            # z3ds_compressor writes the container in place, so a cancel can
+            # leave a partial; drop it so a retry isn't blocked by a truncated
+            # file. (A non-zero exit / stall keeps the prior behavior of leaving
+            # the partial in place for inspection.)
+            with contextlib.suppress(OSError):
                 if os.path.exists(output_path):
-                    try:
-                        os.remove(output_path)
-                    except OSError:
-                        pass
-                raise ConversionCancelled(f"{verb.capitalize()} cancelled by user")
-
-            if process.returncode != 0:
-                error_msg = "\n".join(output_lines[-10:]) if output_lines else "Unknown error"
-                raise RuntimeError(
-                    f"z3ds_compressor failed with exit code {process.returncode}: {error_msg}",
-                )
-
-            yield {"progress": 100, "message": f"3DS {verb} complete"}
-
-        except ConversionCancelled as e:
-            logger.info("z3ds_compress conversion cancelled: %s", e)
-            raise
-        except Exception as e:
-            logger.exception("Error in z3ds_compress.convert: %s", e)
+                    os.remove(output_path)
             raise
 
     def info(self, file_path: str) -> dict:
@@ -559,7 +401,7 @@ class Z3DSCompressService:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            self._track_pid(process.pid)
+            self._runner.track_pid(process.pid)
             overall_timeout = verify_timeout("z3ds")
 
             try:
@@ -641,7 +483,7 @@ class Z3DSCompressService:
                         process.kill()
                     with contextlib.suppress(Exception):
                         await process.wait()
-                self._untrack_pid(process.pid)
+                self._runner.untrack_pid(process.pid)
 
         except Exception as e:
             logger.exception("Error during 3DS verification: %s", e)

--- a/app/services/z3ds_compress.py
+++ b/app/services/z3ds_compress.py
@@ -201,6 +201,7 @@ class Z3DSCompressService:
                 input_path=input_path,
                 output_path=output_path,
                 parse_progress=lambda _line: None,
+                initial_progress=5,
                 cancel_event=cancel_event,
                 fail_label="z3ds_compressor",
                 complete_message=f"3DS {verb} complete",

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -258,8 +258,12 @@ class BaseTool:
 
 ### 3.3 `runner.py`: shared subprocess orchestration
 
-This collapses ~150 near-identical lines now living in each of
-`chdman.py:96`–`334`, `dolphin_tool.py:109`–`356`, `z3ds_compress.py:137`–`347`.
+This collapses the ~150 near-identical lines that were duplicated in every
+tool's `convert()`. All seven conversion tools now delegate their streaming loop
+here: `chdman`, `dolphin_tool`, `romz`, `makeps3iso` directly, and
+`z3ds_compress`, `maxcso`, `nsz` via the size-based-progress seam below (their
+CLIs print no parseable percent, so the growing output file is the progress
+signal).
 
 ```python
 class SubprocessRunner:
@@ -271,17 +275,30 @@ class SubprocessRunner:
     def active_pids(self) -> list[int]: ...
 
     async def run(self, cmd: list[str], *, input_path: str, output_path: str,
-                  parse_progress, cancel_event=None, cwd=None,
-                  start_message="Starting...") -> AsyncGenerator[dict, None]:
+                  parse_progress, cancel_event=None, heartbeat=False,
+                  fail_label="process", complete_message="Conversion complete",
+                  cwd=None, output_growth_paths=None, size_progress=None,
+                  nice_via_wrapper=False, env=None) -> AsyncGenerator[dict, None]:
         """Spawn cmd, stream stdout, yield {"progress","message"}.
-        Handles: nice/ionice wrap, stdbuf, PID tracking, \\r/\\n line buffering,
+        Handles: nice/ionice wrap, PID tracking, \\r/\\n line buffering,
         stall timeout via compute_progress_stall_timeout, cancel-watcher
-        (terminate->kill, clean partial output), ConversionCancelled, non-zero
-        exit -> RuntimeError(tail), final 100%.
-        `parse_progress(line) -> int|None` is the only per-tool knob.
-        `cwd` (optional) sets the subprocess working directory — used by `romz`
-        to run `7z a` from the ROM's directory so the archive stores just the
-        basename, not the absolute volume path.
+        (terminate->kill), ConversionCancelled, non-zero exit -> RuntimeError(tail),
+        final 100%. `parse_progress(line) -> int|None` is the only per-tool knob
+        in the common path. `cwd` sets the working directory (romz runs `7z a`
+        from the ROM dir).
+
+        Opt-in seams, each defaulting off so the direct callers are unaffected:
+        - `heartbeat` — dolphin's 2s "Converting... (Ns)" keep-alive.
+        - `output_growth_paths()` — widen the stall probe to a set of files whose
+          summed size grows even as filenames change mid-run (makeps3iso split).
+        - `size_progress(output_size) -> dict|None` — turn output growth into the
+          emitted progress for tools with no parseable percent (maxcso/nsz/z3ds);
+          see `output_size_progress()` for the shared 5–95% estimate. Also raises
+          the progress floor so a later non-parseable line can't reset the bar.
+        - `nice_via_wrapper` — skip preexec_fn when the caller prefixed cmd with
+          nice/ionice command wrappers (maxcso/nsz avoid forking a Python callable
+          in this multithreaded process before exec). `env` — forwarded to the
+          subprocess (nsz's private keys-home).
         """
 
     async def run_capture(self, cmd: list[str], *, timeout=None,
@@ -300,10 +317,14 @@ class SubprocessRunner:
 
 Per-tool `convert()` becomes ~15 lines: build argv, then
 `async for u in self._runner.run(cmd, ..., parse_progress=self._parse_progress): yield u`.
-The dolphin/z3ds output-size heuristic and dolphin's heartbeat become opt-in
-flags on `run()`. One-shot subprocess work (info / header / embedded-hash
-extraction) shares `run_capture()` rather than re-implementing the
-spawn / cancel / timeout / terminate dance per tool.
+Tools with no parseable percent (maxcso/nsz/z3ds) pass `size_progress=` to drive
+the bar from output growth and `nice_via_wrapper=True` to keep their
+command-wrapper nice; nsz also forwards its keys-home `env=` and writes into a
+private work dir, moving the result onto `output_path` after `run()` returns.
+dolphin's heartbeat and the makeps3iso split-stall probe are likewise opt-in
+flags. One-shot subprocess work (info / header / embedded-hash extraction)
+shares `run_capture()` rather than re-implementing the spawn / cancel / timeout /
+terminate dance per tool.
 
 ### 3.3.1 Shared archive-limit enforcement (`services/archive.py`)
 

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -278,7 +278,8 @@ class SubprocessRunner:
                   parse_progress, cancel_event=None, heartbeat=False,
                   fail_label="process", complete_message="Conversion complete",
                   cwd=None, output_growth_paths=None, size_progress=None,
-                  nice_via_wrapper=False, env=None) -> AsyncGenerator[dict, None]:
+                  nice_via_wrapper=False, env=None,
+                  require_output=False) -> AsyncGenerator[dict, None]:
         """Spawn cmd, stream stdout, yield {"progress","message"}.
         Handles: nice/ionice wrap, PID tracking, \\r/\\n line buffering,
         stall timeout via compute_progress_stall_timeout, cancel-watcher
@@ -299,6 +300,11 @@ class SubprocessRunner:
           nice/ionice command wrappers (maxcso/nsz avoid forking a Python callable
           in this multithreaded process before exec). `env` — forwarded to the
           subprocess (nsz's private keys-home).
+        - `require_output` — treat a clean exit (return code 0) that left no file
+          at `output_path` as a failure, raised as RuntimeError(tail) like the
+          non-zero-exit path, so a tool that exits 0 without producing output
+          still reports the reason it printed first (nsz, whose `output_path` is
+          the temp file the runner already watches).
         """
 
     async def run_capture(self, cmd: list[str], *, timeout=None,
@@ -319,8 +325,9 @@ Per-tool `convert()` becomes ~15 lines: build argv, then
 `async for u in self._runner.run(cmd, ..., parse_progress=self._parse_progress): yield u`.
 Tools with no parseable percent (maxcso/nsz/z3ds) pass `size_progress=` to drive
 the bar from output growth and `nice_via_wrapper=True` to keep their
-command-wrapper nice; nsz also forwards its keys-home `env=` and writes into a
-private work dir, moving the result onto `output_path` after `run()` returns.
+command-wrapper nice; nsz also forwards its keys-home `env=`, sets
+`require_output=True`, and writes into a private work dir, moving the result onto
+`output_path` after `run()` returns.
 dolphin's heartbeat and the makeps3iso split-stall probe are likewise opt-in
 flags. One-shot subprocess work (info / header / embedded-hash extraction)
 shares `run_capture()` rather than re-implementing the spawn / cancel / timeout /

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-Idempotency and robustness hardening (issue #184, part of the #177 tech-debt epic).
+Idempotency, robustness, and modularity hardening (issues #184 and #179, part of
+the #177 tech-debt epic).
 
 ### Changed
 
@@ -15,6 +16,13 @@ Idempotency and robustness hardening (issue #184, part of the #177 tech-debt epi
   An optimistic placeholder is now cleared only when its real job first arrives, not
   on every later progress update, so submitting the same file in the same mode twice
   no longer briefly under-counts the queue.
+- **All conversion tools now share one subprocess loop.** `z3ds`, `maxcso` and `nsz`
+  previously hand-rolled their own ~150-line spawn / stall-timeout / cancel / progress
+  loop; they now delegate to the shared `SubprocessRunner` like `chdman`/`dolphin`/
+  `romz`/`makeps3iso`, so a cancel, stall, or exit-code fix lands in one place instead
+  of drifting between three copies. Progress for these no-parseable-percent tools is
+  still estimated from output-file growth, now via a shared `size_progress` seam, so
+  the conversion bar is unchanged. (issue #179)
 
 ## 4.2.0 (2026-06-13)
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -22,7 +22,10 @@ the #177 tech-debt epic).
   `romz`/`makeps3iso`, so a cancel, stall, or exit-code fix lands in one place instead
   of drifting between three copies. Progress for these no-parseable-percent tools is
   still estimated from output-file growth, now via a shared `size_progress` seam, so
-  the conversion bar is unchanged. (issue #179)
+  the conversion bar is unchanged. Per-tool error parity is preserved too — when nsz
+  exits cleanly but produces no file, the failure still reports the reason nsz printed
+  (via a shared `require_output` seam) instead of a bare "no output" message. (issue
+  #179)
 
 ## 4.2.0 (2026-06-13)
 

--- a/tests/test_cso_service.py
+++ b/tests/test_cso_service.py
@@ -107,7 +107,7 @@ async def test_convert_nonzero_exit_raises(tmp_path, monkeypatch):
 
     monkeypatch.setattr(maxcso_module.asyncio, "create_subprocess_exec", fake_exec)
 
-    with pytest.raises(RuntimeError, match="exit code 1"):
+    with pytest.raises(RuntimeError, match="return code 1"):
         await _drain(service.convert(str(src_path), str(out_path), "cso_compress"))
 
 

--- a/tests/test_cso_service.py
+++ b/tests/test_cso_service.py
@@ -171,6 +171,50 @@ async def test_convert_cancel_removes_partial_output(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_convert_spawn_failure_preserves_existing_output(tmp_path, monkeypatch):
+    """A pre-spawn failure (e.g. missing binary) must NOT delete a pre-existing
+    output: maxcso never ran, so it wrote nothing to remove."""
+    src_path = tmp_path / "game.iso"
+    src_path.write_bytes(b"input")
+    out_path = tmp_path / "game.cso"
+    out_path.write_bytes(b"pre-existing valid output")
+
+    async def fake_exec(*_args, **_kwargs):
+        raise FileNotFoundError("maxcso binary missing")
+
+    monkeypatch.setattr(maxcso_module.asyncio, "create_subprocess_exec", fake_exec)
+
+    with pytest.raises(FileNotFoundError):
+        await _drain(service.convert(str(src_path), str(out_path), "cso_compress"))
+
+    assert out_path.read_bytes() == b"pre-existing valid output"  # untouched
+
+
+@pytest.mark.asyncio
+async def test_convert_cleans_partial_on_generator_close(tmp_path, monkeypatch):
+    """Closing the generator mid-conversion (task cancellation / GeneratorExit)
+    removes the in-place partial — the writer cleans up on BaseException, not
+    only on ConversionCancelled."""
+    src_path = tmp_path / "game.iso"
+    src_path.write_bytes(b"input")
+    out_path = tmp_path / "game.cso"
+
+    async def fake_exec(*args, **_kwargs):
+        _write_output(list(args))  # partial written straight to the -o path
+        return _CancelProcess(pid=21, stop=asyncio.Event())
+
+    monkeypatch.setattr(maxcso_module.asyncio, "create_subprocess_exec", fake_exec)
+
+    gen = service.convert(str(src_path), str(out_path), "cso_compress")
+    assert (await gen.__anext__())["progress"] == 1  # "Starting..." preamble
+    await gen.__anext__()  # enters the runner: spawns (writes partial), reads a line
+    assert out_path.exists()
+
+    await gen.aclose()  # GeneratorExit -> in-place cleanup
+    assert not out_path.exists()
+
+
+@pytest.mark.asyncio
 async def test_verify_passes_on_zero_exit(tmp_path, monkeypatch):
     cso_path = tmp_path / "game.cso"
     cso_path.write_bytes(b"data")

--- a/tests/test_nsz_service.py
+++ b/tests/test_nsz_service.py
@@ -152,7 +152,7 @@ async def test_convert_nonzero_exit_raises(tmp_path, monkeypatch, keys_present):
 
     monkeypatch.setattr(nsz_module.asyncio, "create_subprocess_exec", fake_exec)
 
-    with pytest.raises(RuntimeError, match="exit code 1"):
+    with pytest.raises(RuntimeError, match="return code 1"):
         await _drain(
             nsz_module.nsz_service.convert(str(src_path), str(out_path), "nsz_compress"),
         )

--- a/tests/test_nsz_service.py
+++ b/tests/test_nsz_service.py
@@ -159,6 +159,29 @@ async def test_convert_nonzero_exit_raises(tmp_path, monkeypatch, keys_present):
     assert not out_path.exists()
 
 
+@pytest.mark.asyncio
+async def test_convert_missing_output_raises_with_tail(tmp_path, monkeypatch, keys_present):
+    """nsz exiting 0 without producing a file (e.g. a silent key problem) raises
+    via the runner's require_output guard, surfacing the printed reason in the
+    error rather than a bare "no output" message."""
+    src_path = tmp_path / "game.nsp"
+    src_path.write_bytes(b"input")
+    out_path = tmp_path / "game.nsz"
+
+    async def fake_exec(*_args, **_kwargs):
+        # Exits 0 but never writes the produced file into the work dir.
+        return _FakeProcess(pid=9, chunks=[b"title key missing\n"], returncode=0)
+
+    monkeypatch.setattr(nsz_module.asyncio, "create_subprocess_exec", fake_exec)
+
+    with pytest.raises(RuntimeError, match="produced no output file") as excinfo:
+        await _drain(
+            nsz_module.nsz_service.convert(str(src_path), str(out_path), "nsz_compress"),
+        )
+    assert "title key missing" in str(excinfo.value)
+    assert not out_path.exists()
+
+
 class _CancelStdout:
     def __init__(self, stop: asyncio.Event):
         self._stop = stop

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -235,15 +235,17 @@ def test_cancel_watcher_survives_terminate_processlookuperror(tmp_path, monkeypa
     assert not runner.active_pids()
 
 
-def test_cancel_observed_at_read_timeout_raises_even_if_exited_zero(tmp_path, monkeypatch):
-    """If the loop breaks because cancel_event is set (on a read timeout) while
-    the child has already exited 0, the run observed the cancellation and must
-    raise ConversionCancelled rather than report success.
+def test_cancel_racing_clean_exit_reports_success(tmp_path, monkeypatch):
+    """When cancellation races a clean exit (the child already returned 0), the
+    conversion finished in that instant and is reported complete — a cancel that
+    races a successful completion delivers the result rather than discarding it
+    (a deliberate product choice). The still-running case is covered by
+    test_cancel_event_preset_terminates_and_raises.
     """
 
     class _TimeoutThenExitedProc:
-        """read() always times out and returncode is already 0, so the watcher
-        skips marking the cancel — the loop's event check has to."""
+        """read() times out (no more output) while returncode is already 0, so
+        the watcher skips marking the cancel and the run completes normally."""
 
         def __init__(self):
             self.pid = 555
@@ -270,8 +272,8 @@ def test_cancel_observed_at_read_timeout_raises_even_if_exited_zero(tmp_path, mo
     cancel_event = asyncio.Event()
     cancel_event.set()
 
-    async def _run():
-        return await _drain(
+    updates = asyncio.run(
+        _drain(
             runner.run(
                 _py_cmd("import sys"),
                 input_path=str(tmp_path / "in.bin"),
@@ -281,9 +283,9 @@ def test_cancel_observed_at_read_timeout_raises_even_if_exited_zero(tmp_path, mo
                 fail_label="testproc",
             )
         )
+    )
 
-    with pytest.raises(ConversionCancelled):
-        asyncio.run(_run())
+    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
     assert not runner.active_pids()
 
 

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -235,6 +235,58 @@ def test_cancel_watcher_survives_terminate_processlookuperror(tmp_path, monkeypa
     assert not runner.active_pids()
 
 
+def test_cancel_observed_at_read_timeout_raises_even_if_exited_zero(tmp_path, monkeypatch):
+    """If the loop breaks because cancel_event is set (on a read timeout) while
+    the child has already exited 0, the run observed the cancellation and must
+    raise ConversionCancelled rather than report success.
+    """
+
+    class _TimeoutThenExitedProc:
+        """read() always times out and returncode is already 0, so the watcher
+        skips marking the cancel — the loop's event check has to."""
+
+        def __init__(self):
+            self.pid = 555
+            self.returncode = 0
+            self.stdout = self
+
+        async def read(self, _n: int) -> bytes:
+            raise asyncio.TimeoutError  # the runner wraps read in wait_for(timeout=2)
+
+        async def wait(self) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            pass
+
+        def kill(self) -> None:
+            pass
+
+    async def fake_exec(*_args, **_kwargs):
+        return _TimeoutThenExitedProc()
+
+    monkeypatch.setattr(runner_module.asyncio, "create_subprocess_exec", fake_exec)
+    runner = SubprocessRunner(owner="test")
+    cancel_event = asyncio.Event()
+    cancel_event.set()
+
+    async def _run():
+        return await _drain(
+            runner.run(
+                _py_cmd("import sys"),
+                input_path=str(tmp_path / "in.bin"),
+                output_path=str(tmp_path / "out.bin"),
+                parse_progress=_parse_pct,
+                cancel_event=cancel_event,
+                fail_label="testproc",
+            )
+        )
+
+    with pytest.raises(ConversionCancelled):
+        asyncio.run(_run())
+    assert not runner.active_pids()
+
+
 def test_stall_timeout_raises_runtimeerror(tmp_path, monkeypatch):
     # Force a short stall window; the child emits one line then goes silent and
     # never grows the output file, so the stall watchdog must fire.

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -114,43 +114,15 @@ def test_cancel_event_raises_conversion_cancelled(tmp_path):
     assert not runner.active_pids()
 
 
-def test_cancel_event_preset_short_circuits_before_spawn(tmp_path, monkeypatch):
-    """A cancel_event already set when run() starts raises ConversionCancelled
-    without spawning the child.
+def test_cancel_event_preset_terminates_and_raises(tmp_path):
+    """A cancel_event already set when run() starts is honored by the watcher:
+    the child is spawned, terminated, and ConversionCancelled is raised.
 
-    A job cancelled before it began must do no work, so it can never write (and
-    then have a caller delete) an output. Cancellation the run actually observes
-    mid-flight is covered by test_cancel_event_raises_conversion_cancelled.
+    (The runner intentionally does not short-circuit before spawning, so that a
+    ConversionCancelled always implies the child ran — callers rely on that to
+    avoid deleting an output their conversion never wrote.)
     """
-    spawned = False
-
-    class _UnreachedChild:
-        """Returned only if the short-circuit fails to prevent spawning."""
-
-        pid = 4321
-        returncode = 0
-
-        def __init__(self):
-            self.stdout = self
-
-        async def read(self, _n: int) -> bytes:
-            return b""
-
-        async def wait(self) -> int:
-            return 0
-
-        def terminate(self) -> None:
-            pass
-
-        def kill(self) -> None:
-            pass
-
-    async def fake_exec(*_args, **_kwargs):
-        nonlocal spawned
-        spawned = True
-        return _UnreachedChild()
-
-    monkeypatch.setattr(runner_module.asyncio, "create_subprocess_exec", fake_exec)
+    script = "import time; time.sleep(30)"
     runner = SubprocessRunner(owner="test")
     cancel_event = asyncio.Event()
     cancel_event.set()
@@ -158,7 +130,7 @@ def test_cancel_event_preset_short_circuits_before_spawn(tmp_path, monkeypatch):
     async def _run():
         return await _drain(
             runner.run(
-                _py_cmd("import sys"),
+                _py_cmd(script),
                 input_path=str(tmp_path / "in.bin"),
                 output_path=str(tmp_path / "out.bin"),
                 parse_progress=_parse_pct,
@@ -169,7 +141,34 @@ def test_cancel_event_preset_short_circuits_before_spawn(tmp_path, monkeypatch):
 
     with pytest.raises(ConversionCancelled):
         asyncio.run(_run())
-    assert spawned is False
+    assert not runner.active_pids()
+
+
+def test_spawn_failure_propagates_without_masking(tmp_path, monkeypatch):
+    """A pre-spawn failure (create_subprocess_exec raising) surfaces as-is, with
+    no PID tracked — callers distinguish it from a post-spawn error to avoid
+    deleting an output the conversion never wrote.
+    """
+
+    async def fake_exec(*_args, **_kwargs):
+        raise FileNotFoundError("no such binary")
+
+    monkeypatch.setattr(runner_module.asyncio, "create_subprocess_exec", fake_exec)
+    runner = SubprocessRunner(owner="test")
+
+    async def _run():
+        return await _drain(
+            runner.run(
+                _py_cmd("import sys"),
+                input_path=str(tmp_path / "in.bin"),
+                output_path=str(tmp_path / "out.bin"),
+                parse_progress=_parse_pct,
+                fail_label="testproc",
+            )
+        )
+
+    with pytest.raises(FileNotFoundError):
+        asyncio.run(_run())
     assert not runner.active_pids()
 
 

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -173,6 +173,69 @@ def test_cancel_event_preset_short_circuits_before_spawn(tmp_path, monkeypatch):
     assert not runner.active_pids()
 
 
+def test_cancel_watcher_survives_terminate_processlookuperror(tmp_path, monkeypatch):
+    """If the child exits between the watcher's returncode check and terminate(),
+    the resulting ProcessLookupError must not mask the cancellation.
+
+    Without the guard the watcher task ends in ProcessLookupError, which the
+    finally re-raises over the intended ConversionCancelled.
+    """
+
+    class _RaceProc:
+        """Child whose terminate() raises ProcessLookupError (already exited)."""
+
+        def __init__(self):
+            self.pid = 999
+            self.returncode = None
+            self._stop = asyncio.Event()
+            self.stdout = self
+            self._first = True
+
+        async def read(self, _n: int) -> bytes:
+            if self._first:
+                self._first = False
+                return b"working 10%\n"
+            await self._stop.wait()
+            return b""
+
+        async def wait(self) -> int:
+            await self._stop.wait()
+            if self.returncode is None:
+                self.returncode = 0
+            return self.returncode
+
+        def terminate(self) -> None:
+            self._stop.set()
+            raise ProcessLookupError
+
+        def kill(self) -> None:
+            self._stop.set()
+
+    async def fake_exec(*_args, **_kwargs):
+        return _RaceProc()
+
+    monkeypatch.setattr(runner_module.asyncio, "create_subprocess_exec", fake_exec)
+    runner = SubprocessRunner(owner="test")
+    cancel_event = asyncio.Event()
+
+    async def _run():
+        gen = runner.run(
+            _py_cmd("import sys"),
+            input_path=str(tmp_path / "in.bin"),
+            output_path=str(tmp_path / "out.bin"),
+            parse_progress=_parse_pct,
+            cancel_event=cancel_event,
+            fail_label="testproc",
+        )
+        async for update in gen:
+            if "10%" in update["message"]:
+                cancel_event.set()
+
+    with pytest.raises(ConversionCancelled):
+        asyncio.run(_run())
+    assert not runner.active_pids()
+
+
 def test_stall_timeout_raises_runtimeerror(tmp_path, monkeypatch):
     # Force a short stall window; the child emits one line then goes silent and
     # never grows the output file, so the stall watchdog must fire.

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -87,6 +87,69 @@ def test_nonzero_exit_raises_runtimeerror_with_tail(tmp_path):
     assert not runner.active_pids()
 
 
+def test_require_output_missing_raises_with_tail(tmp_path):
+    """A clean exit (code 0) that leaves no file at output_path is a failure
+    when require_output=True, and the error carries the stdout tail so the
+    reason the tool printed before exiting isn't lost (nsz's prior behavior)."""
+    script = (
+        "import sys\n"
+        "sys.stdout.write('preparing\\n')\n"
+        "sys.stdout.write('keys file missing, nothing written\\n')\n"
+        "sys.exit(0)\n"
+    )
+    runner = SubprocessRunner(owner="test")
+    out = tmp_path / "out.bin"  # the child never creates this
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(
+            _drain(
+                runner.run(
+                    _py_cmd(script),
+                    input_path=str(tmp_path / "in.bin"),
+                    output_path=str(out),
+                    parse_progress=_parse_pct,
+                    fail_label="nsz",
+                    require_output=True,
+                )
+            )
+        )
+
+    message = str(excinfo.value)
+    assert "nsz produced no output file" in message
+    assert "keys file missing, nothing written" in message
+    assert not out.exists()
+    assert not runner.active_pids()
+
+
+def test_require_output_present_completes(tmp_path):
+    """When the child does produce output_path, require_output is satisfied and
+    the run finishes with the normal terminal 100%."""
+    out = tmp_path / "out.bin"
+    script = (
+        "import sys\n"
+        f"open({str(out)!r}, 'wb').write(b'data')\n"
+        "sys.stdout.write('done\\n')\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    updates = asyncio.run(
+        _drain(
+            runner.run(
+                _py_cmd(script),
+                input_path=str(tmp_path / "in.bin"),
+                output_path=str(out),
+                parse_progress=_parse_pct,
+                fail_label="nsz",
+                require_output=True,
+            )
+        )
+    )
+
+    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert out.exists()
+    assert not runner.active_pids()
+
+
 def test_cancel_event_raises_conversion_cancelled(tmp_path):
     script = (
         "import sys, time\n"

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -114,6 +114,60 @@ def test_cancel_event_raises_conversion_cancelled(tmp_path):
     assert not runner.active_pids()
 
 
+def test_cancel_event_wins_even_if_process_exited_zero(tmp_path, monkeypatch):
+    """A set cancel_event raises ConversionCancelled even when the child already
+    exited 0 before the watcher ran (the cancel-vs-completion race).
+
+    The watcher returns early once ``returncode`` is set, so on this race
+    ``cancelled_by_request`` stays False; the runner must still honor the cancel
+    from ``cancel_event`` rather than report the job complete and publish output.
+    """
+
+    class _ExitedProcess:
+        """Child reporting returncode 0 from the start (already exited)."""
+
+        def __init__(self, pid: int):
+            self.pid = pid
+            self.returncode = 0
+            self.stdout = self
+
+        async def read(self, _n: int) -> bytes:
+            return b""
+
+        async def wait(self) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            pass
+
+        def kill(self) -> None:
+            pass
+
+    async def fake_exec(*_args, **_kwargs):
+        return _ExitedProcess(pid=4321)
+
+    monkeypatch.setattr(runner_module.asyncio, "create_subprocess_exec", fake_exec)
+    runner = SubprocessRunner(owner="test")
+    cancel_event = asyncio.Event()
+    cancel_event.set()
+
+    async def _run():
+        return await _drain(
+            runner.run(
+                _py_cmd("import sys"),
+                input_path=str(tmp_path / "in.bin"),
+                output_path=str(tmp_path / "out.bin"),
+                parse_progress=_parse_pct,
+                cancel_event=cancel_event,
+                fail_label="testproc",
+            )
+        )
+
+    with pytest.raises(ConversionCancelled):
+        asyncio.run(_run())
+    assert not runner.active_pids()
+
+
 def test_stall_timeout_raises_runtimeerror(tmp_path, monkeypatch):
     # Force a short stall window; the child emits one line then goes silent and
     # never grows the output file, so the stall watchdog must fire.

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -9,6 +9,7 @@ CLIs are unavailable in the sandbox.
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 import sys
 
@@ -140,6 +141,102 @@ def test_stall_timeout_raises_runtimeerror(tmp_path, monkeypatch):
         )
 
     assert "Conversion stalled" in str(excinfo.value)
+    assert not runner.active_pids()
+
+
+def test_size_progress_emits_from_output_growth(tmp_path):
+    # A tool whose CLI prints no parseable percent: progress must come from the
+    # growing output file via the size_progress hook, ending at the runner's
+    # terminal 100%. The child writes the output file then a stdout line each
+    # step, so the post-line size tick fires without waiting on the read timeout.
+    out = tmp_path / "out.bin"
+    script = (
+        "import sys\n"
+        f"out = {str(out)!r}\n"
+        "with open(out, 'wb') as f:\n"
+        "    for i in range(3):\n"
+        "        f.write(b'x' * 100); f.flush()\n"
+        "        sys.stdout.write(f'step {i}\\n'); sys.stdout.flush()\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    def _size_progress(size: int) -> dict:
+        return {
+            "progress": runner_module.output_size_progress(size, 1000),
+            "message": f"sz {size}",
+        }
+
+    updates = asyncio.run(
+        _drain(
+            runner.run(
+                _py_cmd(script),
+                input_path=str(tmp_path / "in.bin"),
+                output_path=str(out),
+                parse_progress=lambda _line: None,
+                size_progress=_size_progress,
+                fail_label="testproc",
+            )
+        )
+    )
+
+    size_updates = [u for u in updates if u["message"].startswith("sz ")]
+    assert size_updates, "expected at least one size-based progress update"
+    # The estimate matches the shared helper (100 B against expected 1000 -> 14%)
+    # and the emitted bar never goes backwards.
+    assert max(u["progress"] for u in size_updates) >= 14
+    progresses = [u["progress"] for u in updates]
+    assert progresses == sorted(progresses)
+    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert not runner.active_pids()
+
+
+def test_env_is_forwarded_to_subprocess(tmp_path):
+    script = (
+        "import os, sys\n"
+        "sys.stdout.write('VAL=' + os.environ.get('CMP_RUNNER_TEST', 'unset') + '\\n')\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    updates = asyncio.run(
+        _drain(
+            runner.run(
+                _py_cmd(script),
+                input_path=str(tmp_path / "in.bin"),
+                output_path=str(tmp_path / "out.bin"),
+                parse_progress=lambda _line: None,
+                env={**os.environ, "CMP_RUNNER_TEST": "from-env"},
+                fail_label="testproc",
+            )
+        )
+    )
+
+    messages = " ".join(u["message"] for u in updates)
+    assert "VAL=from-env" in messages
+    assert not runner.active_pids()
+
+
+def test_nice_via_wrapper_runs_without_preexec(tmp_path):
+    # With nice_via_wrapper the renice is the caller's command-wrapper concern,
+    # so run() skips preexec_fn; the conversion must still complete normally.
+    out = tmp_path / "out.bin"
+    script = "import sys; sys.stdout.write('done 50%\\n')"
+    runner = SubprocessRunner(owner="test")
+
+    updates = asyncio.run(
+        _drain(
+            runner.run(
+                _py_cmd(script),
+                input_path=str(tmp_path / "in.bin"),
+                output_path=str(out),
+                parse_progress=_parse_pct,
+                nice_via_wrapper=True,
+                fail_label="testproc",
+            )
+        )
+    )
+
+    assert 50 in [u["progress"] for u in updates]
+    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
     assert not runner.active_pids()
 
 

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -145,10 +145,12 @@ def test_stall_timeout_raises_runtimeerror(tmp_path, monkeypatch):
 
 
 def test_size_progress_emits_from_output_growth(tmp_path):
-    # A tool whose CLI prints no parseable percent: progress must come from the
-    # growing output file via the size_progress hook, ending at the runner's
-    # terminal 100%. The child writes the output file then a stdout line each
-    # step, so the post-line size tick fires without waiting on the read timeout.
+    """Progress for a no-parseable-percent tool comes from the size_progress hook.
+
+    The child writes the output file then a stdout line each step, so the
+    post-line size tick fires without waiting on the read timeout, and the
+    stream ends at the runner's terminal 100%.
+    """
     out = tmp_path / "out.bin"
     script = (
         "import sys\n"
@@ -191,6 +193,7 @@ def test_size_progress_emits_from_output_growth(tmp_path):
 
 
 def test_env_is_forwarded_to_subprocess(tmp_path):
+    """run(env=...) is passed through to the spawned subprocess's environment."""
     script = (
         "import os, sys\n"
         "sys.stdout.write('VAL=' + os.environ.get('CMP_RUNNER_TEST', 'unset') + '\\n')\n"
@@ -215,12 +218,26 @@ def test_env_is_forwarded_to_subprocess(tmp_path):
     assert not runner.active_pids()
 
 
-def test_nice_via_wrapper_runs_without_preexec(tmp_path):
-    # With nice_via_wrapper the renice is the caller's command-wrapper concern,
-    # so run() skips preexec_fn; the conversion must still complete normally.
+def test_nice_via_wrapper_omits_preexec_fn(tmp_path, monkeypatch):
+    """nice_via_wrapper=True must spawn with preexec_fn=None — the deadlock-
+    avoidance contract maxcso/nsz rely on — while still completing normally.
+
+    Asserting the spawn kwarg (not just completion) guards against a regression
+    that reintroduced a harmless-looking preexec_fn, which a completion-only
+    test would miss.
+    """
     out = tmp_path / "out.bin"
     script = "import sys; sys.stdout.write('done 50%\\n')"
     runner = SubprocessRunner(owner="test")
+
+    captured = {}
+    real_exec = runner_module.asyncio.create_subprocess_exec
+
+    async def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return await real_exec(*args, **kwargs)
+
+    monkeypatch.setattr(runner_module.asyncio, "create_subprocess_exec", spy)
 
     updates = asyncio.run(
         _drain(
@@ -235,8 +252,55 @@ def test_nice_via_wrapper_runs_without_preexec(tmp_path):
         )
     )
 
+    assert captured.get("preexec_fn") is None
     assert 50 in [u["progress"] for u in updates]
     assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert not runner.active_pids()
+
+
+def test_initial_progress_floor_keeps_bar_monotonic(tmp_path):
+    """A non-parseable early line must not drop the bar below the seeded floor.
+
+    The child emits a stdout line before the output file grows; with
+    parse_progress -> None that line would otherwise emit progress 0. With
+    initial_progress=5 it emits the floor instead, and size growth + the final
+    100% stay monotonic.
+    """
+    out = tmp_path / "out.bin"
+    script = (
+        "import sys\n"
+        f"out = {str(out)!r}\n"
+        "sys.stdout.write('warming up\\n'); sys.stdout.flush()\n"
+        "with open(out, 'wb') as f:\n"
+        "    f.write(b'x' * 100); f.flush()\n"
+        "    sys.stdout.write('step\\n'); sys.stdout.flush()\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    def _size_progress(size: int) -> dict:
+        return {
+            "progress": runner_module.output_size_progress(size, 1000),
+            "message": f"sz {size}",
+        }
+
+    updates = asyncio.run(
+        _drain(
+            runner.run(
+                _py_cmd(script),
+                input_path=str(tmp_path / "in.bin"),
+                output_path=str(out),
+                parse_progress=lambda _line: None,
+                initial_progress=5,
+                size_progress=_size_progress,
+                fail_label="testproc",
+            )
+        )
+    )
+
+    progresses = [u["progress"] for u in updates]
+    assert min(progresses) >= 5            # never drops below the seeded floor
+    assert progresses == sorted(progresses)  # monotonic non-decreasing
+    assert updates[-1]["progress"] == 100
     assert not runner.active_pids()
 
 

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -114,21 +114,23 @@ def test_cancel_event_raises_conversion_cancelled(tmp_path):
     assert not runner.active_pids()
 
 
-def test_cancel_event_wins_even_if_process_exited_zero(tmp_path, monkeypatch):
-    """A set cancel_event raises ConversionCancelled even when the child already
-    exited 0 before the watcher ran (the cancel-vs-completion race).
+def test_cancel_event_preset_short_circuits_before_spawn(tmp_path, monkeypatch):
+    """A cancel_event already set when run() starts raises ConversionCancelled
+    without spawning the child.
 
-    The watcher returns early once ``returncode`` is set, so on this race
-    ``cancelled_by_request`` stays False; the runner must still honor the cancel
-    from ``cancel_event`` rather than report the job complete and publish output.
+    A job cancelled before it began must do no work, so it can never write (and
+    then have a caller delete) an output. Cancellation the run actually observes
+    mid-flight is covered by test_cancel_event_raises_conversion_cancelled.
     """
+    spawned = False
 
-    class _ExitedProcess:
-        """Child reporting returncode 0 from the start (already exited)."""
+    class _UnreachedChild:
+        """Returned only if the short-circuit fails to prevent spawning."""
 
-        def __init__(self, pid: int):
-            self.pid = pid
-            self.returncode = 0
+        pid = 4321
+        returncode = 0
+
+        def __init__(self):
             self.stdout = self
 
         async def read(self, _n: int) -> bytes:
@@ -144,7 +146,9 @@ def test_cancel_event_wins_even_if_process_exited_zero(tmp_path, monkeypatch):
             pass
 
     async def fake_exec(*_args, **_kwargs):
-        return _ExitedProcess(pid=4321)
+        nonlocal spawned
+        spawned = True
+        return _UnreachedChild()
 
     monkeypatch.setattr(runner_module.asyncio, "create_subprocess_exec", fake_exec)
     runner = SubprocessRunner(owner="test")
@@ -165,6 +169,7 @@ def test_cancel_event_wins_even_if_process_exited_zero(tmp_path, monkeypatch):
 
     with pytest.raises(ConversionCancelled):
         asyncio.run(_run())
+    assert spawned is False
     assert not runner.active_pids()
 
 

--- a/tests/test_z3ds_verification_service.py
+++ b/tests/test_z3ds_verification_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from app.services import z3ds_compress as z3ds_module
+from app.services.chdman import ConversionCancelled
 
 
 class _FakeStdin:
@@ -220,3 +221,132 @@ def test_info_flags_new_compressed_extensions(tmp_path, name, compressed):
     rom = tmp_path / name
     rom.write_bytes(b"\0" * 4096)
     assert service.info(str(rom))["compressed"] is compressed
+
+
+# ---------------------------------------------------------------------------
+# convert()  (now delegated to SubprocessRunner — spawn is intercepted via the
+# shared global asyncio.create_subprocess_exec the runner also calls)
+# ---------------------------------------------------------------------------
+
+
+class _ConvertStdout:
+    """Yields preset stdout chunks, then EOF."""
+
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = list(chunks)
+
+    async def read(self, _n: int) -> bytes:
+        if self._chunks:
+            return self._chunks.pop(0)
+        return b""
+
+
+class _ConvertProcess:
+    def __init__(self, pid: int, chunks: list[bytes], returncode: int = 0):
+        self.pid = pid
+        self.stdout = _ConvertStdout(chunks)
+        self.returncode = None
+        self._final_rc = returncode
+        self.killed = False
+
+    async def wait(self) -> int:
+        if self.returncode is None:
+            self.returncode = -9 if self.killed else self._final_rc
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+
+class _CancelStdout:
+    def __init__(self, stop: asyncio.Event):
+        self._stop = stop
+        self._first = True
+
+    async def read(self, _n: int) -> bytes:
+        if self._first:
+            self._first = False
+            return b"working\n"
+        await self._stop.wait()
+        return b""
+
+
+class _CancelProcess:
+    def __init__(self, pid: int, stop: asyncio.Event):
+        self.pid = pid
+        self._stop = stop
+        self.stdout = _CancelStdout(stop)
+        self.returncode = None
+
+    def terminate(self) -> None:
+        self.returncode = -15
+        self._stop.set()
+
+    def kill(self) -> None:
+        self.returncode = -9
+        self._stop.set()
+
+    async def wait(self) -> int:
+        await self._stop.wait()
+        if self.returncode is None:
+            self.returncode = -15
+        return self.returncode
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "src", "out"),
+    [
+        ("z3ds_compress", "game.cci", "game.zcci"),
+        ("z3ds_decompress", "game.zcci", "game.cci"),
+    ],
+)
+async def test_convert_happy_path(tmp_path, monkeypatch, mode, src, out):
+    src_path = tmp_path / src
+    src_path.write_bytes(b"rom-bytes")
+    out_path = tmp_path / out
+
+    async def fake_exec(*args, **_kwargs):
+        # z3ds_compressor writes the container to the last positional arg.
+        Path(list(args)[-1]).write_bytes(b"converted")
+        return _ConvertProcess(pid=4242, chunks=[b"working\n"])
+
+    monkeypatch.setattr(z3ds_module.asyncio, "create_subprocess_exec", fake_exec)
+
+    service = z3ds_module.z3ds_compress_service
+    updates = [u async for u in service.convert(str(src_path), str(out_path), mode)]
+
+    assert updates[0]["progress"] == 5  # the "Starting 3DS ..." preamble
+    assert updates[-1]["progress"] == 100
+    assert out_path.read_bytes() == b"converted"
+    assert not service.active_pids()
+
+
+@pytest.mark.asyncio
+async def test_convert_cancel_cleans_partial_output(tmp_path, monkeypatch):
+    src_path = tmp_path / "game.cci"
+    src_path.write_bytes(b"rom")
+    out_path = tmp_path / "game.zcci"
+
+    cancel_event = asyncio.Event()
+    cancel_event.set()
+
+    async def fake_exec(*args, **_kwargs):
+        Path(list(args)[-1]).write_bytes(b"partial")  # partial written in place
+        return _CancelProcess(pid=7, stop=asyncio.Event())
+
+    monkeypatch.setattr(z3ds_module.asyncio, "create_subprocess_exec", fake_exec)
+
+    service = z3ds_module.z3ds_compress_service
+    with pytest.raises(ConversionCancelled):
+        async for _ in service.convert(
+            str(src_path), str(out_path), "z3ds_compress", cancel_event=cancel_event,
+        ):
+            pass
+
+    assert not out_path.exists()
+    assert not service.active_pids()

--- a/tests/test_z3ds_verification_service.py
+++ b/tests/test_z3ds_verification_service.py
@@ -242,6 +242,8 @@ class _ConvertStdout:
 
 
 class _ConvertProcess:
+    """Fake convert subprocess: streams preset stdout chunks, then exits."""
+
     def __init__(self, pid: int, chunks: list[bytes], returncode: int = 0):
         self.pid = pid
         self.stdout = _ConvertStdout(chunks)
@@ -263,6 +265,8 @@ class _ConvertProcess:
 
 
 class _CancelStdout:
+    """Stdout that yields one line, then blocks until the process is stopped."""
+
     def __init__(self, stop: asyncio.Event):
         self._stop = stop
         self._first = True
@@ -276,6 +280,8 @@ class _CancelStdout:
 
 
 class _CancelProcess:
+    """Fake subprocess that only exits once terminate()/kill() is called."""
+
     def __init__(self, pid: int, stop: asyncio.Event):
         self.pid = pid
         self._stop = stop
@@ -306,6 +312,7 @@ class _CancelProcess:
     ],
 )
 async def test_convert_happy_path(tmp_path, monkeypatch, mode, src, out):
+    """convert() streams the runner's updates and ends at 100% with output written."""
     src_path = tmp_path / src
     src_path.write_bytes(b"rom-bytes")
     out_path = tmp_path / out
@@ -328,6 +335,7 @@ async def test_convert_happy_path(tmp_path, monkeypatch, mode, src, out):
 
 @pytest.mark.asyncio
 async def test_convert_cancel_cleans_partial_output(tmp_path, monkeypatch):
+    """A cancel mid-convert raises ConversionCancelled and removes the partial."""
     src_path = tmp_path / "game.cci"
     src_path.write_bytes(b"rom")
     out_path = tmp_path / "game.zcci"


### PR DESCRIPTION
**Part of #179** (Modularity / High), within the #177 tech-debt epic.

`SubprocessRunner.run` is the shared seam for the streaming convert loop (spawn, nice/ionice, `\r`/`\n` buffering, stall timeout, cancel-watcher → terminate→kill). `chdman`, `dolphin_tool`, `romz` and `makeps3iso` already delegate; `z3ds_compress`, `maxcso` and `nsz` still hand-rolled their own ~150-line copy each, so a cancel/stall/exit-code fix in one silently drifted from the others. This ports the remaining three onto the runner.

## The one genuinely tool-specific bit: size-based progress
maxcso/nsz/z3ds print **no parseable percent** (their TTY bar goes silent on a pipe), so they estimated progress from output-file growth — something `parse_progress(line)` structurally can't express. Rather than drop the bar, this adds a small, shared, **default-off** seam to the runner so all three (and any future such tool) keep it:

- **`size_progress(output_size) -> dict|None`** — emits progress derived from the growing output file and raises the progress floor so a later non-parseable line can't reset the bar. The 5–95% estimate is the shared `output_size_progress(current, expected)` (identical formula across all three).
- **`nice_via_wrapper`** — skips `preexec_fn` when the caller prefixed `cmd` with nice/ionice command wrappers. maxcso/nsz deliberately avoid `preexec_fn` (forking a Python callable in this multithreaded process can deadlock the child before `exec`); this preserves that exactly.
- **`env`** — forwarded to the subprocess (nsz's private keys-home).

All three default off, so the **five existing callers are byte-for-byte unaffected** (verified: `test_makeps3iso` / `test_dolphin_routes` / `test_timeout_policy` green).

## Per-tool notes
- **z3ds** — keeps preexec nice (owner `z3ds`) + ionice in `_build_command`. Added the convert happy-path and **cancel-path** tests this service previously lacked (per the issue's "explicit cancel-path assertion" requirement).
- **maxcso** — command-wrapper nice/ionice (`nice_via_wrapper=True`); write-in-place partial-output cleanup on any failure preserved.
- **nsz** — writes into a private work dir; the runner watches the produced file, and `convert()` still `os.replace`s it onto the real `output_path` and emits the terminal 100% afterward. `env=` carries the keys-home. The work-dir + `rmtree` finally handles partial cleanup.
- Each tool's `convert()` and `verify_stream()` now share the runner's PID set, so a single `active_pids()` sees both.
- `ConversionCancelled` identity is preserved (the runner raises the same object `services.chdman` re-exports), so `job_manager`'s `except` is unaffected.

## Tests / docs
- New runner tests for `size_progress` / `env` / `nice_via_wrapper`; new z3ds convert+cancel tests; maxcso/nsz non-zero-exit assertions follow the runner's standardized "return code" wording.
- `docs/DESIGN_tool_plugin_architecture.md` §3.3 documents the new seams; `docs/RELEASE_NOTES.md` Unreleased note added.
- `ruff check .` clean; `PYTHONPATH=app python -m pytest -q --ignore=tests/test_archive_conversion_e2e.py` → **1001 passed, 1 skipped**. (The e2e file is pre-existing/environmental — missing conversion binaries — and fails identically on the base commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `z3ds`, `maxcso`, and `nsz` now route conversions through a shared subprocess runner, including standardized size-based progress for tools without parseable percent output.
  * Subprocess environment variables are now forwarded, and progress reporting is clamped/monotonic with an initial progress floor.
* **Bug Fixes**
  * Improved cancellation/timeout robustness, including safer termination handling and consistent cleanup of partial output (even when the conversion stream is closed early).
  * Standardized non-zero exit error wording for consistency.
* **Documentation**
  * Updated the design notes describing the shared runner “seams” and progress/streaming behaviors.
* **Tests**
  * Expanded coverage for cancellation races, progress-from-growth behavior, env forwarding, and wrapper/nice handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR finishes moving the remaining conversion tools onto the shared subprocess runner. The main changes are:

- `maxcso`, `nsz`, and `z3ds_compress` now use `SubprocessRunner.run` for streaming conversion.
- Shared size-based progress support was added for tools without parseable percent output.
- Runner options now cover wrapper-based nice/ionice, subprocess environments, and required output checks.
- `nsz` conversion now writes through a private work directory and preserves missing-output stdout details.
- Tests and docs were expanded for runner seams, cancellation, cleanup, and nsz missing-output behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changes appear safe to merge based on the focused migration, expanded coverage, and absence of identified correctness or security issues.

The subprocess runner migration is covered across the updated services, including cancellation, cleanup, progress estimation, environment forwarding, and standardized failure behavior.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared pre-migration and post-migration runner behavior to verify shared streaming semantics did not regress the P1 contract.
- Observed that the head signature includes all requested optional seams and that runtime child subprocess scenarios complete successfully.
- Verified the head NSZ workflow cleanup path: success path moves Game Title.nsz to the requested name and cleans up private work directories, and failure paths also cleanup as described.

<a href="https://app.greptile.com/trex/runs/12152327/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `app/services/subprocess_runner.py`, line 476-479 ([link](https://github.com/pacnpal/compressatorium/blob/b0477ec8f144d485cb3c87d51cde9f1c2f75ac18/app/services/subprocess_runner.py#L476-L479)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cancellation can complete**

   When `cancel_event` is already set or fires before `_cancel_watcher` gets CPU time, this branch breaks the read loop without setting `cancelled_by_request`. If the child then exits with return code 0, the final check at the end of `run()` emits the 100% completion update instead of raising `ConversionCancelled`. A cancelled maxcso/z3ds job can therefore be recorded as complete and skip the caller's cancel cleanup.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: Python harness exercising cancellation timeout race against SubprocessRunner.run](https://app.greptile.com/trex/artifacts/cebb5469-ee3e-4d7f-a46a-6db2d3fc6848)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: harness output showing 100% completion emitted instead of ConversionCancelled](https://app.greptile.com/trex/artifacts/6dad303b-0e18-4f1c-9664-5ac5f7b1fcb6)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/12108049/artifacts?artifact=cebb5469-ee3e-4d7f-a46a-6db2d3fc6848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fsubprocess_runner.py%0ALine%3A%20476-479%0A%0AComment%3A%0A**Cancellation%20can%20complete**%0A%0AWhen%20%60cancel_event%60%20is%20already%20set%20or%20fires%20before%20%60_cancel_watcher%60%20gets%20CPU%20time%2C%20this%20branch%20breaks%20the%20read%20loop%20without%20setting%20%60cancelled_by_request%60.%20If%20the%20child%20then%20exits%20with%20return%20code%200%2C%20the%20final%20check%20at%20the%20end%20of%20%60run%28%29%60%20emits%20the%20100%25%20completion%20update%20instead%20of%20raising%20%60ConversionCancelled%60.%20A%20cancelled%20maxcso%2Fz3ds%20job%20can%20therefore%20be%20recorded%20as%20complete%20and%20skip%20the%20caller's%20cancel%20cleanup.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2F179-subprocess-runner%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2F179-subprocess-runner%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fsubprocess_runner.py%0ALine%3A%20476-479%0A%0AComment%3A%0A**Cancellation%20can%20complete**%0A%0AWhen%20%60cancel_event%60%20is%20already%20set%20or%20fires%20before%20%60_cancel_watcher%60%20gets%20CPU%20time%2C%20this%20branch%20breaks%20the%20read%20loop%20without%20setting%20%60cancelled_by_request%60.%20If%20the%20child%20then%20exits%20with%20return%20code%200%2C%20the%20final%20check%20at%20the%20end%20of%20%60run%28%29%60%20emits%20the%20100%25%20completion%20update%20instead%20of%20raising%20%60ConversionCancelled%60.%20A%20cancelled%20maxcso%2Fz3ds%20job%20can%20therefore%20be%20recorded%20as%20complete%20and%20skip%20the%20caller's%20cancel%20cleanup.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `app/services/subprocess_runner.py`, line 381-385 ([link](https://github.com/pacnpal/compressatorium/blob/b0477ec8f144d485cb3c87d51cde9f1c2f75ac18/app/services/subprocess_runner.py#L381-L385)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Terminate race leaks**

   The watcher checks `process.returncode` and then calls `process.terminate()` without handling `ProcessLookupError`. If the process exits between those two steps during a user cancel, the task can raise `ProcessLookupError`; the `finally` block awaits that task and only suppresses `CancelledError`, so the raw race error can replace the intended conversion result or cancellation.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fsubprocess_runner.py%0ALine%3A%20381-385%0A%0AComment%3A%0A**Terminate%20race%20leaks**%0A%0AThe%20watcher%20checks%20%60process.returncode%60%20and%20then%20calls%20%60process.terminate%28%29%60%20without%20handling%20%60ProcessLookupError%60.%20If%20the%20process%20exits%20between%20those%20two%20steps%20during%20a%20user%20cancel%2C%20the%20task%20can%20raise%20%60ProcessLookupError%60%3B%20the%20%60finally%60%20block%20awaits%20that%20task%20and%20only%20suppresses%20%60CancelledError%60%2C%20so%20the%20raw%20race%20error%20can%20replace%20the%20intended%20conversion%20result%20or%20cancellation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2F179-subprocess-runner%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2F179-subprocess-runner%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fsubprocess_runner.py%0ALine%3A%20381-385%0A%0AComment%3A%0A**Terminate%20race%20leaks**%0A%0AThe%20watcher%20checks%20%60process.returncode%60%20and%20then%20calls%20%60process.terminate%28%29%60%20without%20handling%20%60ProcessLookupError%60.%20If%20the%20process%20exits%20between%20those%20two%20steps%20during%20a%20user%20cancel%2C%20the%20task%20can%20raise%20%60ProcessLookupError%60%3B%20the%20%60finally%60%20block%20awaits%20that%20task%20and%20only%20suppresses%20%60CancelledError%60%2C%20so%20the%20raw%20race%20error%20can%20replace%20the%20intended%20conversion%20result%20or%20cancellation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **maxcso convert still passes preexec_fn despite wrapper-based nice/ionice migration**

   - **Bug**
     - On head, the fake subprocess captured `argv` beginning with `nice -n 7 ionice -c 2 -n 6 maxcso ...`, but the same captured call also had `kwargs` containing `preexec_fn` and reported `preexec: true`. The validation objective explicitly required command-wrapper nice/ionice without `preexec_fn`; this matters because the migration rationale is to avoid running a Python callable in the forked child of a multithreaded service. Base did not pass `preexec_fn` for maxcso convert in the same harness.
   - **Cause**
     - `app/services/subprocess_runner.py` line 342 always includes the `preexec_fn` keyword in the `create_subprocess_exec` call, setting it to `None` when `nice_via_wrapper=True`. The public subprocess API still receives a `preexec_fn` argument, which violates the claimed no-`preexec_fn` contract and can fail strict seams/tests that assert the argument is not used.
   - **Fix**
     - Build subprocess keyword arguments conditionally and omit the `preexec_fn` key entirely when `nice_via_wrapper=True` (or when no preexec is needed), e.g. create `spawn_kwargs = {'stdout': PIPE, 'stderr': STDOUT, 'cwd': cwd, 'env': env}` and only add `spawn_kwargs['preexec_fn'] = _preexec` when `use_preexec` is true.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

4. `app/services/subprocess_runner.py`, line 528-534 ([link](https://github.com/pacnpal/compressatorium/blob/99051c3066162f273ddd27d6b90a1925d4ab378c/app/services/subprocess_runner.py#L528-L534)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Preserve parsed progress**

   This now emits `last_progress_value` for every parsed stdout line. For parsed-progress tools, a real lower value can be meaningful, such as a second phase or next file restarting at `0%` after an earlier `99%`. In that case callers receive progress `99` with a message that says `0%`, so the job UI and recorded progress no longer match the subprocess output. Keep the monotonic floor for size/non-parseable updates, but emit the parsed value when `parse_progress()` returns one.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fsubprocess_runner.py%0ALine%3A%20528-534%0A%0AComment%3A%0A**Preserve%20parsed%20progress**%0A%0AThis%20now%20emits%20%60last_progress_value%60%20for%20every%20parsed%20stdout%20line.%20For%20parsed-progress%20tools%2C%20a%20real%20lower%20value%20can%20be%20meaningful%2C%20such%20as%20a%20second%20phase%20or%20next%20file%20restarting%20at%20%600%25%60%20after%20an%20earlier%20%6099%25%60.%20In%20that%20case%20callers%20receive%20progress%20%6099%60%20with%20a%20message%20that%20says%20%600%25%60%2C%20so%20the%20job%20UI%20and%20recorded%20progress%20no%20longer%20match%20the%20subprocess%20output.%20Keep%20the%20monotonic%20floor%20for%20size%2Fnon-parseable%20updates%2C%20but%20emit%20the%20parsed%20value%20when%20%60parse_progress%28%29%60%20returns%20one.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22pacnpal%2Fcompressatorium%22%20on%20the%20existing%20branch%20%22claude%2F179-subprocess-runner%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2F179-subprocess-runner%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fservices%2Fsubprocess_runner.py%0ALine%3A%20528-534%0A%0AComment%3A%0A**Preserve%20parsed%20progress**%0A%0AThis%20now%20emits%20%60last_progress_value%60%20for%20every%20parsed%20stdout%20line.%20For%20parsed-progress%20tools%2C%20a%20real%20lower%20value%20can%20be%20meaningful%2C%20such%20as%20a%20second%20phase%20or%20next%20file%20restarting%20at%20%600%25%60%20after%20an%20earlier%20%6099%25%60.%20In%20that%20case%20callers%20receive%20progress%20%6099%60%20with%20a%20message%20that%20says%20%600%25%60%2C%20so%20the%20job%20UI%20and%20recorded%20progress%20no%20longer%20match%20the%20subprocess%20output.%20Keep%20the%20monotonic%20floor%20for%20size%2Fnon-parseable%20updates%2C%20but%20emit%20the%20parsed%20value%20when%20%60parse_progress%28%29%60%20returns%20one.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=pacnpal%2Fcompressatorium&pr=194&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (9): Last reviewed commit: ["Restore nsz missing-output diagnostic vi..."](https://github.com/pacnpal/compressatorium/commit/4b698fa504c0b9f181ffbb2001a08974c96d2080) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39475045)</sub>

<!-- /greptile_comment -->