### PR TITLE
fix: harden release workflow shell inputs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -83,19 +83,27 @@ jobs:
         id: version
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag version: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version from release tag: ${VERSION}"
 
       - name: Sync version to package.json
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
+          VERSION_SYNC_TOKEN: ${{ secrets.VERSION_SYNC_TOKEN }}
         run: |
-          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+          npm version "$RELEASE_VERSION" --no-git-tag-version --allow-same-version
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
           if ! git diff --cached --quiet; then
-            git commit -m "chore: sync package.json to v${{ steps.version.outputs.version }} [skip ci]"
-            git remote set-url origin https://x-access-token:${{ secrets.VERSION_SYNC_TOKEN }}@github.com/${{ github.repository }}.git
-            git push origin HEAD:${{ github.event.release.target_commitish }}
+            git commit -m "chore: sync package.json to v${RELEASE_VERSION} [skip ci]"
+            git remote set-url origin "https://x-access-token:${VERSION_SYNC_TOKEN}@github.com/${{ github.repository }}.git"
+            git push origin "HEAD:${TARGET_COMMITISH}"
           fi
 
       - name: Extract Docker metadata
@@ -231,28 +239,33 @@ jobs:
 
     steps:
       - name: Generate summary
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          IMAGE_DIGEST: ${{ needs.build.outputs.image-digest }}
+          IMAGE_TAGS: ${{ needs.build.outputs.image-tags }}
         run: |
-          echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Release" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Release:** \`${{ github.event.release.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Prerelease:** \`${{ github.event.release.prerelease }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Images Published" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Registry | Image |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Docker Hub | \`${{ env.DOCKERHUB_IMAGE }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| GitHub | \`${{ env.GHCR_IMAGE }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Build Details" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Digest:** \`${{ needs.build.outputs.image-digest }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Platforms:** \`${{ env.PLATFORMS }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Tags" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ needs.build.outputs.image-tags }}" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "## Docker Build Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Release" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Release:** \`${RELEASE_TAG}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Prerelease:** \`${RELEASE_PRERELEASE}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Images Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Registry | Image |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Docker Hub | \`${DOCKERHUB_IMAGE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| GitHub | \`${GHCR_IMAGE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Build Details" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Digest:** \`${IMAGE_DIGEST}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Platforms:** \`${PLATFORMS}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Tags" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "$IMAGE_TAGS" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- The release workflow interpolated `GITHUB_REF_NAME` and `github.event.release.target_commitish` directly into shell `run` steps and `git` commands, creating a command-injection risk when a release tag contains shell metacharacters.
- The change limits the CI attack surface by validating and safely using release-derived values before any shell evaluation or network/registry operations.

### Description
- Add a stricter SemVer-like validation in the `Extract version from release tag` step and write the validated value to `$GITHUB_OUTPUT` only when it matches the pattern.
- Pass release-derived values through environment variables (`RELEASE_VERSION`, `TARGET_COMMITISH`, `VERSION_SYNC_TOKEN`) into the `Sync version to package.json` step and use quoted shell expansions to avoid pre-shell expression interpolation.
- Quote the `git remote` URL and `git push` refspec to prevent unquoted injection of `target_commitish` into `git` commands.
- Move summary values into step `env` variables and quote all writes to `$GITHUB_STEP_SUMMARY` to avoid direct expression substitution in the summary shell script.

### Testing
- Loaded the workflow with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-image.yml")'`, which succeeded and validated YAML syntax.
- Ran targeted assertions and a small Python check that the previous vulnerable interpolation sinks were removed, which passed.
- Performed a local simulation with malicious `RELEASE_VERSION='1.2.3$(touch VERSION_INJECTED)'` and `TARGET_COMMITISH='main;touch TARGET_INJECTED'` using stubbed `npm`/`git` binaries and confirmed no marker files were created, demonstrating the injection is mitigated.
- Executed `pytest -q tests` which failed due to module import path issues without `PYTHONPATH=app`, and `PYTHONPATH=app pytest -q tests` produced many failures because the runner environment lacks the async test plugins needed to run the full suite, so full automated test-suite verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a584480483239c5c241900485eeb)