### PR TITLE
Address PR #216 review: block volume-root deletion in batch endpoint

### DIFF
--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -920,6 +920,14 @@ async def delete_files_batch(request: BulkDeleteRequest) -> dict:
 
         try:
             if is_dir:
+                if await run_in_threadpool(
+                    is_configured_volume_root, path, treat_archives=False,
+                ):
+                    return {
+                        "path": path,
+                        "success": False,
+                        "error": "Cannot delete a configured volume root",
+                    }
                 # Only delete empty directories for safety
                 # os.listdir can be blocking
                 contents = await run_in_threadpool(os.listdir, path)

--- a/tests/test_files_junk_and_delete.py
+++ b/tests/test_files_junk_and_delete.py
@@ -6,13 +6,14 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+from starlette.datastructures import Headers
 
 from app.routes import files as files_routes
 from app.utils.junk import is_junk_entry, is_junk_path
 
 
 def _request(headers: dict[str, str] | None = None):
-    return SimpleNamespace(headers=headers or {})
+    return SimpleNamespace(headers=Headers(headers or {}))
 
 
 @pytest.fixture(name="vol")
@@ -107,6 +108,25 @@ async def test_delete_configured_volume_root_is_blocked(vol: Path):
     assert "volume root" in exc.value.detail.lower()
     assert vol.exists()
     assert (vol / "a.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_batch_blocks_configured_volume_root(vol: Path):
+    # An empty configured volume root must not be removable through the batch
+    # endpoint, which deletes empty directories with os.rmdir.
+    for child in vol.iterdir():
+        child.unlink()
+    assert not any(vol.iterdir())
+
+    response = await files_routes.delete_files_batch(
+        files_routes.BulkDeleteRequest(paths=[str(vol)]),
+    )
+    assert response["success"] == 0
+    assert response["failed"] == 1
+    result = response["results"][0]
+    assert result["success"] is False
+    assert "volume root" in result["error"].lower()
+    assert vol.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up addressing review feedback on #216. Targets that PR's head branch so the fixes land in #216 when merged.

### Changes

- **Extend the volume-root guard to the batch delete endpoint** (Codex P2 review comment). `POST /api/files/delete-batch` removes empty directories with `os.rmdir` and only checked `is_within_configured_volumes`, so an empty configured volume root could still be deleted through the batch path — bypassing the single-delete guard added in #216. It now rejects a configured volume root via `is_configured_volume_root` before removal.
- **Use `starlette.datastructures.Headers` for the mock request headers** in `tests/test_files_junk_and_delete.py` (Gemini Code Assist review comments). This exercises the same case-insensitive header lookup as real FastAPI/Starlette requests instead of a plain `dict`.
- **Add a regression test** (`test_delete_batch_blocks_configured_volume_root`) covering the new batch-endpoint guard.

### Testing

- `PYTHONPATH=app python -m pytest tests/test_files_junk_and_delete.py -q` → 23 passed.
- `ruff check app/routes/files.py tests/test_files_junk_and_delete.py` → clean.
- Full suite: the only failures are the pre-existing `test_archive_conversion_e2e.py` cases, which require external conversion binaries not present in this environment and fail identically without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nn73gxHK7Rg9NnSG8JJFJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn73gxHK7Rg9NnSG8JJFJB)_