### PR TITLE
Fix chdman verify stream cancellation cleanup

### DIFF
--- a/app/services/chdman.py
+++ b/app/services/chdman.py
@@ -185,80 +185,84 @@ class ChdmanService:
                 return True
             return False
 
-        while True:
-            try:
-                chunk = await asyncio.wait_for(process.stdout.read(100), timeout=2)
-            except asyncio.TimeoutError:
+        try:
+            while True:
+                try:
+                    chunk = await asyncio.wait_for(process.stdout.read(100), timeout=2)
+                except asyncio.TimeoutError:
+                    if await _check_timeouts(time.monotonic()):
+                        break
+                    continue
+                if not chunk:
+                    break
+
+                buffer += chunk.decode("utf-8", errors="replace")
+                last_output_at = time.monotonic()
+
+                while "\r" in buffer or "\n" in buffer:
+                    if "\r" in buffer:
+                        parts = buffer.split("\r")
+                        for part in parts[:-1]:
+                            line = part.strip()
+                            if line:
+                                output_lines.append(line)
+                                progress = self._parse_progress(line)
+                                yield {
+                                    "type": "progress",
+                                    "progress": progress,
+                                    "message": line,
+                                }
+                        buffer = parts[-1]
+                    elif "\n" in buffer:
+                        parts = buffer.split("\n")
+                        for part in parts[:-1]:
+                            line = part.strip()
+                            if line:
+                                output_lines.append(line)
+                                progress = self._parse_progress(line)
+                                yield {
+                                    "type": "progress",
+                                    "progress": progress,
+                                    "message": line,
+                                }
+                        buffer = parts[-1]
                 if await _check_timeouts(time.monotonic()):
                     break
-                continue
-            if not chunk:
-                break
 
-            buffer += chunk.decode("utf-8", errors="replace")
-            last_output_at = time.monotonic()
+            if buffer.strip():
+                line = buffer.strip()
+                output_lines.append(line)
+                progress = self._parse_progress(line)
+                yield {"type": "progress", "progress": progress, "message": line}
 
-            while "\r" in buffer or "\n" in buffer:
-                if "\r" in buffer:
-                    parts = buffer.split("\r")
-                    for part in parts[:-1]:
-                        line = part.strip()
-                        if line:
-                            output_lines.append(line)
-                            progress = self._parse_progress(line)
-                            yield {
-                                "type": "progress",
-                                "progress": progress,
-                                "message": line,
-                            }
-                    buffer = parts[-1]
-                elif "\n" in buffer:
-                    parts = buffer.split("\n")
-                    for part in parts[:-1]:
-                        line = part.strip()
-                        if line:
-                            output_lines.append(line)
-                            progress = self._parse_progress(line)
-                            yield {
-                                "type": "progress",
-                                "progress": progress,
-                                "message": line,
-                            }
-                    buffer = parts[-1]
-            if await _check_timeouts(time.monotonic()):
-                break
+            await process.wait()
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "chdman verify pid=%s exit=%s", process.pid, process.returncode,
+                )
 
-        if buffer.strip():
-            line = buffer.strip()
-            output_lines.append(line)
-            progress = self._parse_progress(line)
-            yield {"type": "progress", "progress": progress, "message": line}
+            if timeout_error:
+                yield {"type": "error", "valid": False, "message": timeout_error}
+                return
 
-        await process.wait()
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "chdman verify pid=%s exit=%s", process.pid, process.returncode,
-            )
-        self._runner.untrack_pid(process.pid)
-
-        if timeout_error:
-            yield {"type": "error", "valid": False, "message": timeout_error}
-            return
-
-        output_lines = output_lines[-20:]
-        output = "\n".join(output_lines).strip()
-        if process.returncode == 0:
-            yield {
-                "type": "complete",
-                "valid": True,
-                "message": "CHD file verified successfully",
-            }
-        else:
-            yield {
-                "type": "error",
-                "valid": False,
-                "message": output or "CHD verification failed",
-            }
+            output_lines = output_lines[-20:]
+            output = "\n".join(output_lines).strip()
+            if process.returncode == 0:
+                yield {
+                    "type": "complete",
+                    "valid": True,
+                    "message": "CHD file verified successfully",
+                }
+            else:
+                yield {
+                    "type": "error",
+                    "valid": False,
+                    "message": output or "CHD verification failed",
+                }
+        finally:
+            if process.returncode is None:
+                await self._terminate_process(process)
+            self._runner.untrack_pid(process.pid)
 
     @staticmethod
     async def _terminate_process(process: asyncio.subprocess.Process) -> None:

--- a/tests/test_chdman_verify_stream.py
+++ b/tests/test_chdman_verify_stream.py
@@ -1,0 +1,57 @@
+import asyncio
+import os
+from app.services.chdman import ChdmanService
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def test_verify_stream_cleans_up_subprocess_when_cancelled(tmp_path):
+    asyncio.run(_verify_stream_cleans_up_subprocess_when_cancelled(tmp_path))
+
+
+async def _verify_stream_cleans_up_subprocess_when_cancelled(tmp_path):
+    fake_chdman = tmp_path / "fake_chdman.py"
+    fake_chdman.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "import time\n"
+        "print('Verifying, 1% complete')\n"
+        "sys.stdout.flush()\n"
+        "time.sleep(60)\n"
+    )
+    fake_chdman.chmod(0o755)
+
+    service = ChdmanService()
+    service.chdman_path = str(fake_chdman)
+    updates = []
+
+    async def consume_updates():
+        async for update in service.verify_stream(str(tmp_path / "sample.chd")):
+            updates.append(update)
+
+    task = asyncio.create_task(consume_updates())
+    for _ in range(50):
+        if updates and service.active_pids():
+            break
+        await asyncio.sleep(0.05)
+
+    assert updates[0]["type"] == "progress"
+    pid = service.active_pids()[0]
+    await asyncio.sleep(0.1)
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    else:
+        raise AssertionError("verify_stream consumer was not cancelled")
+
+    assert service.active_pids() == []
+    assert not _pid_exists(pid)


### PR DESCRIPTION
### Motivation
- The SSE verification endpoint could leave native `chdman verify` subprocesses running when the Python consumer task was cancelled, causing a resource-leak / availability issue.
- The change ensures verification streams always clean up the child process and PID tracking on cancellation or early generator close to avoid process-table and I/O exhaustion.

### Description
- Wrap the streaming loop in `ChdmanService.verify_stream` with a `try/finally` that calls `_terminate_process()` if the child `process` is still running and always untracks the PID. (file: `app/services/chdman.py`)
- Preserve existing timeout and stall checks so they still call `_terminate_process()` when triggered. (file: `app/services/chdman.py`)
- Add a regression test that spawns a fake long-running `chdman`, cancels the consumer after the first progress update, and asserts the child process is terminated and no PID remains tracked. (file: `tests/test_chdman_verify_stream.py`)

### Testing
- Ran targeted verification tests: `PYTHONPATH=app pytest -q tests/test_chdman_verify_stream.py tests/test_chdman_annotations.py`, which passed locally (regression test confirmed cleanup).
- Ran the single test `PYTHONPATH=app pytest -q tests/test_chdman_verify_stream.py` successfully as a quick verification.
- Attempted a full test run and to install `requirements-dev.txt` but the environment lacks network access to the package index and `pytest-asyncio` was not available here, so the full suite could not be validated in this environment.

Summary: ensured `chdman verify` subprocesses are terminated and untracked on cancellation, added a focused regression test that verifies the fix, and validated the change with the targeted unit tests; please run the full test suite in CI or a developer environment with `requirements-dev.txt` installed to confirm broad compatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b18543708323adb9afec37cb3296)