### PR TITLE
Address #215 review: harden PS3 root symlink check, drop redundant per-entry resolution, non-destructive revalidation

### DIFF
--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1790,15 +1790,15 @@ class JobManager:
                 if cancel_event.is_set():
                     raise ConversionCancelled("Conversion cancelled")
 
-            await self._clear_existing_output(job)
-
-            _convert_service = registry.for_mode(job.mode.value)
             if job.input_kind == InputKind.DIRECTORY:
                 # Re-check directory-input safety after acquiring the source
                 # subtree lock and immediately before invoking the native
                 # recursive packer. A queued PS3 folder job may have been
                 # valid when planned but mutated before it starts; this guards
-                # the exact tree makeps3iso is about to read.
+                # the exact tree makeps3iso is about to read. Run it *before*
+                # clearing any existing output so a safety rejection on an
+                # overwrite job is non-destructive: the user's prior ISO/split
+                # set is only removed once the source is confirmed still safe.
                 if not await run_in_threadpool(is_safe_directory_tree, input_path):
                     job.status = JobStatus.FAILED
                     job.error_message = (
@@ -1816,6 +1816,9 @@ class JobManager:
                     )
                     return
 
+            await self._clear_existing_output(job)
+
+            _convert_service = registry.for_mode(job.mode.value)
             async for update in _convert_service.convert(
                 input_path,
                 job.output_path,

--- a/app/utils/path_utils.py
+++ b/app/utils/path_utils.py
@@ -84,17 +84,16 @@ def is_safe_directory_tree(path: str) -> bool:
     the confined root's real subtree is the only thing the native reader sees.
     """
     # Reject a symlinked source root before resolving it. A trailing separator
+    # or "." component (".../LinkGame/", ".../LinkGame/.", ".../LinkGame/./")
     # makes ``os.path.islink``/``os.lstat`` follow the link to its target, so a
     # request like ``/volume/LinkGame/`` would otherwise resolve the symlink
     # away and hand the native packer a root pointing outside the configured
-    # volume. Strip trailing separators and ``lstat`` the original path itself.
-    # Preserve any drive prefix: on Windows ``"C:\\".rstrip(sep)`` collapses to
-    # ``"C:"``, which ``lstat`` resolves to the *current directory* on that
-    # drive rather than the drive root, so strip only the remainder.
-    seps = os.sep + (os.altsep or "")
-    drive, rest = os.path.splitdrive(path)
-    stripped_rest = rest.rstrip(seps)
-    raw_root = drive + stripped_rest if stripped_rest else path
+    # volume. ``os.path.normpath`` collapses those trailing components (and any
+    # duplicate separators) purely lexically — without following symlinks — so
+    # the ``lstat`` sees the submitted root itself. It also preserves a drive
+    # root (``"C:\\"`` stays ``"C:\\"`` and never collapses to ``"C:"``, which
+    # would target the current directory on that drive).
+    raw_root = os.path.normpath(path) if path else path
     try:
         raw_lstat = os.lstat(raw_root)
     except OSError:

--- a/app/utils/path_utils.py
+++ b/app/utils/path_utils.py
@@ -80,22 +80,25 @@ def is_safe_directory_tree(path: str) -> bool:
     """Return whether a directory tree is safe for native recursive readers.
 
     Native tools such as makeps3iso recursively read the source tree outside of
-    Python's path guards.  Reject symlinks and non-regular filesystem entries,
-    and require every visited entry to remain within both the source root and a
-    configured volume after resolution.
+    Python's path guards.  Reject symlinks and non-regular filesystem entries so
+    the confined root's real subtree is the only thing the native reader sees.
     """
-    if os.path.islink(path):
+    # Reject a symlinked source root before resolving it. A trailing separator
+    # makes ``os.path.islink``/``os.lstat`` follow the link to its target, so a
+    # request like ``/volume/LinkGame/`` would otherwise resolve the symlink
+    # away and hand the native packer a root pointing outside the configured
+    # volume. Strip trailing separators and ``lstat`` the original path itself.
+    seps = os.sep + (os.altsep or "")
+    raw_root = path.rstrip(seps) or path
+    try:
+        raw_lstat = os.lstat(raw_root)
+    except OSError:
+        return False
+    if stat.S_ISLNK(raw_lstat.st_mode):
         return False
 
     root = _resolve_path(path, strict=True)
     if root is None or not root.is_dir():
-        return False
-
-    try:
-        root_lstat = os.lstat(root)
-    except OSError:
-        return False
-    if stat.S_ISLNK(root_lstat.st_mode):
         return False
 
     root_str = str(root)
@@ -125,16 +128,13 @@ def is_safe_directory_tree(path: str) -> bool:
                 return False
             if not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
                 return False
-
-            entry_real = _resolve_path(entry, strict=True)
-            if entry_real is None:
-                return False
-            try:
-                entry_real.relative_to(root)
-            except ValueError:
-                return False
-            if not is_within_configured_volumes(str(entry_real), treat_archives=False):
-                return False
+            # No per-entry resolve/volume re-check: ``os.walk(followlinks=False)``
+            # never descends through a symlink, and every symlink or special
+            # entry is rejected above, so each visited entry is a genuine child
+            # of the already volume-confined ``root``. Resolving and
+            # re-verifying containment for every file would add tens of
+            # thousands of redundant syscalls on a large PS3 tree while proving
+            # something the traversal already guarantees.
 
     return not walk_errors
 

--- a/app/utils/path_utils.py
+++ b/app/utils/path_utils.py
@@ -76,6 +76,33 @@ def is_within_configured_volumes(path: str, *, treat_archives: bool = True) -> b
     return False
 
 
+def _strip_trailing_dot_and_seps(path: str) -> str:
+    """Strip only *trailing* separators and ``.`` components from ``path``.
+
+    Used to find the submitted root entry to ``lstat`` before resolution. Unlike
+    :func:`os.path.normpath`, interior ``..`` and symlinked components are left
+    intact: normalizing ``/vol/anchor/../LinkGame`` to ``/vol/LinkGame`` would
+    lexically cancel a symlinked ``anchor`` against the following ``..``, so a
+    pre-resolve ``lstat`` would probe a benign lexical path instead of the real
+    final component the kernel reaches (``/outside/LinkGame``). Keeping the
+    interior intact lets ``lstat`` resolve the ancestors exactly as the kernel
+    does and report the true final entry (catching a symlinked root), while the
+    trailing ``/`` / ``/.`` / ``/./`` are removed so the probe lands on that
+    entry itself rather than following it.
+    """
+    seps = os.sep + (os.altsep or "")
+    drive, tail = os.path.splitdrive(path)
+    prev = None
+    while tail != prev:
+        prev = tail
+        tail = tail.rstrip(seps)
+        # Drop a standalone trailing "." component (".", ".../.") — but never the
+        # "." inside a ".." component, which stays meaningful.
+        if tail.endswith(".") and (len(tail) == 1 or tail[-2] in seps):
+            tail = tail[:-1]
+    return (drive + tail) or path
+
+
 def is_safe_directory_tree(path: str) -> bool:
     """Return whether a directory tree is safe for native recursive readers.
 
@@ -88,12 +115,11 @@ def is_safe_directory_tree(path: str) -> bool:
     # makes ``os.path.islink``/``os.lstat`` follow the link to its target, so a
     # request like ``/volume/LinkGame/`` would otherwise resolve the symlink
     # away and hand the native packer a root pointing outside the configured
-    # volume. ``os.path.normpath`` collapses those trailing components (and any
-    # duplicate separators) purely lexically — without following symlinks — so
-    # the ``lstat`` sees the submitted root itself. It also preserves a drive
-    # root (``"C:\\"`` stays ``"C:\\"`` and never collapses to ``"C:"``, which
-    # would target the current directory on that drive).
-    raw_root = os.path.normpath(path) if path else path
+    # volume. Strip only those trailing components (see the helper) and ``lstat``
+    # the resulting root: the kernel resolves any symlinked ancestors while
+    # ``lstat`` reports the final entry without following it, so a symlinked
+    # root is caught even behind a "." or a ".."-cancelled symlinked ancestor.
+    raw_root = _strip_trailing_dot_and_seps(path)
     try:
         raw_lstat = os.lstat(raw_root)
     except OSError:

--- a/app/utils/path_utils.py
+++ b/app/utils/path_utils.py
@@ -88,8 +88,13 @@ def is_safe_directory_tree(path: str) -> bool:
     # request like ``/volume/LinkGame/`` would otherwise resolve the symlink
     # away and hand the native packer a root pointing outside the configured
     # volume. Strip trailing separators and ``lstat`` the original path itself.
+    # Preserve any drive prefix: on Windows ``"C:\\".rstrip(sep)`` collapses to
+    # ``"C:"``, which ``lstat`` resolves to the *current directory* on that
+    # drive rather than the drive root, so strip only the remainder.
     seps = os.sep + (os.altsep or "")
-    raw_root = path.rstrip(seps) or path
+    drive, rest = os.path.splitdrive(path)
+    stripped_rest = rest.rstrip(seps)
+    raw_root = drive + stripped_rest if stripped_rest else path
     try:
         raw_lstat = os.lstat(raw_root)
     except OSError:

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -511,9 +511,11 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   advisory check — `supports_delete_on_verify=False`, so a curated source folder
   is never auto-deleted. Before queuing the native packer, `plan_job` also walks
   the whole source tree with `utils.path_utils.is_safe_directory_tree`: the root
-  is `lstat`ed (after `os.path.normpath` collapses trailing separators and `.`
-  components, so a symlinked root cannot hide behind a trailing `/`, `/.`, or
-  `/./`) and confined to a configured volume, then every
+  is `lstat`ed after stripping only trailing separators and `.` components
+  (interior `..`/symlinked ancestors are left intact, so the kernel resolves
+  them and `lstat` reports the true final entry — a symlinked root cannot hide
+  behind a trailing `/`, `/.`, `/./`, or a `..`-cancelled symlinked ancestor)
+  and confined to a configured volume, then every
   entry is `lstat`ed and any symlink or non-regular entry is rejected. Because
   `os.walk(followlinks=False)` never descends through a link, the surviving
   entries are all genuine children of the confined root — no per-entry resolve

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -362,7 +362,10 @@ validate both at planning time and again in `JobManager._process_job` after the
 source subtree lock is acquired, immediately before invoking the tool. The PS3
 `folder_to_iso` path uses `is_safe_directory_tree` for both checks so a queued
 job cannot be made unsafe by adding a symlink, special file, or volume-escaping
-entry after planning but before `makeps3iso` starts.
+entry after planning but before `makeps3iso` starts. The worker runs the
+re-check *before* `_clear_existing_output`, so a safety rejection on an
+overwrite job is non-destructive — the prior output is only cleared once the
+source is confirmed still safe.
 
 ### 3.3.1 Shared archive-limit enforcement (`services/archive.py`)
 
@@ -507,10 +510,14 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   built ISO (reusing the shared `disc_id.read_iso_file` ISO 9660 reader) as an
   advisory check — `supports_delete_on_verify=False`, so a curated source folder
   is never auto-deleted. Before queuing the native packer, `plan_job` also walks
-  the whole source tree with `utils.path_utils.is_safe_directory_tree`: symlinks
-  and non-regular entries are rejected, and every resolved entry must remain
-  under both the selected source root and a configured volume, so makeps3iso
-  cannot dereference a link and embed files outside the volume boundary.
+  the whole source tree with `utils.path_utils.is_safe_directory_tree`: the root
+  is `lstat`ed (with trailing separators stripped, so a symlinked root cannot
+  hide behind a trailing slash) and confined to a configured volume, then every
+  entry is `lstat`ed and any symlink or non-regular entry is rejected. Because
+  `os.walk(followlinks=False)` never descends through a link, the surviving
+  entries are all genuine children of the confined root — no per-entry resolve
+  is needed — so makeps3iso cannot dereference a link and embed files outside
+  the volume boundary.
 - **Job model.** `ConversionJob.input_kind: InputKind` is threaded end-to-end
   (derived from the mode spec at queue time, serialized to a string only at the
   API/persistence edge). The generic `_process_job` flow already handles a

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -511,8 +511,9 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
   advisory check — `supports_delete_on_verify=False`, so a curated source folder
   is never auto-deleted. Before queuing the native packer, `plan_job` also walks
   the whole source tree with `utils.path_utils.is_safe_directory_tree`: the root
-  is `lstat`ed (with trailing separators stripped, so a symlinked root cannot
-  hide behind a trailing slash) and confined to a configured volume, then every
+  is `lstat`ed (after `os.path.normpath` collapses trailing separators and `.`
+  components, so a symlinked root cannot hide behind a trailing `/`, `/.`, or
+  `/./`) and confined to a configured volume, then every
   entry is `lstat`ed and any symlink or non-regular entry is rejected. Because
   `os.walk(followlinks=False)` never descends through a link, the surviving
   entries are all genuine children of the confined root — no per-entry resolve

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -10,9 +10,12 @@ and #179, part of the #177 tech-debt epic).
 - **PS3 folder-to-ISO inputs are now recursively confined to configured volumes.**
   Directory-input planning rejects symlinks and non-regular filesystem entries,
   and the queued worker repeats the same safety walk after acquiring the source
-  directory lock immediately before invoking `makeps3iso`. This prevents a
-  crafted or mutated PS3 folder from causing the native packer to read and embed
-  files outside the configured volume boundary.
+  directory lock and before clearing any existing output, immediately before
+  invoking `makeps3iso`. A symlinked source root is rejected even when submitted
+  with a trailing slash. This prevents a crafted or mutated PS3 folder from
+  causing the native packer to read and embed files outside the configured
+  volume boundary, and keeps a safety rejection on an overwrite job from
+  deleting the user's prior output.
 
 - **Deterministic ordering across the registry, search, and runner (issue
   #183).** The `ToolRegistry` extension-union helpers (`convertible_extensions`,

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -12,7 +12,8 @@ and #179, part of the #177 tech-debt epic).
   and the queued worker repeats the same safety walk after acquiring the source
   directory lock and before clearing any existing output, immediately before
   invoking `makeps3iso`. A symlinked source root is rejected even when submitted
-  with a trailing slash. This prevents a crafted or mutated PS3 folder from
+  with a trailing separator or `.`/`./` component. This prevents a crafted or
+  mutated PS3 folder from
   causing the native packer to read and embed files outside the configured
   volume boundary, and keeps a safety rejection on an overwrite job from
   deleting the user's prior output.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -11,9 +11,9 @@ and #179, part of the #177 tech-debt epic).
   Directory-input planning rejects symlinks and non-regular filesystem entries,
   and the queued worker repeats the same safety walk after acquiring the source
   directory lock and before clearing any existing output, immediately before
-  invoking `makeps3iso`. A symlinked source root is rejected even when submitted
-  with a trailing separator or `.`/`./` component. This prevents a crafted or
-  mutated PS3 folder from
+  invoking `makeps3iso`. A symlinked source root is rejected even when hidden
+  behind a trailing separator, a `.`/`./` component, or a `..`-cancelled
+  symlinked ancestor. This prevents a crafted or mutated PS3 folder from
   causing the native packer to read and embed files outside the configured
   volume boundary, and keeps a safety rejection on an overwrite job from
   deleting the user's prior output.

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -221,6 +221,62 @@ async def test_plan_job_rejects_symlinked_ps3_root_with_dot_component(
     assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_UNSAFE
 
 
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("/vol/link", "/vol/link"),
+        ("/vol/link/", "/vol/link"),
+        ("/vol/link/.", "/vol/link"),
+        ("/vol/link/./", "/vol/link"),
+        ("/vol/link///", "/vol/link"),
+        ("/", "/"),
+        (".", "."),
+        # Interior ".." and symlinked ancestors must survive untouched so lstat
+        # resolves them the way the kernel does.
+        ("/vol/anchor/../link", "/vol/anchor/../link"),
+        ("/vol/game/subdir/..", "/vol/game/subdir/.."),
+    ],
+)
+def test_strip_trailing_dot_and_seps(raw, expected):
+    from app.utils.path_utils import _strip_trailing_dot_and_seps
+
+    assert _strip_trailing_dot_and_seps(raw) == expected
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rejects_symlinked_root_behind_dotdot_cancelled_ancestor(
+    tmp_path, monkeypatch,
+):
+    # A symlinked root reached through a ".."-cancelled symlinked ancestor must
+    # still be rejected. Submitting "<volume>/anchor/../LinkGame" (anchor is a
+    # symlink) lexically normalizes to "<volume>/LinkGame" — a benign decoy dir —
+    # but the kernel resolves ".." *after* following anchor, so the real final
+    # component is a symlink. The pre-resolve lstat must probe the un-normalized
+    # path so S_ISLNK catches it, rather than lstat'ing the lexical decoy.
+    _confine_to_volume(monkeypatch, tmp_path / "volume")
+    volume = tmp_path / "volume"
+    real_folder = _make_ps3_folder(volume / "RealGame")
+    outside = tmp_path / "outside"
+    (outside / "x").mkdir(parents=True)
+    (volume / "anchor").symlink_to(outside / "x", target_is_directory=True)
+    (outside / "LinkGame").symlink_to(real_folder, target_is_directory=True)
+    # Decoy: the path that lexical normalization ("anchor/.." cancels) would hit,
+    # existing as a plain directory so an lstat on it would wrongly pass.
+    (volume / "LinkGame").mkdir()
+
+    submitted = str(volume / "anchor") + os.sep + ".." + os.sep + "LinkGame"
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            submitted,
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_UNSAFE
+
+
 @pytest.mark.asyncio
 async def test_plan_job_rejects_ps3_dir_with_symlinked_directory(tmp_path, monkeypatch):
     _confine_to_volume(monkeypatch, tmp_path / "volume")

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -195,6 +195,33 @@ async def test_plan_job_rejects_symlinked_ps3_root_with_trailing_slash(tmp_path,
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("suffix", [os.sep + ".", os.sep + "." + os.sep])
+async def test_plan_job_rejects_symlinked_ps3_root_with_dot_component(
+    tmp_path, monkeypatch, suffix,
+):
+    # A symlinked source root must be rejected even when hidden behind a trailing
+    # "." or "./" component: those make os.lstat follow the link, so
+    # is_safe_directory_tree must normalize them away before the pre-resolve lstat
+    # to keep "/vol/link/." from handing makeps3iso a symlinked root.
+    _confine_to_volume(monkeypatch, tmp_path / "volume")
+    volume = tmp_path / "volume"
+    real_folder = _make_ps3_folder(volume / "MyGame")
+    link_root = volume / "LinkGame"
+    link_root.symlink_to(real_folder, target_is_directory=True)
+
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(link_root) + suffix,
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_UNSAFE
+
+
+@pytest.mark.asyncio
 async def test_plan_job_rejects_ps3_dir_with_symlinked_directory(tmp_path, monkeypatch):
     _confine_to_volume(monkeypatch, tmp_path / "volume")
     volume = tmp_path / "volume"

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -7,6 +7,7 @@ search directory annotation, the service convert (mocked subprocess), and the
 from __future__ import annotations
 
 import asyncio
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -160,6 +161,30 @@ async def test_plan_job_rejects_ps3_dir_with_symlinked_file(tmp_path, monkeypatc
     with pytest.raises(convert_routes.SkipFile) as exc:
         await convert_routes.plan_job(
             str(folder),
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.PS3_FOLDER_UNSAFE
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rejects_symlinked_ps3_root_with_trailing_slash(tmp_path, monkeypatch):
+    # A symlinked source root must be rejected even with a trailing separator: a
+    # trailing slash makes os.path.islink/os.lstat follow the link, so
+    # is_safe_directory_tree must lstat the trailing-slash-stripped path to keep
+    # a request like "/volume/LinkGame/" from handing makeps3iso a symlinked root.
+    _confine_to_volume(monkeypatch, tmp_path / "volume")
+    volume = tmp_path / "volume"
+    real_folder = _make_ps3_folder(volume / "MyGame")
+    link_root = volume / "LinkGame"
+    link_root.symlink_to(real_folder, target_is_directory=True)
+
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(link_root) + os.sep,
             spec=registry.spec("folder_to_iso"),
             mode="folder_to_iso",
             output_dir=None,
@@ -879,6 +904,77 @@ async def test_process_job_revalidates_ps3_tree_after_dir_lock(tmp_path, monkeyp
         _, output_locked = lock_manager.check_file_status(out)
         assert output_locked is False
         assert lock_manager.dir_lock_would_conflict(str(folder_path)) is False
+    finally:
+        lock_manager.release_lock(out)
+        lock_manager.release_dir_lock(str(folder_path))
+        concurrency_manager.release(job.id)
+        job_manager.jobs.pop(job.id, None)
+        job_manager._cancel_events.pop(job.id, None)
+        job_manager._cancelled.discard(job.id)
+
+
+@pytest.mark.asyncio
+async def test_process_job_revalidation_is_non_destructive_on_overwrite(tmp_path, monkeypatch):
+    # An overwrite folder_to_iso job whose source turned unsafe after planning
+    # must fail *without* deleting the user's prior output: the revalidation
+    # runs before _clear_existing_output, so the existing ISO is preserved.
+    from app.services import job_manager as job_manager_module
+    from app.services.job_manager import job_manager
+    from services.concurrency_manager import concurrency_manager
+    from services.lock_manager import lock_manager
+
+    folder_path = _make_ps3_folder(tmp_path / "volume" / "MyGame")
+    out = str(tmp_path / "volume" / "MyGame.iso")
+    # A prior output already exists — an overwrite job would normally clear it.
+    with open(out, "wb") as prior:
+        prior.write(b"previous-iso-contents")
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("secret", encoding="utf-8")
+    (folder_path / "PS3_GAME" / "LEAK.TXT").symlink_to(outside)
+
+    monkeypatch.setattr(
+        job_manager_module.is_safe_directory_tree.__globals__["settings"],
+        "chd_volumes",
+        str(tmp_path / "volume"),
+    )
+    monkeypatch.setattr(
+        job_manager_module.is_safe_directory_tree.__globals__["settings"],
+        "data_mount_root",
+        str(tmp_path / "volume"),
+    )
+
+    called = False
+
+    async def fake_convert(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        yield {"progress": 100, "message": "should not run"}
+
+    monkeypatch.setattr(
+        job_manager_module.registry.for_mode("folder_to_iso"), "convert", fake_convert,
+    )
+
+    job = ConversionJob(
+        id="ps3unsafe2",
+        file_path=str(folder_path),
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.QUEUED,
+        created_at=datetime.now(timezone.utc),
+        output_path=out,
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=True,
+    )
+    job_manager.jobs[job.id] = job
+    try:
+        await job_manager._process_job(job.id)
+        assert job.status == JobStatus.FAILED
+        assert "PS3 folder contains symlinks" in (job.error_message or "")
+        assert called is False
+        # The prior output must be untouched — rejection is non-destructive.
+        assert os.path.exists(out)
+        with open(out, "rb") as saved:
+            assert saved.read() == b"previous-iso-contents"
     finally:
         lock_manager.release_lock(out)
         lock_manager.release_dir_lock(str(folder_path))


### PR DESCRIPTION
## Motivation

Follow-up to the reviews on #215 (PS3 folder input hardening). This branches off #215's head and targets it so the fixes land on that PR when merged. Three reviewer points are addressed.

## Changes

**`app/utils/path_utils.py` — `is_safe_directory_tree`**
- **Reject symlinked source roots with a trailing slash (codex P2).** A trailing separator made `os.path.islink(path)` follow the link, and the follow-up `os.lstat` operated on the already-resolved target — so a request like `/vol/link/` bypassed the symlink guard and handed the native packer a mutable symlink root. Now the root is `lstat`ed with trailing separators stripped, before resolution.
- **Drop the per-entry `_resolve_path` + `is_within_configured_volumes` re-check (gemini, performance).** `os.walk(followlinks=False)` never descends through a link and every symlink/special entry is already rejected, so each visited entry is a genuine child of the already volume-confined root. Resolving and re-verifying containment for every file added tens of thousands of redundant syscalls on large PS3 trees for a guarantee the traversal already provides. Only the lightweight `lstat` type checks remain.

**`app/services/job_manager.py` — `_process_job`**
- **Order the directory-safety revalidation before `_clear_existing_output` (codex P2).** Previously an overwrite `folder_to_iso` job cleared its prior ISO/split set *before* discovering the source had been mutated to contain a symlink, leaving the user with neither a new nor an old output. The re-check now runs before clearing (still after the source subtree lock), so a safety rejection is non-destructive.

## Testing

- `PYTHONPATH=app python -m pytest -q tests/test_makeps3iso.py` — new/changed tests pass:
  - `test_plan_job_rejects_symlinked_ps3_root_with_trailing_slash` (verified to fail on the pre-fix code)
  - `test_process_job_revalidation_is_non_destructive_on_overwrite`
- `ruff check` clean on the changed files.
- Pre-existing, environment-only failures remain unchanged (missing native conversion binaries in `test_archive_conversion_e2e.py`; `test_plan_job_rejects_output_inside_source` lacks volume confinement) — all reproduce identically on the base commit and are unrelated to this change.

## Docs

- `docs/DESIGN_tool_plugin_architecture.md` and `docs/RELEASE_NOTES.md` updated to describe the trailing-slash root guard, the removal of per-entry resolution, and the non-destructive re-check ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFZRq4tEgneip4tVcqKy5w)_