### PR TITLE
ci: harden release version sync

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -83,19 +83,27 @@ jobs:
         id: version
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must be a semantic version, optionally prefixed with v: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "Version from release tag: ${VERSION}"
 
       - name: Sync version to package.json
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
+          VERSION_SYNC_TOKEN: ${{ secrets.VERSION_SYNC_TOKEN }}
         run: |
-          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+          npm version "${VERSION}" --no-git-tag-version --allow-same-version
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
           if ! git diff --cached --quiet; then
-            git commit -m "chore: sync package.json to v${{ steps.version.outputs.version }} [skip ci]"
-            git remote set-url origin https://x-access-token:${{ secrets.VERSION_SYNC_TOKEN }}@github.com/${{ github.repository }}.git
-            git push origin HEAD:${{ github.event.release.target_commitish }}
+            git commit -m "chore: sync package.json to v${VERSION} [skip ci]"
+            git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer ${VERSION_SYNC_TOKEN}" \
+              push origin "HEAD:${TARGET_COMMITISH}"
           fi
 
       - name: Extract Docker metadata


### PR DESCRIPTION
### Motivation

- The release workflow previously interpolated release-controlled values directly into a multi-line shell script, enabling command injection from crafted tag/target names and exposing `VERSION_SYNC_TOKEN` in the generated script and `.git/config`.
- The change's goal is to prevent command-injection sinks and avoid persisting the write-scoped PAT while preserving the workflow's package.json version sync behavior.

### Description

- Validate the tag-derived `VERSION` in the `Extract version from release tag` step using a semantic-version regex and write the validated value to `GITHUB_OUTPUT` with quoting.
- Move release-controlled values into step environment variables: `VERSION`, `TARGET_COMMITISH`, and `VERSION_SYNC_TOKEN` for the `Sync version to package.json` step.
- Use `npm version "${VERSION}"` and avoid embedding `${{ secrets.VERSION_SYNC_TOKEN }}` into shell code or `git remote set-url`.
- Push the change with an in-memory auth header via `git -c http.https://github.com/.extraheader="AUTHORIZATION: bearer ${VERSION_SYNC_TOKEN}" push origin "HEAD:${TARGET_COMMITISH}"` and quote the refspec to avoid unquoted interpolation.

### Testing

- Parsed the modified workflow with `python -c "import yaml; yaml.safe_load(open('.github/workflows/docker-image.yml'))"`, which completed successfully.
- Applied and committed the change locally with `git` and verified the modified file diff, and the commit operation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52a58aa6a48323a1711d1f09f5249c)