### PR TITLE
Validate NSZ archive member extensions before output-path derivation

### DIFF
--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -555,6 +555,7 @@ async def plan_job(
     output_exists = False
 
     display_filename = None
+    bad_ext_reason = _BAD_EXTENSION_REASON.get(spec.tool_id)
 
     # Handle archive files
     if "::" in file_path:
@@ -566,6 +567,11 @@ async def plan_job(
 
         if not os.path.isfile(archive_path):
             raise SkipFile(SkipReason.ARCHIVE_NOT_FOUND)
+
+        if bad_ext_reason is not None:
+            ext = _input_extension(file_path)
+            if ext not in spec.input_extensions:
+                raise SkipFile(bad_ext_reason)
 
         # Calculate output path before extraction to avoid unnecessary work.
         # Use the extension-preserving flattened name so tools whose output
@@ -609,7 +615,6 @@ async def plan_job(
     # direction is validated against the right set. chdman is handled above by
     # the .chd create/extract checks (it drops .chd from input_extensions). The
     # per-tool skip reason carries the tool-specific message.
-    bad_ext_reason = _BAD_EXTENSION_REASON.get(spec.tool_id)
     if bad_ext_reason is not None:
         ext = _input_extension(file_path)
         if ext not in spec.input_extensions:

--- a/tests/test_archive_conversion_e2e.py
+++ b/tests/test_archive_conversion_e2e.py
@@ -163,6 +163,33 @@ async def test_archive_member_converts_end_to_end(e2e_env, ext, mode, out_ext):
 
 
 @pytest.mark.asyncio
+async def test_invalid_nsz_archive_member_returns_bad_extension(e2e_env):
+    """Invalid Switch archive members should fail validation before output
+    path mapping tries to derive .nsz/.xcz names from the member suffix."""
+    from fastapi import HTTPException
+
+    tmp_path: Path = e2e_env["tmp_path"]
+    archive = tmp_path / "switch.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("bad.txt", b"not-a-switch-container")
+
+    request = JobCreateRequest(
+        file_path=f"{archive}::bad.txt",
+        mode=ConversionMode.NSZ_COMPRESS,
+        duplicate_action=DuplicateAction.SKIP,
+        delete_on_verify=False,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await convert_routes.create_job(request)
+
+    status, detail = convert_routes._SKIP_HTTP[
+        convert_routes.SkipReason.NSZ_BAD_EXTENSION
+    ]
+    assert exc.value.status_code == status == 400
+    assert exc.value.detail == detail
+
+
+@pytest.mark.asyncio
 async def test_archive_chd_member_rejected_for_recompress(e2e_env):
     """Recompressing a .chd straight out of an archive is a pointless round
     trip, so chdman's copy mode keeps allows_archive_input=False and the route


### PR DESCRIPTION
### Motivation
- Enabling archive inputs for the NSZ tool caused archive-member names with unsupported suffixes to hit the NSZ output-path mapper and raise an uncaught `ValueError`, producing HTTP 500 instead of the intended `NSZ_BAD_EXTENSION` 400 response.
- The goal is to fail archive-member inputs early with the existing per-tool skip reason so callers receive a controlled 400 error and the later per-tool checks remain intact.

### Description
- Add an early per-tool archive-member extension check in `plan_job` by obtaining `bad_ext_reason = _BAD_EXTENSION_REASON.get(spec.tool_id)` and validating the member extension inside the `"::"` archive branch before deriving the archive `output_path` (file: `app/routes/convert.py`).
- Preserve the generic extension gate for the non-archive planning path so on-disk inputs still follow the original validation flow (file: `app/routes/convert.py`).
- Add a regression test `test_invalid_nsz_archive_member_returns_bad_extension` to `tests/test_archive_conversion_e2e.py` that posts `switch.zip::bad.txt` with `nsz_compress` and asserts the API returns the `NSZ_BAD_EXTENSION` 400 detail.

### Testing
- Wrote and committed the regression test `tests/test_archive_conversion_e2e.py::test_invalid_nsz_archive_member_returns_bad_extension` and the route change in `app/routes/convert.py` and verified Python syntax with `python -m compileall -q app/routes/convert.py tests/test_archive_conversion_e2e.py` which succeeded.
- Performed a manual async reproduction using `PYTHONPATH=app python - <<'PY' ... PY` that invoked `create_job` for `switch.zip::bad.txt` and observed `400 nsz_compress requires .nsp/.xci; nsz_decompress requires .nsz/.xcz`, confirming the intended behavior.
- Attempted to run the test suite with `PYTHONPATH=app pytest -q tests` and to install `requirements-dev.txt`, but the environment lacked `pytest-asyncio` and package-index access failed (network 403), so the full automated test run could not be executed here; the added unit test should pass locally with dev dependencies installed.

What changed, what I verified, and what to check by hand: I added the early archive-member extension check and a regression test, verified behavior with a local `PYTHONPATH=app` async repro and static compilation, and you should run `pip install -r requirements-dev.txt` then `PYTHONPATH=app pytest -q tests/test_archive_conversion_e2e.py::test_invalid_nsz_archive_member_returns_bad_extension` to confirm the regression test passes in CI or a full dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5295b482a0832398aff22b9dbb2047)