### PR TITLE
Harden PS3 folder input validation

### DIFF
--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -460,7 +460,17 @@ async def _plan_directory_job(
     if not accepts:
         raise SkipFile(SkipReason.PS3_FOLDER_INVALID)
 
-    normalized = os.path.normpath(file_path)
+    # Canonicalize the source to its real, symlink-free path before deriving the
+    # job, and pack *that* path. makeps3iso reads the source tree as a native
+    # subprocess, so a submitted path with a symlink in an ancestor component
+    # (e.g. "/vol/link/MyGame" with "link" -> "/vol/real") would otherwise let a
+    # concurrent swap of that link retarget the native reader to an unchecked
+    # tree after validation. Resolving to the real path removes that mutable
+    # window; a symlinked *root* is still rejected outright by
+    # `is_safe_directory_tree` below (which runs on the original submitted path).
+    source_real = await run_in_threadpool(os.path.realpath, file_path)
+
+    normalized = os.path.normpath(source_real)
     display_filename = os.path.basename(normalized)
     output_path = await run_in_threadpool(
         _get_output_path, mode, normalized, output_dir,
@@ -475,7 +485,6 @@ async def _plan_directory_job(
     # guards against *other* jobs, not a job's own output.) Resolve symlinks
     # first so a symlinked output dir into the tree can't slip past this.
     output_real = await run_in_threadpool(os.path.realpath, output_path)
-    source_real = await run_in_threadpool(os.path.realpath, file_path)
     if output_real == source_real or output_real.startswith(source_real + os.sep):
         raise SkipFile(SkipReason.PS3_OUTPUT_INSIDE_SOURCE)
 
@@ -521,7 +530,7 @@ async def _plan_directory_job(
         duplicate_action == DuplicateAction.OVERWRITE and output_exists
     )
     return JobPlan(
-        file_path=file_path,
+        file_path=source_real,
         output_path=output_path,
         base_output_path=base_output_path,
         allow_overwrite=allow_overwrite,

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -851,6 +851,18 @@ async def create_job(request: JobCreateRequest):
             detail="Access denied: output directory outside configured volumes",
         )
 
+    # Proactive queue-depth check: reject with 429 *before* planning if the
+    # queue is already at capacity, so a full-queue submit doesn't pay for the
+    # PS3 folder safety walk (which stats the whole source tree) just to be
+    # rejected. Parity with the batch-create path, and surfaces backpressure
+    # even when tests or callers stub out ``job_manager.create_job``.
+    max_depth = max(0, int(getattr(settings, "max_queue_depth", 0) or 0))
+    if 0 < max_depth <= job_manager.get_queue_depth():
+        raise HTTPException(
+            status_code=429,
+            detail=f"Conversion queue full ({max_depth} jobs). Retry later.",
+        )
+
     try:
         plan = await plan_job(
             request.file_path,
@@ -868,17 +880,6 @@ async def create_job(request: JobCreateRequest):
             status_code=400,
             detail=f"Delete-on-verify blocked: {exc.message}",
         ) from None
-
-    # Proactive queue-depth check: reject with 429 before spending work
-    # on job construction if the queue is already at capacity.  Parity
-    # with the batch-create path, and surfaces backpressure even when
-    # tests or callers stub out ``job_manager.create_job``.
-    max_depth = max(0, int(getattr(settings, "max_queue_depth", 0) or 0))
-    if 0 < max_depth <= job_manager.get_queue_depth():
-        raise HTTPException(
-            status_code=429,
-            detail=f"Conversion queue full ({max_depth} jobs). Retry later.",
-        )
 
     try:
         job = await job_manager.create_job(
@@ -935,6 +936,18 @@ async def create_batch_jobs(request: BatchJobCreateRequest):
         raise HTTPException(
             status_code=403,
             detail="Access denied: output directory outside configured volumes",
+        )
+
+    # Fast-fail when the queue is already at capacity, before planning any
+    # candidate — planning a PS3 folder walks its whole source tree, so a
+    # full-queue batch shouldn't pay for that just to be rejected. The
+    # projected-depth check below still runs once the surviving candidate count
+    # is known (for the "would exceed" case where the queue isn't yet full).
+    max_depth = max(0, int(getattr(settings, "max_queue_depth", 0) or 0))
+    if 0 < max_depth <= job_manager.get_queue_depth():
+        raise HTTPException(
+            status_code=429,
+            detail=f"Conversion queue full ({max_depth} jobs). Retry later.",
         )
 
     skipped = []

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -459,8 +459,6 @@ async def _plan_directory_job(
     )
     if not accepts:
         raise SkipFile(SkipReason.PS3_FOLDER_INVALID)
-    if not await run_in_threadpool(is_safe_directory_tree, file_path):
-        raise SkipFile(SkipReason.PS3_FOLDER_UNSAFE)
 
     normalized = os.path.normpath(file_path)
     display_filename = os.path.basename(normalized)
@@ -509,6 +507,15 @@ async def _plan_directory_job(
             output_path = await run_in_threadpool(
                 get_unique_output_path, output_path, mode,
             )
+
+    # Recursive PS3 safety walk, deferred until the job is known to actually run.
+    # Skip/locked collisions above short-circuit first, so a batch SKIP over an
+    # already-converted large PS3 library isn't forced to stat every entry only
+    # to skip with OUTPUT_EXISTS. Jobs that will queue are still validated here,
+    # and `_process_job` revalidates the exact tree again after acquiring the
+    # directory lock, immediately before makeps3iso runs.
+    if not await run_in_threadpool(is_safe_directory_tree, file_path):
+        raise SkipFile(SkipReason.PS3_FOLDER_UNSAFE)
 
     allow_overwrite = (
         duplicate_action == DuplicateAction.OVERWRITE and output_exists

--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -27,7 +27,7 @@ from services.lock_manager import lock_manager
 from services.tools import InputKind, ModeKind, registry
 from sse_starlette.sse import EventSourceResponse
 from utils.delete_plan import build_delete_plan, build_delete_snapshot
-from utils.path_utils import is_within_configured_volumes
+from utils.path_utils import is_safe_directory_tree, is_within_configured_volumes
 
 router = APIRouter()
 logger = get_logger()
@@ -306,6 +306,7 @@ class SkipReason(Enum):
     PS3_FOLDER_INVALID = "ps3_folder_invalid"
     PS3_OUTPUT_INSIDE_SOURCE = "ps3_output_inside_source"
     PS3_OUTPUT_OUTSIDE_VOLUMES = "ps3_output_outside_volumes"
+    PS3_FOLDER_UNSAFE = "ps3_folder_unsafe"
 
 
 class SkipFile(Exception):  # noqa: N818 - control-flow signal, not an error
@@ -402,6 +403,10 @@ _SKIP_HTTP: dict[SkipReason, tuple[int, str]] = {
         "Default output .iso would land outside the configured volumes "
         "(the PS3 folder is a volume root); choose an in-volume output directory",
     ),
+    SkipReason.PS3_FOLDER_UNSAFE: (
+        400,
+        "PS3 folder contains symlinks or non-regular entries and cannot be packed safely",
+    ),
 }
 
 
@@ -454,6 +459,8 @@ async def _plan_directory_job(
     )
     if not accepts:
         raise SkipFile(SkipReason.PS3_FOLDER_INVALID)
+    if not await run_in_threadpool(is_safe_directory_tree, file_path):
+        raise SkipFile(SkipReason.PS3_FOLDER_UNSAFE)
 
     normalized = os.path.normpath(file_path)
     display_filename = os.path.basename(normalized)

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1790,15 +1790,15 @@ class JobManager:
                 if cancel_event.is_set():
                     raise ConversionCancelled("Conversion cancelled")
 
-            await self._clear_existing_output(job)
-
-            _convert_service = registry.for_mode(job.mode.value)
             if job.input_kind == InputKind.DIRECTORY:
                 # Re-check directory-input safety after acquiring the source
                 # subtree lock and immediately before invoking the native
                 # recursive packer. A queued PS3 folder job may have been
                 # valid when planned but mutated before it starts; this guards
-                # the exact tree makeps3iso is about to read.
+                # the exact tree makeps3iso is about to read. Run it *before*
+                # clearing any existing output so a safety rejection on an
+                # overwrite job is non-destructive: the user's prior ISO/split
+                # set is only removed once the source is confirmed still safe.
                 if not await run_in_threadpool(is_safe_directory_tree, input_path):
                     job.status = JobStatus.FAILED
                     job.error_message = (
@@ -1816,6 +1816,9 @@ class JobManager:
                     )
                     return
 
+            await self._clear_existing_output(job)
+
+            _convert_service = registry.for_mode(job.mode.value)
             async for update in _convert_service.convert(
                 input_path,
                 job.output_path,

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -25,7 +25,11 @@ from services.makeps3iso import makeps3iso_service
 from services.tools import ModeKind, registry
 from services.verification_store import verification_store
 from utils.delete_plan import build_delete_plan
-from utils.path_utils import is_within_configured_volumes, strip_archive_path
+from utils.path_utils import (
+    is_safe_directory_tree,
+    is_within_configured_volumes,
+    strip_archive_path,
+)
 
 logger = get_logger("job_manager")
 
@@ -1789,6 +1793,29 @@ class JobManager:
             await self._clear_existing_output(job)
 
             _convert_service = registry.for_mode(job.mode.value)
+            if job.input_kind == InputKind.DIRECTORY:
+                # Re-check directory-input safety after acquiring the source
+                # subtree lock and immediately before invoking the native
+                # recursive packer. A queued PS3 folder job may have been
+                # valid when planned but mutated before it starts; this guards
+                # the exact tree makeps3iso is about to read.
+                if not await run_in_threadpool(is_safe_directory_tree, input_path):
+                    job.status = JobStatus.FAILED
+                    job.error_message = (
+                        "PS3 folder contains symlinks, special files, "
+                        "or paths outside configured volumes"
+                    )
+                    job.completed_at = datetime.now(timezone.utc)
+                    await self._notify_subscribers(
+                        job_id,
+                        {
+                            "type": "error",
+                            "job_id": job_id,
+                            "error": job.error_message,
+                        },
+                    )
+                    return
+
             async for update in _convert_service.convert(
                 input_path,
                 job.output_path,

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1816,6 +1816,14 @@ class JobManager:
                     )
                     return
 
+            # The recursive PS3 safety walk above can take a while on a large
+            # source tree; honor a cancellation requested during it before
+            # deleting the user's existing output, mirroring the post-extract
+            # cancel check. Otherwise an overwrite job cancelled mid-walk would
+            # still clear the prior ISO/split set only to abort immediately.
+            if cancel_event.is_set():
+                raise ConversionCancelled("Conversion cancelled")
+
             await self._clear_existing_output(job)
 
             _convert_service = registry.for_mode(job.mode.value)

--- a/app/utils/path_utils.py
+++ b/app/utils/path_utils.py
@@ -76,26 +76,59 @@ def is_within_configured_volumes(path: str, *, treat_archives: bool = True) -> b
     return False
 
 
+def _strip_trailing_dot_and_seps(path: str) -> str:
+    """Strip only *trailing* separators and ``.`` components from ``path``.
+
+    Used to find the submitted root entry to ``lstat`` before resolution. Unlike
+    :func:`os.path.normpath`, interior ``..`` and symlinked components are left
+    intact: normalizing ``/vol/anchor/../LinkGame`` to ``/vol/LinkGame`` would
+    lexically cancel a symlinked ``anchor`` against the following ``..``, so a
+    pre-resolve ``lstat`` would probe a benign lexical path instead of the real
+    final component the kernel reaches (``/outside/LinkGame``). Keeping the
+    interior intact lets ``lstat`` resolve the ancestors exactly as the kernel
+    does and report the true final entry (catching a symlinked root), while the
+    trailing ``/`` / ``/.`` / ``/./`` are removed so the probe lands on that
+    entry itself rather than following it.
+    """
+    seps = os.sep + (os.altsep or "")
+    drive, tail = os.path.splitdrive(path)
+    prev = None
+    while tail != prev:
+        prev = tail
+        tail = tail.rstrip(seps)
+        # Drop a standalone trailing "." component (".", ".../.") — but never the
+        # "." inside a ".." component, which stays meaningful.
+        if tail.endswith(".") and (len(tail) == 1 or tail[-2] in seps):
+            tail = tail[:-1]
+    return (drive + tail) or path
+
+
 def is_safe_directory_tree(path: str) -> bool:
     """Return whether a directory tree is safe for native recursive readers.
 
     Native tools such as makeps3iso recursively read the source tree outside of
-    Python's path guards.  Reject symlinks and non-regular filesystem entries,
-    and require every visited entry to remain within both the source root and a
-    configured volume after resolution.
+    Python's path guards.  Reject symlinks and non-regular filesystem entries so
+    the confined root's real subtree is the only thing the native reader sees.
     """
-    if os.path.islink(path):
+    # Reject a symlinked source root before resolving it. A trailing separator
+    # or "." component (".../LinkGame/", ".../LinkGame/.", ".../LinkGame/./")
+    # makes ``os.path.islink``/``os.lstat`` follow the link to its target, so a
+    # request like ``/volume/LinkGame/`` would otherwise resolve the symlink
+    # away and hand the native packer a root pointing outside the configured
+    # volume. Strip only those trailing components (see the helper) and ``lstat``
+    # the resulting root: the kernel resolves any symlinked ancestors while
+    # ``lstat`` reports the final entry without following it, so a symlinked
+    # root is caught even behind a "." or a ".."-cancelled symlinked ancestor.
+    raw_root = _strip_trailing_dot_and_seps(path)
+    try:
+        raw_lstat = os.lstat(raw_root)
+    except OSError:
+        return False
+    if stat.S_ISLNK(raw_lstat.st_mode):
         return False
 
     root = _resolve_path(path, strict=True)
     if root is None or not root.is_dir():
-        return False
-
-    try:
-        root_lstat = os.lstat(root)
-    except OSError:
-        return False
-    if stat.S_ISLNK(root_lstat.st_mode):
         return False
 
     root_str = str(root)
@@ -125,16 +158,13 @@ def is_safe_directory_tree(path: str) -> bool:
                 return False
             if not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
                 return False
-
-            entry_real = _resolve_path(entry, strict=True)
-            if entry_real is None:
-                return False
-            try:
-                entry_real.relative_to(root)
-            except ValueError:
-                return False
-            if not is_within_configured_volumes(str(entry_real), treat_archives=False):
-                return False
+            # No per-entry resolve/volume re-check: ``os.walk(followlinks=False)``
+            # never descends through a symlink, and every symlink or special
+            # entry is rejected above, so each visited entry is a genuine child
+            # of the already volume-confined ``root``. Resolving and
+            # re-verifying containment for every file would add tens of
+            # thousands of redundant syscalls on a large PS3 tree while proving
+            # something the traversal already guarantees.
 
     return not walk_errors
 

--- a/app/utils/path_utils.py
+++ b/app/utils/path_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import errno
 import os
+import stat
 from pathlib import Path
 from typing import Optional
 
@@ -73,6 +74,69 @@ def is_within_configured_volumes(path: str, *, treat_archives: bool = True) -> b
             continue
 
     return False
+
+
+def is_safe_directory_tree(path: str) -> bool:
+    """Return whether a directory tree is safe for native recursive readers.
+
+    Native tools such as makeps3iso recursively read the source tree outside of
+    Python's path guards.  Reject symlinks and non-regular filesystem entries,
+    and require every visited entry to remain within both the source root and a
+    configured volume after resolution.
+    """
+    if os.path.islink(path):
+        return False
+
+    root = _resolve_path(path, strict=True)
+    if root is None or not root.is_dir():
+        return False
+
+    try:
+        root_lstat = os.lstat(root)
+    except OSError:
+        return False
+    if stat.S_ISLNK(root_lstat.st_mode):
+        return False
+
+    root_str = str(root)
+    if not is_within_configured_volumes(root_str, treat_archives=False):
+        return False
+
+    walk_errors: list[OSError] = []
+
+    def _record_walk_error(error: OSError) -> None:
+        walk_errors.append(error)
+
+    for current, dirs, files in os.walk(
+        root_str, topdown=True, followlinks=False, onerror=_record_walk_error,
+    ):
+        if walk_errors:
+            return False
+        entries = [*dirs, *files]
+        for name in entries:
+            entry = os.path.join(current, name)
+            try:
+                entry_lstat = os.lstat(entry)
+            except OSError:
+                return False
+
+            mode = entry_lstat.st_mode
+            if stat.S_ISLNK(mode):
+                return False
+            if not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
+                return False
+
+            entry_real = _resolve_path(entry, strict=True)
+            if entry_real is None:
+                return False
+            try:
+                entry_real.relative_to(root)
+            except ValueError:
+                return False
+            if not is_within_configured_volumes(str(entry_real), treat_archives=False):
+                return False
+
+    return not walk_errors
 
 
 def ensure_path_within_volumes(path: str, *, treat_archives: bool = True) -> Path:

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -520,7 +520,12 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   `os.walk(followlinks=False)` never descends through a link, the surviving
   entries are all genuine children of the confined root — no per-entry resolve
   is needed — so makeps3iso cannot dereference a link and embed files outside
-  the volume boundary.
+  the volume boundary. The directory job is also **canonicalized to the resolved
+  real source path** (`os.path.realpath`) before being queued, so makeps3iso is
+  handed a symlink-free path: a concurrent swap of a symlinked *ancestor*
+  component after validation cannot retarget the native reader to an unchecked
+  tree. (A symlinked *root* is still rejected outright, since the safety walk
+  runs on the original submitted path.)
 - **Job model.** `ConversionJob.input_kind: InputKind` is threaded end-to-end
   (derived from the mode spec at queue time, serialized to a string only at the
   API/persistence edge). The generic `_process_job` flow already handles a

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -357,6 +357,13 @@ flags. One-shot subprocess work (info / header / embedded-hash extraction)
 shares `run_capture()` rather than re-implementing the spawn / cancel / timeout /
 terminate dance per tool.
 
+Directory-input tools that hand a source tree to a native recursive reader must
+validate both at planning time and again in `JobManager._process_job` after the
+source subtree lock is acquired, immediately before invoking the tool. The PS3
+`folder_to_iso` path uses `is_safe_directory_tree` for both checks so a queued
+job cannot be made unsafe by adding a symlink, special file, or volume-escaping
+entry after planning but before `makeps3iso` starts.
+
 ### 3.3.1 Shared archive-limit enforcement (`services/archive.py`)
 
 `ArchiveService.enforce_archive_limits(members)` is the shared seam any

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -499,7 +499,11 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   cancel/failure, and runs a light **PARAM.SFO `TITLE_ID` readback** from the
   built ISO (reusing the shared `disc_id.read_iso_file` ISO 9660 reader) as an
   advisory check — `supports_delete_on_verify=False`, so a curated source folder
-  is never auto-deleted.
+  is never auto-deleted. Before queuing the native packer, `plan_job` also walks
+  the whole source tree with `utils.path_utils.is_safe_directory_tree`: symlinks
+  and non-regular entries are rejected, and every resolved entry must remain
+  under both the selected source root and a configured volume, so makeps3iso
+  cannot dereference a link and embed files outside the volume boundary.
 - **Job model.** `ConversionJob.input_kind: InputKind` is threaded end-to-end
   (derived from the mode spec at queue time, serialized to a string only at the
   API/persistence edge). The generic `_process_job` flow already handles a

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -365,7 +365,14 @@ job cannot be made unsafe by adding a symlink, special file, or volume-escaping
 entry after planning but before `makeps3iso` starts. The worker runs the
 re-check *before* `_clear_existing_output`, so a safety rejection on an
 overwrite job is non-destructive — the prior output is only cleared once the
-source is confirmed still safe.
+source is confirmed still safe. Because that walk can be slow on a large tree,
+the worker also re-checks the cancel event immediately after it (before
+clearing outputs), so a job cancelled mid-walk keeps its prior output. To keep
+the planning-time walk off the hot rejection paths, `_plan_directory_job` runs
+it only after the output is derived and skip/locked collisions short-circuit,
+and the create/batch routes apply queue-depth backpressure (HTTP 429) *before*
+planning when the queue is already full — so a doomed submit never pays for the
+tree walk.
 
 ### 3.3.1 Shared archive-limit enforcement (`services/archive.py`)
 

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -362,7 +362,10 @@ validate both at planning time and again in `JobManager._process_job` after the
 source subtree lock is acquired, immediately before invoking the tool. The PS3
 `folder_to_iso` path uses `is_safe_directory_tree` for both checks so a queued
 job cannot be made unsafe by adding a symlink, special file, or volume-escaping
-entry after planning but before `makeps3iso` starts.
+entry after planning but before `makeps3iso` starts. The worker runs the
+re-check *before* `_clear_existing_output`, so a safety rejection on an
+overwrite job is non-destructive — the prior output is only cleared once the
+source is confirmed still safe.
 
 ### 3.3.1 Shared archive-limit enforcement (`services/archive.py`)
 
@@ -507,10 +510,17 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   built ISO (reusing the shared `disc_id.read_iso_file` ISO 9660 reader) as an
   advisory check — `supports_delete_on_verify=False`, so a curated source folder
   is never auto-deleted. Before queuing the native packer, `plan_job` also walks
-  the whole source tree with `utils.path_utils.is_safe_directory_tree`: symlinks
-  and non-regular entries are rejected, and every resolved entry must remain
-  under both the selected source root and a configured volume, so makeps3iso
-  cannot dereference a link and embed files outside the volume boundary.
+  the whole source tree with `utils.path_utils.is_safe_directory_tree`: the root
+  is `lstat`ed after stripping only trailing separators and `.` components
+  (interior `..`/symlinked ancestors are left intact, so the kernel resolves
+  them and `lstat` reports the true final entry — a symlinked root cannot hide
+  behind a trailing `/`, `/.`, `/./`, or a `..`-cancelled symlinked ancestor)
+  and confined to a configured volume, then every
+  entry is `lstat`ed and any symlink or non-regular entry is rejected. Because
+  `os.walk(followlinks=False)` never descends through a link, the surviving
+  entries are all genuine children of the confined root — no per-entry resolve
+  is needed — so makeps3iso cannot dereference a link and embed files outside
+  the volume boundary.
 - **Job model.** `ConversionJob.input_kind: InputKind` is threaded end-to-end
   (derived from the mode spec at queue time, serialized to a string only at the
   API/persistence edge). The generic `_process_job` flow already handles a

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -8,9 +8,11 @@ and #179, part of the #177 tech-debt epic).
 ### Changed
 
 - **PS3 folder-to-ISO inputs are now recursively confined to configured volumes.**
-  Directory-input planning rejects symlinks and non-regular filesystem entries
-  before invoking `makeps3iso`, preventing a crafted PS3 folder from causing the
-  native packer to read and embed files outside the configured volume boundary.
+  Directory-input planning rejects symlinks and non-regular filesystem entries,
+  and the queued worker repeats the same safety walk after acquiring the source
+  directory lock immediately before invoking `makeps3iso`. This prevents a
+  crafted or mutated PS3 folder from causing the native packer to read and embed
+  files outside the configured volume boundary.
 
 - **Deterministic ordering across the registry, search, and runner (issue
   #183).** The `ToolRegistry` extension-union helpers (`convertible_extensions`,

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -10,9 +10,13 @@ and #179, part of the #177 tech-debt epic).
 - **PS3 folder-to-ISO inputs are now recursively confined to configured volumes.**
   Directory-input planning rejects symlinks and non-regular filesystem entries,
   and the queued worker repeats the same safety walk after acquiring the source
-  directory lock immediately before invoking `makeps3iso`. This prevents a
-  crafted or mutated PS3 folder from causing the native packer to read and embed
-  files outside the configured volume boundary.
+  directory lock and before clearing any existing output, immediately before
+  invoking `makeps3iso`. A symlinked source root is rejected even when hidden
+  behind a trailing separator, a `.`/`./` component, or a `..`-cancelled
+  symlinked ancestor. This prevents a crafted or mutated PS3 folder from
+  causing the native packer to read and embed files outside the configured
+  volume boundary, and keeps a safety rejection on an overwrite job from
+  deleting the user's prior output.
 
 - **Deterministic ordering across the registry, search, and runner (issue
   #183).** The `ToolRegistry` extension-union helpers (`convertible_extensions`,

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -7,6 +7,11 @@ and #179, part of the #177 tech-debt epic).
 
 ### Changed
 
+- **PS3 folder-to-ISO inputs are now recursively confined to configured volumes.**
+  Directory-input planning rejects symlinks and non-regular filesystem entries
+  before invoking `makeps3iso`, preventing a crafted PS3 folder from causing the
+  native packer to read and embed files outside the configured volume boundary.
+
 - **Deterministic ordering across the registry, search, and runner (issue
   #183).** The `ToolRegistry` extension-union helpers (`convertible_extensions`,
   `archive_input_extensions`, `verify_extensions`, `output_extensions`,

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -820,6 +820,75 @@ async def test_process_job_rejects_existing_split_set_without_overwrite(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_process_job_revalidates_ps3_tree_after_dir_lock(tmp_path, monkeypatch):
+    # A queued folder_to_iso job can be planned while safe, then have a symlink
+    # inserted before it reaches the worker. The worker must revalidate after
+    # acquiring the directory subtree lock and before makeps3iso runs.
+    from app.services import job_manager as job_manager_module
+    from app.services.job_manager import job_manager
+    from services.concurrency_manager import concurrency_manager
+    from services.lock_manager import lock_manager
+
+    folder_path = _make_ps3_folder(tmp_path / "volume" / "MyGame")
+    out = str(tmp_path / "volume" / "MyGame.iso")
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("secret", encoding="utf-8")
+    (folder_path / "PS3_GAME" / "LEAK.TXT").symlink_to(outside)
+
+    # is_safe_directory_tree consults its own imported settings singleton; patch
+    # that exact global so the temporary tree is treated as the configured volume.
+    monkeypatch.setattr(
+        job_manager_module.is_safe_directory_tree.__globals__["settings"],
+        "chd_volumes",
+        str(tmp_path / "volume"),
+    )
+    monkeypatch.setattr(
+        job_manager_module.is_safe_directory_tree.__globals__["settings"],
+        "data_mount_root",
+        str(tmp_path / "volume"),
+    )
+
+    called = False
+
+    async def fake_convert(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        yield {"progress": 100, "message": "should not run"}
+
+    monkeypatch.setattr(
+        job_manager_module.registry.for_mode("folder_to_iso"), "convert", fake_convert,
+    )
+
+    job = ConversionJob(
+        id="ps3unsafe1",
+        file_path=str(folder_path),
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.QUEUED,
+        created_at=datetime.now(timezone.utc),
+        output_path=out,
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=False,
+    )
+    job_manager.jobs[job.id] = job
+    try:
+        await job_manager._process_job(job.id)
+        assert job.status == JobStatus.FAILED
+        assert "PS3 folder contains symlinks" in (job.error_message or "")
+        assert called is False
+        _, output_locked = lock_manager.check_file_status(out)
+        assert output_locked is False
+        assert lock_manager.dir_lock_would_conflict(str(folder_path)) is False
+    finally:
+        lock_manager.release_lock(out)
+        lock_manager.release_dir_lock(str(folder_path))
+        concurrency_manager.release(job.id)
+        job_manager.jobs.pop(job.id, None)
+        job_manager._cancel_events.pop(job.id, None)
+        job_manager._cancelled.discard(job.id)
+
+
+@pytest.mark.asyncio
 async def test_process_job_rejects_directory_output(tmp_path):
     # A directory shadowing the output path (MyGame.iso/) is never a valid
     # makeps3iso target. acquire_lock already rejects it (its ``not isfile``

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -244,6 +244,34 @@ def test_strip_trailing_dot_and_seps(raw, expected):
 
 
 @pytest.mark.asyncio
+async def test_plan_job_canonicalizes_symlinked_ancestor(tmp_path, monkeypatch):
+    # A source reached through a symlinked ANCESTOR (link -> real) is accepted,
+    # but the plan must pack the resolved real path — not the mutable symlinked
+    # spelling — so a concurrent swap of the ancestor link can't retarget
+    # makeps3iso to an unchecked tree after validation.
+    _confine_to_volume(monkeypatch, tmp_path / "volume")
+    volume = tmp_path / "volume"
+    real_parent = volume / "real"
+    real_parent.mkdir(parents=True)
+    folder = _make_ps3_folder(real_parent / "MyGame")
+    (volume / "link").symlink_to(real_parent, target_is_directory=True)
+
+    submitted = str(volume / "link" / "MyGame")  # traverses the symlinked ancestor
+    plan = await convert_routes.plan_job(
+        submitted,
+        spec=registry.spec("folder_to_iso"),
+        mode="folder_to_iso",
+        output_dir=None,
+        duplicate_action=convert_routes.DuplicateAction.SKIP,
+        delete_on_verify=False,
+    )
+    # Packed path is the real, symlink-free location.
+    assert plan.file_path == os.path.realpath(submitted)
+    assert plan.file_path == str(folder)
+    assert f"{os.sep}link{os.sep}" not in plan.file_path
+
+
+@pytest.mark.asyncio
 async def test_plan_job_rejects_symlinked_root_behind_dotdot_cancelled_ancestor(
     tmp_path, monkeypatch,
 ):

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -7,6 +7,7 @@ search directory annotation, the service convert (mocked subprocess), and the
 from __future__ import annotations
 
 import asyncio
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -160,6 +161,113 @@ async def test_plan_job_rejects_ps3_dir_with_symlinked_file(tmp_path, monkeypatc
     with pytest.raises(convert_routes.SkipFile) as exc:
         await convert_routes.plan_job(
             str(folder),
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_UNSAFE
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rejects_symlinked_ps3_root_with_trailing_slash(tmp_path, monkeypatch):
+    # A symlinked source root must be rejected even with a trailing separator: a
+    # trailing slash makes os.path.islink/os.lstat follow the link, so
+    # is_safe_directory_tree must lstat the trailing-slash-stripped path to keep
+    # a request like "/volume/LinkGame/" from handing makeps3iso a symlinked root.
+    _confine_to_volume(monkeypatch, tmp_path / "volume")
+    volume = tmp_path / "volume"
+    real_folder = _make_ps3_folder(volume / "MyGame")
+    link_root = volume / "LinkGame"
+    link_root.symlink_to(real_folder, target_is_directory=True)
+
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(link_root) + os.sep,
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_UNSAFE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suffix", [os.sep + ".", os.sep + "." + os.sep])
+async def test_plan_job_rejects_symlinked_ps3_root_with_dot_component(
+    tmp_path, monkeypatch, suffix,
+):
+    # A symlinked source root must be rejected even when hidden behind a trailing
+    # "." or "./" component: those make os.lstat follow the link, so
+    # is_safe_directory_tree must normalize them away before the pre-resolve lstat
+    # to keep "/vol/link/." from handing makeps3iso a symlinked root.
+    _confine_to_volume(monkeypatch, tmp_path / "volume")
+    volume = tmp_path / "volume"
+    real_folder = _make_ps3_folder(volume / "MyGame")
+    link_root = volume / "LinkGame"
+    link_root.symlink_to(real_folder, target_is_directory=True)
+
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(link_root) + suffix,
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_UNSAFE
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("/vol/link", "/vol/link"),
+        ("/vol/link/", "/vol/link"),
+        ("/vol/link/.", "/vol/link"),
+        ("/vol/link/./", "/vol/link"),
+        ("/vol/link///", "/vol/link"),
+        ("/", "/"),
+        (".", "."),
+        # Interior ".." and symlinked ancestors must survive untouched so lstat
+        # resolves them the way the kernel does.
+        ("/vol/anchor/../link", "/vol/anchor/../link"),
+        ("/vol/game/subdir/..", "/vol/game/subdir/.."),
+    ],
+)
+def test_strip_trailing_dot_and_seps(raw, expected):
+    from app.utils.path_utils import _strip_trailing_dot_and_seps
+
+    assert _strip_trailing_dot_and_seps(raw) == expected
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rejects_symlinked_root_behind_dotdot_cancelled_ancestor(
+    tmp_path, monkeypatch,
+):
+    # A symlinked root reached through a ".."-cancelled symlinked ancestor must
+    # still be rejected. Submitting "<volume>/anchor/../LinkGame" (anchor is a
+    # symlink) lexically normalizes to "<volume>/LinkGame" — a benign decoy dir —
+    # but the kernel resolves ".." *after* following anchor, so the real final
+    # component is a symlink. The pre-resolve lstat must probe the un-normalized
+    # path so S_ISLNK catches it, rather than lstat'ing the lexical decoy.
+    _confine_to_volume(monkeypatch, tmp_path / "volume")
+    volume = tmp_path / "volume"
+    real_folder = _make_ps3_folder(volume / "RealGame")
+    outside = tmp_path / "outside"
+    (outside / "x").mkdir(parents=True)
+    (volume / "anchor").symlink_to(outside / "x", target_is_directory=True)
+    (outside / "LinkGame").symlink_to(real_folder, target_is_directory=True)
+    # Decoy: the path that lexical normalization ("anchor/.." cancels) would hit,
+    # existing as a plain directory so an lstat on it would wrongly pass.
+    (volume / "LinkGame").mkdir()
+
+    submitted = str(volume / "anchor") + os.sep + ".." + os.sep + "LinkGame"
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            submitted,
             spec=registry.spec("folder_to_iso"),
             mode="folder_to_iso",
             output_dir=None,
@@ -879,6 +987,77 @@ async def test_process_job_revalidates_ps3_tree_after_dir_lock(tmp_path, monkeyp
         _, output_locked = lock_manager.check_file_status(out)
         assert output_locked is False
         assert lock_manager.dir_lock_would_conflict(str(folder_path)) is False
+    finally:
+        lock_manager.release_lock(out)
+        lock_manager.release_dir_lock(str(folder_path))
+        concurrency_manager.release(job.id)
+        job_manager.jobs.pop(job.id, None)
+        job_manager._cancel_events.pop(job.id, None)
+        job_manager._cancelled.discard(job.id)
+
+
+@pytest.mark.asyncio
+async def test_process_job_revalidation_is_non_destructive_on_overwrite(tmp_path, monkeypatch):
+    # An overwrite folder_to_iso job whose source turned unsafe after planning
+    # must fail *without* deleting the user's prior output: the revalidation
+    # runs before _clear_existing_output, so the existing ISO is preserved.
+    from app.services import job_manager as job_manager_module
+    from app.services.job_manager import job_manager
+    from services.concurrency_manager import concurrency_manager
+    from services.lock_manager import lock_manager
+
+    folder_path = _make_ps3_folder(tmp_path / "volume" / "MyGame")
+    out = str(tmp_path / "volume" / "MyGame.iso")
+    # A prior output already exists — an overwrite job would normally clear it.
+    with open(out, "wb") as prior:
+        prior.write(b"previous-iso-contents")
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("secret", encoding="utf-8")
+    (folder_path / "PS3_GAME" / "LEAK.TXT").symlink_to(outside)
+
+    monkeypatch.setattr(
+        job_manager_module.is_safe_directory_tree.__globals__["settings"],
+        "chd_volumes",
+        str(tmp_path / "volume"),
+    )
+    monkeypatch.setattr(
+        job_manager_module.is_safe_directory_tree.__globals__["settings"],
+        "data_mount_root",
+        str(tmp_path / "volume"),
+    )
+
+    called = False
+
+    async def fake_convert(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        yield {"progress": 100, "message": "should not run"}
+
+    monkeypatch.setattr(
+        job_manager_module.registry.for_mode("folder_to_iso"), "convert", fake_convert,
+    )
+
+    job = ConversionJob(
+        id="ps3unsafe2",
+        file_path=str(folder_path),
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.QUEUED,
+        created_at=datetime.now(timezone.utc),
+        output_path=out,
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=True,
+    )
+    job_manager.jobs[job.id] = job
+    try:
+        await job_manager._process_job(job.id)
+        assert job.status == JobStatus.FAILED
+        assert "PS3 folder contains symlinks" in (job.error_message or "")
+        assert called is False
+        # The prior output must be untouched — rejection is non-destructive.
+        assert os.path.exists(out)
+        with open(out, "rb") as saved:
+            assert saved.read() == b"previous-iso-contents"
     finally:
         lock_manager.release_lock(out)
         lock_manager.release_dir_lock(str(folder_path))

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -149,6 +149,49 @@ async def test_plan_job_rejects_output_outside_volumes(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_plan_job_rejects_ps3_dir_with_symlinked_file(tmp_path, monkeypatch):
+    _confine_to_volume(monkeypatch, tmp_path / "volume")
+    volume = tmp_path / "volume"
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("secret", encoding="utf-8")
+    folder = _make_ps3_folder(volume / "MyGame")
+    (folder / "PS3_GAME" / "LEAK.TXT").symlink_to(outside)
+
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(folder),
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_UNSAFE
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rejects_ps3_dir_with_symlinked_directory(tmp_path, monkeypatch):
+    _confine_to_volume(monkeypatch, tmp_path / "volume")
+    volume = tmp_path / "volume"
+    outside_dir = tmp_path / "outside-dir"
+    outside_dir.mkdir()
+    (outside_dir / "secret.txt").write_text("secret", encoding="utf-8")
+    folder = _make_ps3_folder(volume / "MyGame")
+    (folder / "PS3_GAME" / "EXTRA").symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(folder),
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_UNSAFE
+
+
+@pytest.mark.asyncio
 async def test_plan_job_rejects_non_ps3_dir(tmp_path):
     plain = tmp_path / "plain"
     plain.mkdir()

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -316,9 +316,12 @@ async def test_plan_job_rejects_non_ps3_dir(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_plan_job_rejects_output_inside_source(tmp_path):
+async def test_plan_job_rejects_output_inside_source(tmp_path, monkeypatch):
     # An output_dir inside the source folder would make makeps3iso pack its own
-    # in-progress ISO and corrupt the image — must be rejected.
+    # in-progress ISO and corrupt the image — must be rejected. Confine the
+    # source to a configured volume so the (safe) tree passes is_safe_directory_tree
+    # and the output-inside-source guard is the one that fires.
+    _confine_to_volume(monkeypatch, tmp_path)
     folder = _make_ps3_folder(tmp_path / "MyGame")
     with pytest.raises(convert_routes.SkipFile) as exc:
         await convert_routes.plan_job(
@@ -330,6 +333,40 @@ async def test_plan_job_rejects_output_inside_source(tmp_path):
             delete_on_verify=False,
         )
     assert exc.value.reason is convert_routes.SkipReason.PS3_OUTPUT_INSIDE_SOURCE
+
+
+@pytest.mark.asyncio
+async def test_plan_job_skip_conflict_short_circuits_before_safety_walk(
+    tmp_path, monkeypatch,
+):
+    # A SKIP request whose output already exists must short-circuit with
+    # OUTPUT_EXISTS *without* running the recursive PS3 safety walk — otherwise a
+    # batch skip over a large already-converted library stats every tree for
+    # nothing. The worker still revalidates the tree for jobs that actually run.
+    _confine_to_volume(monkeypatch, tmp_path)
+    folder = _make_ps3_folder(tmp_path / "MyGame")
+    (tmp_path / "MyGame.iso").write_bytes(b"iso")  # existing sibling output
+
+    walked = False
+
+    def _tracking_walk(path):
+        nonlocal walked
+        walked = True
+        return True
+
+    monkeypatch.setattr(convert_routes, "is_safe_directory_tree", _tracking_walk)
+
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(folder),
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.OUTPUT_EXISTS
+    assert walked is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -1133,6 +1133,70 @@ async def test_process_job_revalidation_is_non_destructive_on_overwrite(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_process_job_honors_cancel_during_safety_walk(tmp_path, monkeypatch):
+    # A cancellation that arrives while the pre-pack safety walk is running must
+    # be honored before _clear_existing_output, so an overwrite job cancelled
+    # mid-walk keeps the user's prior output instead of clearing it and aborting.
+    from app.services import job_manager as job_manager_module
+    from app.services.job_manager import job_manager
+    from services.concurrency_manager import concurrency_manager
+    from services.lock_manager import lock_manager
+
+    folder_path = _make_ps3_folder(tmp_path / "volume" / "MyGame")
+    out = str(tmp_path / "volume" / "MyGame.iso")
+    with open(out, "wb") as prior:
+        prior.write(b"previous-iso-contents")
+
+    called = False
+
+    async def fake_convert(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        yield {"progress": 100, "message": "should not run"}
+
+    monkeypatch.setattr(
+        job_manager_module.registry.for_mode("folder_to_iso"), "convert", fake_convert,
+    )
+
+    # Simulate a cancellation arriving *during* the walk: the patched safety
+    # check sets the job's cancel event, then reports the tree as safe. The
+    # worker must then bail out before clearing the existing output.
+    def cancel_midwalk(_path):
+        job_manager._cancel_events["cancelmidwalk"].set()
+        return True
+
+    monkeypatch.setattr(job_manager_module, "is_safe_directory_tree", cancel_midwalk)
+
+    job = ConversionJob(
+        id="cancelmidwalk",
+        file_path=str(folder_path),
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.QUEUED,
+        created_at=datetime.now(timezone.utc),
+        output_path=out,
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=True,
+    )
+    job_manager.jobs[job.id] = job
+    try:
+        await job_manager._process_job(job.id)
+        assert job.status == JobStatus.CANCELLED
+        assert called is False
+        # The prior output survives — cancel is honored before clearing.
+        assert os.path.exists(out)
+        with open(out, "rb") as saved:
+            assert saved.read() == b"previous-iso-contents"
+    finally:
+        lock_manager.release_lock(out)
+        lock_manager.release_dir_lock(str(folder_path))
+        concurrency_manager.release(job.id)
+        job_manager.jobs.pop(job.id, None)
+        job_manager._cancel_events.pop(job.id, None)
+        job_manager._cancelled.discard(job.id)
+
+
+@pytest.mark.asyncio
 async def test_process_job_rejects_directory_output(tmp_path):
     # A directory shadowing the output path (MyGame.iso/) is never a valid
     # makeps3iso target. acquire_lock already rejects it (its ``not isfile``


### PR DESCRIPTION
### Motivation
- Directory-input planning for the PS3 folder→ISO seam only performed shallow checks and could hand a folder containing symlinks or special filesystem entries to the native `makeps3iso` packer, allowing files outside configured volumes to be embedded into the produced ISO.  
- The change prevents a crafted source tree from escaping the configured-volume confinement by rejecting unsafe trees before the native packer runs.

### Description
- Add a recursive safety validator `is_safe_directory_tree(path: str)` in `app/utils/path_utils.py` that rejects symlinks, non-regular entries, unreadable walk errors, and entries whose resolved path does not remain inside the source root and a configured volume.  
- Invoke `is_safe_directory_tree` from `_plan_directory_job` in `app/routes/convert.py` and add a `PS3_FOLDER_UNSAFE` `SkipReason` with a 400 message when the validator fails.  
- Add two regression tests in `tests/test_makeps3iso.py` to assert `plan_job` rejects PS3 folders containing a symlinked file and a symlinked directory.  
- Document the hardening in `docs/DESIGN_tool_plugin_architecture.md` and `docs/RELEASE_NOTES.md`.

### Testing
- Ran `python -m py_compile app/utils/path_utils.py app/routes/convert.py` and it succeeded.  
- Ran `PYTHONPATH=app pytest -q tests/test_ps3_detector.py` and it passed (`6 passed`).  
- Performed a manual `PYTHONPATH=app python - <<'PY' ... PY` invocation that calls `plan_job` against PS3 folders with symlinked file and directory entries and confirmed they raise `SkipFile` with `SkipReason.PS3_FOLDER_UNSAFE`.  
- Attempted to run the full test suite, but `pytest-asyncio` (dev dependency) was not available in the environment and `pip install -r requirements-dev.txt` failed due to outbound index access returning `403 Forbidden`, so a complete CI-style run could not be completed here; async-enabled tests therefore failed during local collection in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a529400900c8323bea7c328fa1a2b71)