### PR TITLE
Require confirmation header for recursive delete and block configured-volume-root deletion

### DIFF
--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -5,7 +5,7 @@ import shutil
 from pathlib import Path
 
 from config import settings
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.concurrency import run_in_threadpool
 from models import (
     BulkDeleteRequest,
@@ -25,6 +25,7 @@ from utils.junk import is_junk_entry
 from utils.path_utils import (
     ensure_path_within_volumes,
     get_volume_name_for_path,
+    is_configured_volume_root,
     is_within_configured_volumes,
 )
 
@@ -34,6 +35,8 @@ logger = get_logger("files")
 # Upper bound on archives summarized in one /archive-summary request. The browser
 # hydrates the visible page, so this is a safety ceiling, not the normal size.
 MAX_ARCHIVE_SUMMARY_PATHS = 1000
+ACTION_CONFIRM_HEADER = "x-chd-action-confirm"
+CONFIRM_RECURSIVE_DELETE = "recursive-delete"
 
 
 # A makeps3iso ``-s`` split set: ``Game.iso.0``, ``Game.iso.1``, … The numeric
@@ -820,6 +823,7 @@ async def rename_file(
 
 @router.delete("/files/delete")
 async def delete_file(
+    request: Request,
     path: str = Query(..., description="Path to file or directory to delete"),
     recursive: bool = Query(
         False,
@@ -839,6 +843,11 @@ async def delete_file(
         raise HTTPException(status_code=404, detail="File or directory not found")
 
     is_dir = await run_in_threadpool(os.path.isdir, path)
+    if is_dir and await run_in_threadpool(
+        is_configured_volume_root, path, treat_archives=False,
+    ):
+        raise HTTPException(status_code=400, detail="Cannot delete a configured volume root")
+
     # For a recursive directory delete this also rejects the request if any
     # active job's path lives under the directory (see _assert_path_not_in_use).
     await _assert_path_not_in_use(path, is_dir=is_dir)
@@ -854,6 +863,12 @@ async def delete_file(
                     detail="Directory is not empty; confirm recursive delete to remove it",
                 )
             if contents:
+                confirmation = request.headers.get(ACTION_CONFIRM_HEADER, "")
+                if confirmation != CONFIRM_RECURSIVE_DELETE:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Missing confirmation header for recursive delete",
+                    )
                 await run_in_threadpool(shutil.rmtree, path)
             else:
                 await run_in_threadpool(os.rmdir, path)

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -920,6 +920,14 @@ async def delete_files_batch(request: BulkDeleteRequest) -> dict:
 
         try:
             if is_dir:
+                if await run_in_threadpool(
+                    is_configured_volume_root, path, treat_archives=False,
+                ):
+                    return {
+                        "path": path,
+                        "success": False,
+                        "error": "Cannot delete a configured volume root",
+                    }
                 # Only delete empty directories for safety
                 # os.listdir can be blocking
                 contents = await run_in_threadpool(os.listdir, path)

--- a/app/utils/path_utils.py
+++ b/app/utils/path_utils.py
@@ -75,6 +75,21 @@ def is_within_configured_volumes(path: str, *, treat_archives: bool = True) -> b
     return False
 
 
+def is_configured_volume_root(path: str, *, treat_archives: bool = True) -> bool:
+    """Check whether the given path is exactly one of the configured volume roots."""
+    base_path = strip_archive_path(path) if treat_archives else path
+    real_path = _resolve_path(base_path, strict=False)
+    if real_path is None:
+        return False
+
+    for volume in settings.volumes:
+        real_volume = _resolve_volume(volume)
+        if real_volume is not None and real_path == real_volume:
+            return True
+
+    return False
+
+
 def ensure_path_within_volumes(path: str, *, treat_archives: bool = True) -> Path:
     """Return the resolved path if it is within configured volumes, else raise ValueError."""
     if not is_within_configured_volumes(path, treat_archives=treat_archives):

--- a/src/lib/api/client.js
+++ b/src/lib/api/client.js
@@ -18,6 +18,7 @@ export const CONFIRM = Object.freeze({
   CANCEL_ALL_JOBS: 'cancel-all-jobs',
   CLEAR_COMPLETED_JOBS: 'clear-completed-jobs',
   DELETE_ON_VERIFY: 'delete-on-verify',
+  RECURSIVE_DELETE: 'recursive-delete',
 });
 
 /**

--- a/src/lib/api/endpoints.js
+++ b/src/lib/api/endpoints.js
@@ -148,9 +148,10 @@ export const api = {
   deleteFile(path, { recursive = false } = {}) {
     const params = new URLSearchParams({ path });
     if (recursive) params.set('recursive', 'true');
+    const headers = recursive ? { 'X-CHD-Action-Confirm': CONFIRM.RECURSIVE_DELETE } : {};
     return fetchJson(
       buildApiUrl('/files/delete', params),
-      { method: 'DELETE' },
+      { method: 'DELETE', headers },
       'Failed to delete',
     );
   },

--- a/tests/test_files_junk_and_delete.py
+++ b/tests/test_files_junk_and_delete.py
@@ -6,13 +6,14 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+from starlette.datastructures import Headers
 
 from app.routes import files as files_routes
 from app.utils.junk import is_junk_entry, is_junk_path
 
 
 def _request(headers: dict[str, str] | None = None):
-    return SimpleNamespace(headers=headers or {})
+    return SimpleNamespace(headers=Headers(headers or {}))
 
 
 @pytest.fixture(name="vol")
@@ -107,6 +108,25 @@ async def test_delete_configured_volume_root_is_blocked(vol: Path):
     assert "volume root" in exc.value.detail.lower()
     assert vol.exists()
     assert (vol / "a.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_batch_blocks_configured_volume_root(vol: Path):
+    # An empty configured volume root must not be removable through the batch
+    # endpoint, which deletes empty directories with os.rmdir.
+    for child in vol.iterdir():
+        child.unlink()
+    assert not any(vol.iterdir())
+
+    response = await files_routes.delete_files_batch(
+        files_routes.BulkDeleteRequest(paths=[str(vol)]),
+    )
+    assert response["success"] == 0
+    assert response["failed"] == 1
+    result = response["results"][0]
+    assert result["success"] is False
+    assert "volume root" in result["error"].lower()
+    assert vol.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_files_junk_and_delete.py
+++ b/tests/test_files_junk_and_delete.py
@@ -2,12 +2,17 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
 
 from app.routes import files as files_routes
 from app.utils.junk import is_junk_entry, is_junk_path
+
+
+def _request(headers: dict[str, str] | None = None):
+    return SimpleNamespace(headers=headers or {})
 
 
 @pytest.fixture(name="vol")
@@ -68,21 +73,47 @@ async def test_delete_nonempty_dir_requires_recursive(vol: Path):
     # recursive=False is what HTTP resolves when the param is absent; pass it
     # explicitly here since a direct call leaves Query(...) defaults unresolved.
     with pytest.raises(HTTPException) as exc:
-        await files_routes.delete_file(path=str(d), recursive=False)
+        await files_routes.delete_file(_request(), path=str(d), recursive=False)
     assert exc.value.status_code == 409
     assert "not empty" in exc.value.detail.lower()
     assert d.exists()  # nothing deleted on the refusal
 
-    result = await files_routes.delete_file(path=str(d), recursive=True)
+    with pytest.raises(HTTPException) as exc:
+        await files_routes.delete_file(_request(), path=str(d), recursive=True)
+    assert exc.value.status_code == 400
+    assert "confirmation header" in exc.value.detail.lower()
+    assert d.exists()
+
+    result = await files_routes.delete_file(
+        _request({"x-chd-action-confirm": "recursive-delete"}),
+        path=str(d),
+        recursive=True,
+    )
     assert result["success"] is True
     assert not d.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_configured_volume_root_is_blocked(vol: Path):
+    (vol / "a.txt").write_bytes(b"x")
+
+    with pytest.raises(HTTPException) as exc:
+        await files_routes.delete_file(
+            _request({"x-chd-action-confirm": "recursive-delete"}),
+            path=str(vol),
+            recursive=True,
+        )
+    assert exc.value.status_code == 400
+    assert "volume root" in exc.value.detail.lower()
+    assert vol.exists()
+    assert (vol / "a.txt").exists()
 
 
 @pytest.mark.asyncio
 async def test_delete_empty_dir_needs_no_recursive(vol: Path):
     d = vol / "empty"
     d.mkdir()
-    result = await files_routes.delete_file(path=str(d), recursive=False)
+    result = await files_routes.delete_file(_request(), path=str(d), recursive=False)
     assert result["success"] is True
     assert not d.exists()
 
@@ -91,6 +122,6 @@ async def test_delete_empty_dir_needs_no_recursive(vol: Path):
 async def test_delete_file(vol: Path):
     f = vol / "x.bin"
     f.write_bytes(b"x")
-    result = await files_routes.delete_file(path=str(f), recursive=False)
+    result = await files_routes.delete_file(_request(), path=str(f), recursive=False)
     assert result["success"] is True
     assert not f.exists()


### PR DESCRIPTION
### Motivation
- Close a critical vulnerability where the `DELETE /api/files/delete?recursive=true` query parameter allowed unauthenticated callers to recursively remove any in-volume directory (including an entire configured volume root) without server-side confirmation or a volume-root guard.

### Description
- Require a confirmation header `X-CHD-Action-Confirm: recursive-delete` before performing `shutil.rmtree` on a non-empty directory and return 400 if it is missing (change in `app/routes/files.py`).
- Add a server-side guard that rejects attempts to delete a configured volume root even when recursive deletion is requested, implemented via `is_configured_volume_root` in `app/utils/path_utils.py` and checked in `app/routes/files.py`.
- Surface a named confirmation token to the frontend and send the header only when recursive deletion is requested (changes in `src/lib/api/client.js` and `src/lib/api/endpoints.js`).
- Add regression checks that exercise the header requirement and the volume-root block in `tests/test_files_junk_and_delete.py`.

### Testing
- Compiled modified modules with `PYTHONPATH=app python -m py_compile app/routes/files.py app/utils/path_utils.py`, which succeeded.
- Ran a targeted async smoke check (local Python script invoking `delete_file` with a fake `Request`-like object) that verified: missing confirmation header returns 400, confirmed recursive delete succeeds, and deletion of a configured volume root is blocked; all assertions passed.
- Ran `npm run lint` for the frontend changes, which completed without errors.
- Attempted to run the test suite (`pytest`), but the environment is missing `pytest-asyncio` and installing dev requirements failed due to package index/network restrictions (pip returned 403), so full automated test runs could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5297926510832397678a14750a342b)