### PR TITLE
Detect numbered makeps3iso split siblings as output conflicts

### DIFF
--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -162,6 +162,24 @@ def _is_same_path(path_a: str, path_b: str) -> bool:
         return False
 
 
+def _numbered_output_siblings(output_path: str) -> list[str]:
+    """Existing ``output_path.<digits>`` siblings that a split build may occupy."""
+    siblings: list[str] = []
+    directory = os.path.dirname(output_path) or "."
+    basename = os.path.basename(output_path)
+    try:
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                if (
+                    entry.is_file()
+                    and re.fullmatch(re.escape(basename) + r"\.\d+", entry.name)
+                ):
+                    siblings.append(entry.path)
+    except OSError:
+        pass
+    return siblings
+
+
 def get_disallowed_archive_paths(file_paths: list[str]) -> set[str]:
     """Get archive paths that should not allow delete-on-verify due to multiple selections."""
     archive_counts = {}
@@ -214,6 +232,11 @@ def check_output_conflicts(mode: str, output_path: str) -> tuple:
         c_exists, c_locked = lock_manager.check_file_status(companion)
         exists = exists or c_exists or c_locked
         locked = locked or c_locked
+    if mode == "folder_to_iso":
+        for sibling in _numbered_output_siblings(output_path):
+            s_exists, s_locked = lock_manager.check_file_status(sibling)
+            exists = exists or s_exists or s_locked
+            locked = locked or s_locked
     return exists, locked
 
 

--- a/tests/test_makeps3iso.py
+++ b/tests/test_makeps3iso.py
@@ -564,6 +564,28 @@ async def test_plan_job_rejects_existing_split_set(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_plan_job_rejects_existing_numbered_split_sibling(
+    tmp_path, monkeypatch,
+):
+    _confine_to_volume(monkeypatch, tmp_path)
+    _make_ps3_folder(tmp_path / "MyGame")
+    # A numbered sibling can become part of a future contiguous split set after
+    # makeps3iso creates the preceding parts, so it must block the output name
+    # even when .0 does not exist yet.
+    (tmp_path / "MyGame.iso.1").write_bytes(b"unrelated")
+    with pytest.raises(convert_routes.SkipFile) as exc:
+        await convert_routes.plan_job(
+            str(tmp_path / "MyGame"),
+            spec=registry.spec("folder_to_iso"),
+            mode="folder_to_iso",
+            output_dir=None,
+            duplicate_action=convert_routes.DuplicateAction.SKIP,
+            delete_on_verify=False,
+        )
+    assert exc.value.reason is convert_routes.SkipReason.OUTPUT_EXISTS
+
+
+@pytest.mark.asyncio
 async def test_plan_job_rename_steps_past_split_set(tmp_path, monkeypatch):
     _confine_to_volume(monkeypatch, tmp_path)
     _make_ps3_folder(tmp_path / "MyGame")
@@ -577,6 +599,25 @@ async def test_plan_job_rename_steps_past_split_set(tmp_path, monkeypatch):
         delete_on_verify=False,
     )
     # RENAME bumps past the occupied split set to a free name.
+    assert plan.output_path == str(tmp_path / "MyGame_1.iso")
+
+
+@pytest.mark.asyncio
+async def test_plan_job_rename_steps_past_numbered_split_sibling(
+    tmp_path, monkeypatch,
+):
+    _confine_to_volume(monkeypatch, tmp_path)
+    _make_ps3_folder(tmp_path / "MyGame")
+    (tmp_path / "MyGame.iso.1").write_bytes(b"unrelated")
+    plan = await convert_routes.plan_job(
+        str(tmp_path / "MyGame"),
+        spec=registry.spec("folder_to_iso"),
+        mode="folder_to_iso",
+        output_dir=None,
+        duplicate_action=convert_routes.DuplicateAction.RENAME,
+        delete_on_verify=False,
+    )
+    # RENAME must avoid any numbered sibling, not just a contiguous set from .0.
     assert plan.output_path == str(tmp_path / "MyGame_1.iso")
 
 
@@ -823,6 +864,16 @@ def test_check_output_conflicts_split_aware(tmp_path):
     exists, _ = convert_routes.check_output_conflicts("folder_to_iso", out)
     assert exists is True
     # A non-directory mode ignores the .0 probe (no plain file present).
+    exists_other, _ = convert_routes.check_output_conflicts("createcd", out)
+    assert exists_other is False
+
+
+def test_check_output_conflicts_detects_any_numbered_split_sibling(tmp_path):
+    out = str(tmp_path / "Game.iso")
+    Path(out + ".2").write_bytes(b"unrelated")
+    exists, _ = convert_routes.check_output_conflicts("folder_to_iso", out)
+    assert exists is True
+
     exists_other, _ = convert_routes.check_output_conflicts("createcd", out)
     assert exists_other is False
 


### PR DESCRIPTION
### Motivation
- Preflight only checked the bare output and `.0` for `folder_to_iso`, allowing a pre-existing numbered sibling such as `Game.iso.1` to pass and later be deleted by split cleanup; this change prevents accidental removal of unrelated files.

### Description
- Add `_numbered_output_siblings(output_path)` to enumerate any existing `output_path.<digits>` siblings in the output directory.
- Include those siblings in `check_output_conflicts(...)` for `mode == "folder_to_iso"` so skip/overwrite/rename planning treats them as occupied.
- Add regression tests that assert a non-zero numbered sibling blocks `SKIP`, is avoided by `RENAME`, and is detected by `check_output_conflicts`.
- Guard the directory scan with `OSError` suppression to match existing I/O-safe patterns.

### Testing
- Ran the focused unit tests: `PYTHONPATH=app pytest -q tests/test_makeps3iso.py::test_check_output_conflicts_split_aware tests/test_makeps3iso.py::test_check_output_conflicts_detects_any_numbered_split_sibling`, and they passed.
- Attempted to run `PYTHONPATH=app pytest -q tests/test_makeps3iso.py tests/test_companion_outputs_182.py` but the async test suite could not run because `pytest-asyncio` is not installed in the environment; installing `requirements-dev.txt` failed due to the package index returning `403 Forbidden`, so the full async suite was not executed here.
- Ran `ruff check app/routes/convert.py tests/test_makeps3iso.py`, which passed with no issues.
- Summary: changed conflict detection to include any numbered split sibling, added targeted tests, verified the focused tests and linter; please run the full test suite (with `pytest-asyncio` available) in CI or locally to validate the async tests and integration scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5295b481b08323839e3d2e37288083)