### PR TITLE
Frontend SSOT: backend↔frontend parity guard + dedup of constants/dead code (#186)

### DIFF
--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -815,6 +815,18 @@ export const TOOLS = [
 `CHDInfoModal` routing/verify-batch routing (all in `app.js`) become lookups
 into `TOOLS` instead of `if (tool === 'dolphin') …` chains.
 
+**Parity guard (`tests/test_frontend_parity_186.py`).** `registry.js` is a
+hand-maintained mirror of the backend `ModeSpec`s, and there is no shared build
+step, so a drift in `allows_archive_input` / `supports_delete_on_verify` /
+`input_extensions` / `output_ext` / `kind` would silently make the UI offer a
+job `plan_job` rejects ("0 queued") or fail on submit. The test evaluates
+`registry.js` with Node and asserts its mode rows match `registry.mode_specs()`
+field-by-field (skipped when Node is unavailable). `tool_id` is excluded: the
+synthetic `cso_to_chd` chain mode is owned by the `chain` tool on the backend
+but grouped under `cso` in the UI. The deliberate `.iso`-not-in-Dolphin-verify
+divergence lives on `verifyExts` (a verify-routing fact), not on a `ModeSpec`
+field, so it is outside the guard's scope.
+
 ---
 
 ## 4. The payoff: what a new tool looks like *after*

--- a/src/lib/api/format.js
+++ b/src/lib/api/format.js
@@ -12,30 +12,3 @@ export function formatSize(bytes) {
   );
   return `${Number.parseFloat((bytes / k ** i).toFixed(2))} ${SIZE_UNITS.at(i)}`;
 }
-
-export function getFileIcon(entry) {
-  if (!entry) return '📄';
-  if (entry.type === 'directory') return '📁';
-  if (entry.type === 'archive') return '📦';
-  const ext = entry.extension?.toLowerCase();
-  if (ext === '.chd') return '💿';
-  if (['.rvz', '.wia', '.gcz', '.wbfs', '.3ds', '.cci', '.cia', '.cxi', '.3dsx', '.z3ds', '.zcci', '.zcia', '.zcxi', '.z3dsx'].includes(ext)) {
-    return '🎮';
-  }
-  if (['.iso', '.gdi', '.cue', '.bin'].includes(ext)) return '💽';
-  return '📄';
-}
-
-export const DOLPHIN_EXTENSIONS = ['.rvz', '.wia', '.gcz', '.wbfs'];
-
-export function isDolphinFile(path) {
-  if (!path) return false;
-  // Isolate the filename first: a directory name with a dot (e.g.
-  // `/games/dir.rvz/file`) would otherwise make split('.').pop() return
-  // `rvz/file` and wrongly classify the wrapping directory as the format.
-  const filename = path.split(/[/\\]/).pop() ?? '';
-  if (!filename.includes('.')) return false;
-  const ext = filename.split('.').pop();
-  if (!ext) return false;
-  return DOLPHIN_EXTENSIONS.includes(`.${ext.toLowerCase()}`);
-}

--- a/src/lib/components/panels/CompressionPicker.svelte
+++ b/src/lib/components/panels/CompressionPicker.svelte
@@ -11,6 +11,7 @@
   // (optionally) a level range; this file does not need editing.
 
   import { conversion } from '$lib/stores/conversion.svelte.js';
+  import { DEFAULT_COMPRESSION_LEVEL_RANGE } from '$lib/tools/registry.js';
   import { toast } from 'svelte-sonner';
   import Check from '@lucide/svelte/icons/check';
   import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
@@ -20,9 +21,9 @@
   const codecs = $derived(tool?.compressionCodecs ?? []);
   const style = $derived(tool?.compressionStyle ?? 'none');
   const selection = $derived(conversion.compressionSelection);
-  const level = $derived(conversion.dolphinCompressionLevel);
+  const level = $derived(conversion.compressionLevel);
   const levelRange = $derived(
-    tool?.compressionLevelRange ?? { min: 1, max: 22, default: 19 },
+    tool?.compressionLevelRange ?? DEFAULT_COMPRESSION_LEVEL_RANGE,
   );
   const supports = $derived(
     !!(spec?.supportsCompression || spec?.supportsCompressionLevel),
@@ -111,7 +112,7 @@
               max={levelRange.max}
               step="1"
               value={level}
-              oninput={(e) => conversion.setDolphinLevel(e.currentTarget.value)}
+              oninput={(e) => conversion.setCompressionLevel(e.currentTarget.value)}
               aria-label="Compression level"
             />
             <input
@@ -121,7 +122,7 @@
               max={levelRange.max}
               step="1"
               value={level}
-              oninput={(e) => conversion.setDolphinLevel(e.currentTarget.value)}
+              oninput={(e) => conversion.setCompressionLevel(e.currentTarget.value)}
               aria-label="Compression level value"
             />
           </div>

--- a/src/lib/stores/conversion.svelte.js
+++ b/src/lib/stores/conversion.svelte.js
@@ -4,7 +4,7 @@
 
 import { toast } from 'svelte-sonner';
 import { api } from '$lib/api/endpoints.js';
-import { registry } from '$lib/tools/registry.js';
+import { registry, DEFAULT_COMPRESSION_LEVEL_RANGE } from '$lib/tools/registry.js';
 import { STORAGE_KEYS, readString, writeString } from '$lib/util/localStorage.js';
 import { jobs } from './jobs.svelte.js';
 
@@ -46,7 +46,7 @@ class ConversionStore {
   // wrong duplicate checks and compression flags before setPrimaryTool runs.
   mode = $state(defaultModeFor(INITIAL_TOOL));
   compressionSelection = $state(defaultCompressionFor(INITIAL_TOOL));
-  dolphinCompressionLevel = $state('19');
+  compressionLevel = $state('19');
   outputDir = $state('');
   deleteOnVerify = $state(false);
   split = $state(false);
@@ -188,8 +188,8 @@ class ConversionStore {
       // reject the token. Fall back to the registered default range
       // value when the field is empty or non-numeric, then clamp into
       // [min, max] so out-of-range edits also stay safe.
-      const range = this.currentTool?.compressionLevelRange ?? { min: 1, max: 22, default: 19 };
-      const rawLevel = this.dolphinCompressionLevel;
+      const range = this.currentTool?.compressionLevelRange ?? DEFAULT_COMPRESSION_LEVEL_RANGE;
+      const rawLevel = this.compressionLevel;
       const parsed = Number.parseInt(rawLevel, 10);
       const safeLevel = Number.isFinite(parsed)
         ? Math.min(range.max, Math.max(range.min, parsed))
@@ -243,7 +243,7 @@ class ConversionStore {
     // previously selected single-with-level tool can't leak across (e.g.
     // Dolphin's 19 bleeding into Switch, which defaults to 18).
     if (isLevel) {
-      this.dolphinCompressionLevel = String(tool?.compressionLevelRange?.default ?? 19);
+      this.compressionLevel = String(tool?.compressionLevelRange?.default ?? DEFAULT_COMPRESSION_LEVEL_RANGE.default);
     }
     if (!value) {
       this.compressionSelection = defaultCompressionFor(toolId);
@@ -256,7 +256,7 @@ class ConversionStore {
     if (isLevel) {
       const [codec, lvl] = value.split(':');
       this.compressionSelection = codec ? [codec] : defaultCompressionFor(toolId);
-      if (lvl) this.dolphinCompressionLevel = String(lvl);
+      if (lvl) this.compressionLevel = String(lvl);
       return;
     }
     this.compressionSelection = value.split(',').filter(Boolean);
@@ -294,8 +294,8 @@ class ConversionStore {
     this.#persistCompression();
   }
 
-  setDolphinLevel(level) {
-    this.dolphinCompressionLevel = String(level);
+  setCompressionLevel(level) {
+    this.compressionLevel = String(level);
     this.#persistCompression();
   }
 
@@ -350,7 +350,7 @@ class ConversionStore {
     const tool = registry.forTool(toolId);
     this.compressionSelection = defaultCompressionFor(toolId);
     if ((tool?.compressionStyle ?? 'none') === 'single-with-level') {
-      this.dolphinCompressionLevel = String(tool?.compressionLevelRange?.default ?? 19);
+      this.compressionLevel = String(tool?.compressionLevelRange?.default ?? DEFAULT_COMPRESSION_LEVEL_RANGE.default);
     }
     this.#persistCompression();
   }
@@ -368,8 +368,8 @@ class ConversionStore {
     if (sel.length !== def.length || !sel.every((v, i) => v === def[i])) return false;
     if (this.currentSpec?.supportsCompressionLevel) {
       const tool = registry.forTool(toolId);
-      const defLevel = String(tool?.compressionLevelRange?.default ?? 19);
-      return String(this.dolphinCompressionLevel) === defLevel;
+      const defLevel = String(tool?.compressionLevelRange?.default ?? DEFAULT_COMPRESSION_LEVEL_RANGE.default);
+      return String(this.compressionLevel) === defLevel;
     }
     return true;
   }

--- a/src/lib/stores/conversion.svelte.js
+++ b/src/lib/stores/conversion.svelte.js
@@ -34,6 +34,16 @@ function defaultCompressionFor(toolId) {
   return registry.forTool(toolId)?.defaultCompression ?? ['zlib'];
 }
 
+// The slider level a tool boots / resets to: its registry range default, or the
+// shared fallback for tools that declare no range (they hide the slider). Used
+// at construction so the very first submit after a reload — before the async
+// `loadServerPrefs()` resolves — already matches the selected tool's default
+// (e.g. Switch's 18, not Dolphin's 19).
+function defaultLevelFor(toolId) {
+  const range = registry.forTool(toolId)?.compressionLevelRange ?? DEFAULT_COMPRESSION_LEVEL_RANGE;
+  return String(range.default ?? DEFAULT_COMPRESSION_LEVEL_RANGE.default);
+}
+
 const PREF_SAVE_DEBOUNCE_MS = 500;
 const isBrowser = typeof window !== 'undefined';
 
@@ -46,7 +56,7 @@ class ConversionStore {
   // wrong duplicate checks and compression flags before setPrimaryTool runs.
   mode = $state(defaultModeFor(INITIAL_TOOL));
   compressionSelection = $state(defaultCompressionFor(INITIAL_TOOL));
-  compressionLevel = $state('19');
+  compressionLevel = $state(defaultLevelFor(INITIAL_TOOL));
   outputDir = $state('');
   deleteOnVerify = $state(false);
   split = $state(false);
@@ -243,7 +253,7 @@ class ConversionStore {
     // previously selected single-with-level tool can't leak across (e.g.
     // Dolphin's 19 bleeding into Switch, which defaults to 18).
     if (isLevel) {
-      this.compressionLevel = String(tool?.compressionLevelRange?.default ?? DEFAULT_COMPRESSION_LEVEL_RANGE.default);
+      this.compressionLevel = defaultLevelFor(toolId);
     }
     if (!value) {
       this.compressionSelection = defaultCompressionFor(toolId);
@@ -350,7 +360,7 @@ class ConversionStore {
     const tool = registry.forTool(toolId);
     this.compressionSelection = defaultCompressionFor(toolId);
     if ((tool?.compressionStyle ?? 'none') === 'single-with-level') {
-      this.compressionLevel = String(tool?.compressionLevelRange?.default ?? DEFAULT_COMPRESSION_LEVEL_RANGE.default);
+      this.compressionLevel = defaultLevelFor(toolId);
     }
     this.#persistCompression();
   }
@@ -367,9 +377,7 @@ class ConversionStore {
     const sel = this.compressionSelection;
     if (sel.length !== def.length || !sel.every((v, i) => v === def[i])) return false;
     if (this.currentSpec?.supportsCompressionLevel) {
-      const tool = registry.forTool(toolId);
-      const defLevel = String(tool?.compressionLevelRange?.default ?? DEFAULT_COMPRESSION_LEVEL_RANGE.default);
-      return String(this.compressionLevel) === defLevel;
+      return String(this.compressionLevel) === defaultLevelFor(toolId);
     }
     return true;
   }

--- a/src/lib/stores/jobConstants.js
+++ b/src/lib/stores/jobConstants.js
@@ -1,0 +1,18 @@
+// Single source of truth for the job-status / job-mode sets shared across the
+// job stores (jobs.svelte.js and jobToasts.svelte.js). Each store previously
+// defined its own copy of TERMINAL_STATUSES / EXTERNAL_SCAN_MODES (jobToasts
+// even commented "Mirror jobs.svelte.js"); a drift between the copies would
+// desync which jobs the queue and the toast tracker treat as finished or hide.
+
+// Statuses a job never leaves — used to resolve a toast, prune a finished job,
+// or prefer the incoming copy during reconciliation.
+export const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
+
+// Statuses a job is still working through.
+export const ACTIVE_STATUSES = new Set(['queued', 'processing']);
+
+// Background housekeeping modes the queue and the toast surface hide by
+// default: they run constantly as a side-effect of browsing (FileList
+// hydration kicks dat_match jobs), so surfacing them would flood the UI.
+// Shown only when the user opts into external-scan jobs.
+export const EXTERNAL_SCAN_MODES = new Set(['metadata_scan', 'dat_match']);

--- a/src/lib/stores/jobToasts.svelte.js
+++ b/src/lib/stores/jobToasts.svelte.js
@@ -11,14 +11,7 @@
 
 import { toast } from 'svelte-sonner';
 import { registry } from '$lib/tools/registry.js';
-
-const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
-// Mirror jobs.svelte.js: metadata_scan / dat_match are background
-// housekeeping jobs the queue hides by default. They run constantly as a
-// side-effect of browsing (FileList hydration kicks dat_match jobs), so
-// toasting them would flood the surface. They're only toasted when the
-// user has opted to show external-scan jobs in the queue.
-const EXTERNAL_SCAN_MODES = new Set(['metadata_scan', 'dat_match']);
+import { EXTERNAL_SCAN_MODES, TERMINAL_STATUSES } from './jobConstants.js';
 
 function filenameOf(job) {
   return job?.file_path?.split(/[/\\]/).pop() ?? job?.file_path ?? 'Job';

--- a/src/lib/stores/jobs.svelte.js
+++ b/src/lib/stores/jobs.svelte.js
@@ -7,10 +7,12 @@ import { api } from '$lib/api/endpoints.js';
 import { STORAGE_KEYS, readBool, writeBool } from '$lib/util/localStorage.js';
 import { verification } from './verification.svelte.js';
 import { ui } from './ui.svelte.js';
+import {
+  ACTIVE_STATUSES,
+  EXTERNAL_SCAN_MODES,
+  TERMINAL_STATUSES,
+} from './jobConstants.js';
 
-const EXTERNAL_SCAN_MODES = new Set(['metadata_scan', 'dat_match']);
-const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
-const ACTIVE_STATUSES = new Set(['queued', 'processing']);
 const MAX_OPTIMISTIC_PLACEHOLDERS = 100;
 
 class JobsStore {

--- a/src/lib/tools/registry.js
+++ b/src/lib/tools/registry.js
@@ -111,6 +111,15 @@ function swapExt(path, newExt) {
   return path.replace(/\.[^./\\]+$/, newExt);
 }
 
+/**
+ * Fallback compression-level range for the slider when a tool declares no
+ * `compressionLevelRange`. Every level-capable tool sets its own (Dolphin
+ * default 19, nsz 18), so this is only a safety net — but it lives here once
+ * rather than re-inlined as `{ min: 1, max: 22, default: 19 }` in the
+ * conversion store and the CompressionPicker.
+ */
+export const DEFAULT_COMPRESSION_LEVEL_RANGE = { min: 1, max: 22, default: 19 };
+
 /** @type {ToolDescriptor[]} */
 export const TOOLS = [
   {

--- a/src/lib/tools/registry.js
+++ b/src/lib/tools/registry.js
@@ -118,7 +118,7 @@ function swapExt(path, newExt) {
  * rather than re-inlined as `{ min: 1, max: 22, default: 19 }` in the
  * conversion store and the CompressionPicker.
  */
-export const DEFAULT_COMPRESSION_LEVEL_RANGE = { min: 1, max: 22, default: 19 };
+export const DEFAULT_COMPRESSION_LEVEL_RANGE = Object.freeze({ min: 1, max: 22, default: 19 });
 
 /** @type {ToolDescriptor[]} */
 export const TOOLS = [

--- a/tests/test_frontend_parity_186.py
+++ b/tests/test_frontend_parity_186.py
@@ -10,9 +10,10 @@ fails loudly on any such drift.
 
 It evaluates ``registry.js`` with Node — the same engine the app uses, so the JS
 ext constants and spreads resolve exactly — and compares each mode row
-field-by-field to the backend spec. ``tool_id`` is deliberately NOT compared:
-the synthetic ``cso_to_chd`` chain mode is owned by the ``chain`` tool on the
-backend but grouped under ``cso`` in the UI. Skipped when Node is unavailable.
+field-by-field to the backend spec, including ``input_kinds`` (directory vs file
+input) and the owning ``tool_id``. The only ``tool_id`` exception is the
+synthetic ``cso_to_chd`` chain mode, owned by the ``chain`` tool on the backend
+but grouped under ``cso`` in the UI. Skipped when Node is unavailable.
 """
 from __future__ import annotations
 
@@ -29,16 +30,28 @@ from services.tools import registry
 _REGISTRY_JS = Path(__file__).resolve().parents[1] / "src" / "lib" / "tools" / "registry.js"
 
 # Fields whose drift would actually mis-route a job. Frontend camelCase is
-# normalized to these snake_case keys in the Node dump below.
+# normalized to these snake_case keys in the Node dump below. `input_kinds` is
+# what makes folder_to_iso a directory-input mode (fileBrowser offers folders,
+# not files), so it must be compared even though its extensions are empty on
+# both sides.
 _COMPARED_FIELDS = (
     "kind",
     "output_ext",
     "input_extensions",
+    "input_kinds",
     "supports_compression",
     "supports_compression_level",
     "supports_delete_on_verify",
     "allows_archive_input",
 )
+
+# `tool_id` is compared too — a mode filed under the wrong frontend tool
+# descriptor drives the wrong menu / compression style / verify bindings even
+# when its per-mode fields still match — EXCEPT for these modes, whose frontend
+# owner intentionally differs from the backend. `cso_to_chd` is the synthetic
+# chain mode: owned by the `chain` tool on the backend, grouped under `cso` in
+# the UI.
+_TOOL_ID_EXCEPTIONS = frozenset({"cso_to_chd"})
 
 
 def _find_node() -> str | None:
@@ -67,9 +80,11 @@ def _frontend_rows(tmp_path: Path) -> dict[str, dict]:
     src += (
         "\nconst __rows = TOOLS.flatMap((t) => t.modes.map((m) => ({"
         " mode: m.mode,"
+        " tool_id: t.id,"
         " kind: m.kind,"
         " output_ext: m.outputExt ?? null,"
         " input_extensions: [...m.inputExtensions].sort(),"
+        " input_kinds: [...(m.inputKinds ?? ['file'])].sort(),"
         " supports_compression: !!m.supportsCompression,"
         " supports_compression_level: !!m.supportsCompressionLevel,"
         " supports_delete_on_verify: !!m.supportsDeleteOnVerify,"
@@ -93,9 +108,11 @@ def _backend_rows() -> dict[str, dict]:
     for spec in registry.mode_specs():
         rows[spec.mode] = {
             "mode": spec.mode,
+            "tool_id": spec.tool_id,
             "kind": spec.kind.value,
             "output_ext": spec.output_ext,
             "input_extensions": sorted(spec.input_extensions),
+            "input_kinds": sorted(k.value for k in spec.input_kinds),
             "supports_compression": spec.supports_compression,
             "supports_compression_level": spec.supports_compression_level,
             "supports_delete_on_verify": spec.supports_delete_on_verify,
@@ -123,6 +140,11 @@ def test_frontend_registry_mirrors_backend_mode_specs(tmp_path):
                     f"  {mode}.{field}: registry.js={fe.get(field)!r} "
                     f"mode_specs()={be.get(field)!r}"
                 )
+        if mode not in _TOOL_ID_EXCEPTIONS and fe.get("tool_id") != be.get("tool_id"):
+            mismatches.append(
+                f"  {mode}.tool_id: registry.js={fe.get('tool_id')!r} "
+                f"mode_specs()={be.get('tool_id')!r}"
+            )
     assert not mismatches, (
         "registry.js ↔ registry.mode_specs() field drift "
         "(update src/lib/tools/registry.js or the backend ModeSpec to match):\n"

--- a/tests/test_frontend_parity_186.py
+++ b/tests/test_frontend_parity_186.py
@@ -1,0 +1,130 @@
+"""Guard the backend↔frontend tool-registry mirror (issue #186, site 1).
+
+``src/lib/tools/registry.js`` (frontend) and the backend ``ModeSpec`` rows
+(``registry.mode_specs()``) are a hand-maintained mirror: the UI offers exactly
+the modes / extensions the backend will accept. There is no shared build step,
+so a drift in ``allows_archive_input`` / ``supports_delete_on_verify`` /
+``input_extensions`` / ``output_ext`` / ``kind`` would silently make the UI
+offer a job ``plan_job`` rejects (→ "0 queued") or fail on submit. This test
+fails loudly on any such drift.
+
+It evaluates ``registry.js`` with Node — the same engine the app uses, so the JS
+ext constants and spreads resolve exactly — and compares each mode row
+field-by-field to the backend spec. ``tool_id`` is deliberately NOT compared:
+the synthetic ``cso_to_chd`` chain mode is owned by the ``chain`` tool on the
+backend but grouped under ``cso`` in the UI. Skipped when Node is unavailable.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from services.tools import registry
+
+_REGISTRY_JS = Path(__file__).resolve().parents[1] / "src" / "lib" / "tools" / "registry.js"
+
+# Fields whose drift would actually mis-route a job. Frontend camelCase is
+# normalized to these snake_case keys in the Node dump below.
+_COMPARED_FIELDS = (
+    "kind",
+    "output_ext",
+    "input_extensions",
+    "supports_compression",
+    "supports_compression_level",
+    "supports_delete_on_verify",
+    "allows_archive_input",
+)
+
+
+def _find_node() -> str | None:
+    found = shutil.which("node")
+    if found:
+        return found
+    for cand in (os.environ.get("NODE"), "/opt/node22/bin/node", "/usr/bin/node"):
+        if cand and os.path.exists(cand):
+            return cand
+    return None
+
+
+def _frontend_rows(tmp_path: Path) -> dict[str, dict]:
+    node = _find_node()
+    if node is None:
+        pytest.skip("node not available to evaluate registry.js")
+
+    src = _REGISTRY_JS.read_text(encoding="utf-8")
+    # registry.js imports the SvelteKit `$lib` alias only for the getInfo/verify
+    # bindings, which this dump never calls — stub it so plain Node can evaluate
+    # the module as-is (preserving every ext constant and spread).
+    stub = "const api = {};"
+    needle = "import { api } from '$lib/api/endpoints.js';"
+    assert needle in src, "registry.js import shape changed; update the parity stub"
+    src = src.replace(needle, stub)
+    src += (
+        "\nconst __rows = TOOLS.flatMap((t) => t.modes.map((m) => ({"
+        " mode: m.mode,"
+        " kind: m.kind,"
+        " output_ext: m.outputExt ?? null,"
+        " input_extensions: [...m.inputExtensions].sort(),"
+        " supports_compression: !!m.supportsCompression,"
+        " supports_compression_level: !!m.supportsCompressionLevel,"
+        " supports_delete_on_verify: !!m.supportsDeleteOnVerify,"
+        " allows_archive_input: !!m.allowsArchiveInput,"
+        "})));\n"
+        "process.stdout.write(JSON.stringify(__rows));\n"
+    )
+    script = tmp_path / "registry_eval.mjs"
+    script.write_text(src, encoding="utf-8")
+
+    proc = subprocess.run(
+        [node, str(script)], capture_output=True, text=True, timeout=30,
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"Could not evaluate registry.js via node:\n{proc.stderr}")
+    return {row["mode"]: row for row in json.loads(proc.stdout)}
+
+
+def _backend_rows() -> dict[str, dict]:
+    rows: dict[str, dict] = {}
+    for spec in registry.mode_specs():
+        rows[spec.mode] = {
+            "mode": spec.mode,
+            "kind": spec.kind.value,
+            "output_ext": spec.output_ext,
+            "input_extensions": sorted(spec.input_extensions),
+            "supports_compression": spec.supports_compression,
+            "supports_compression_level": spec.supports_compression_level,
+            "supports_delete_on_verify": spec.supports_delete_on_verify,
+            "allows_archive_input": spec.allows_archive_input,
+        }
+    return rows
+
+
+def test_frontend_registry_mirrors_backend_mode_specs(tmp_path):
+    frontend = _frontend_rows(tmp_path)
+    backend = _backend_rows()
+
+    assert set(frontend) == set(backend), (
+        "Mode set drift between registry.js and registry.mode_specs():\n"
+        f"  frontend-only: {sorted(set(frontend) - set(backend))}\n"
+        f"  backend-only:  {sorted(set(backend) - set(frontend))}"
+    )
+
+    mismatches = []
+    for mode in sorted(backend):
+        fe, be = frontend[mode], backend[mode]
+        for field in _COMPARED_FIELDS:
+            if fe.get(field) != be.get(field):
+                mismatches.append(
+                    f"  {mode}.{field}: registry.js={fe.get(field)!r} "
+                    f"mode_specs()={be.get(field)!r}"
+                )
+    assert not mismatches, (
+        "registry.js ↔ registry.mode_specs() field drift "
+        "(update src/lib/tools/registry.js or the backend ModeSpec to match):\n"
+        + "\n".join(mismatches)
+    )


### PR DESCRIPTION
**Part of #186** (SSOT / Modularity), within the #177 tech-debt epic. Implements **sites 1, 2, 4, 5**; sites 3 and 6 are deferred (rationale below).

## What's here

### 1. Backend↔frontend parity guard — the standing risk
`src/lib/tools/registry.js` is a hand-maintained mirror of the backend `ModeSpec`s, with **no shared build step**. A drift in `allows_archive_input` / `supports_delete_on_verify` / `input_extensions` / `output_ext` / `kind` would silently make the UI offer a job `plan_job` rejects (→ "0 queued") or fail on submit.

New `tests/test_frontend_parity_186.py` evaluates `registry.js` **with Node** (the same engine the app uses, so the JS ext constants and spreads resolve exactly) and asserts every mode row matches `registry.mode_specs()` field-by-field. Skipped when Node is unavailable.
- `tool_id` is excluded: the synthetic `cso_to_chd` chain mode is owned by the `chain` tool on the backend but grouped under `cso` in the UI.
- The deliberate `.iso`-not-in-Dolphin-verify divergence lives on `verifyExts` (verify routing), not a `ModeSpec` field, so it's correctly outside the guard's scope.
- Verified the guard *bites*: perturbing one flag in `registry.js` fails with `copy.allows_archive_input: registry.js=True mode_specs()=False`.

### 2. Dead code removed (`src/lib/api/format.js`)
`getFileIcon` / `DOLPHIN_EXTENSIONS` / `isDolphinFile` had **zero importers** (a stale 4th copy of the Dolphin ext list). Trimmed to just `formatSize`.

### 4. Centralized duplicated job constants
`TERMINAL_STATUSES` / `ACTIVE_STATUSES` / `EXTERNAL_SCAN_MODES` were defined independently in `jobs.svelte.js` and `jobToasts.svelte.js` (the latter literally commented *"Mirror jobs.svelte.js"*). Now one `src/lib/stores/jobConstants.js`, imported by both.

### 5. Generic compression-level naming + single fallback range
Renamed the Dolphin-specific `dolphinCompressionLevel` / `setDolphinLevel` → `compressionLevel` / `setCompressionLevel`, and sourced the slider's fallback range from one `DEFAULT_COMPRESSION_LEVEL_RANGE` in `registry.js` instead of re-inlining `{ min: 1, max: 22, default: 19 }` in the store **and** the picker (the per-tool ranges — Dolphin 19, nsz 18 — already correctly override).

## Deferred (follow-up)
- **Site 3** (fileIcon.js `GAME_EXTS`/`DISC_EXTS`, HelpView `modeGroups`): these are hand-curated **presentation** — the icon buckets don't map onto registry facts without re-introducing `forTool('dolphin')`-style coupling, and the Help table has intentionally merged rows + companion annotations (`.cue + .bin`) that generation would flatten (a user-facing change). Needs its own focused pass.
- **Site 6** (Phase 9): removing the dual-maintained `FileEntry` booleans + migrating the Svelte `FileList` badges to `outputs`/`convertible_by` + iterating verify-route registration — a large, explicitly *Low*-priority backend+frontend change.

I can take either as a follow-up PR.

## Verification
- Svelte autofixer clean on `CompressionPicker.svelte` and `conversion.svelte.js` (no issues/suggestions).
- `ruff check .` clean; `PYTHONPATH=app python -m pytest -q --ignore=tests/test_archive_conversion_e2e.py` → **1112 passed, 1 skipped** (the e2e file is pre-existing/environmental — missing conversion binaries).
- No external importers left referencing the removed `format.js` exports or the old per-store constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFKXZpCMAtkbuZWUi8kL7o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compression level controls now work consistently across tools, with a shared default range when a tool doesn’t provide its own limits.
  * Job status handling is now standardized, improving consistency for active, finished, and external-scan jobs.

* **Bug Fixes**
  * Reduced mismatches between the frontend and backend tool lists, helping prevent mode/options drift.
  * Compression settings now reset and validate more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens the frontend tool registry as a single source of truth. The main changes are:

- Adds a backend-to-frontend parity test for tool mode metadata.
- Centralizes shared job status and external scan constants.
- Renames compression level state to be tool-neutral.
- Shares the fallback compression level range from the registry.
- Removes unused file icon and Dolphin extension helpers.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on the reviewed changes.

The changes are focused refactors and parity checks with no accepted code issues.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran parity guard checks on the base commit; there was no existing parity guard file and pytest could not run.
- Ran parity guard checks after applying the head commit; the guard now runs under pytest/Node path, passes, and detects intentional frontend drift with a visible field-level mismatch; no contract mismatch was found.
- Inspected compression defaults on the base commit dfc9ba07; nsz was initialized as nsz\_compress with level-capable, dolphinCompressionLevel: "18", compressionValue: "solid:18", and no generic setter found by the harness.
- Inspected compression defaults after head commit 203ba54; switch/nsz initialized with compressionLevel: "18" and compressionValue: "solid:18"; setCompressionLevel(7) changed serialization to solid:7; resetCompression restored compressionLevel: "18" and compressionValue: "solid:18".

<a href="https://app.greptile.com/trex/runs/12169747/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["#186: address review — boot-default leve..."](https://github.com/pacnpal/compressatorium/commit/203ba54a195ed992aa064fc67bc64c6e75a09402) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39590864)</sub>

<!-- /greptile_comment -->