### PR TITLE
Fix archive conversion e2e test failures (split kwarg)

### DIFF
--- a/tests/test_archive_conversion_e2e.py
+++ b/tests/test_archive_conversion_e2e.py
@@ -82,7 +82,7 @@ def _e2e_env(tmp_path: Path, monkeypatch):
     calls: list[dict] = []
 
     async def fake_convert(input_path, output_path, mode, *, compression=None,
-                           cancel_event=None):
+                           split=False, cancel_event=None):
         # The member must have been extracted to a real temp file before the
         # tool is invoked, this is the core of the archive-conversion path.
         assert os.path.isfile(input_path), f"member not extracted: {input_path}"


### PR DESCRIPTION
## Summary

`tests/test_archive_conversion_e2e.py` had 27 failing parametrized cases — every conversion in the matrix failed with `fake_convert() got an unexpected keyword argument 'split'`.

The `BaseTool.convert` contract gained a `split` keyword parameter (makeps3iso folder→iso `-s` FAT32 split), and `job_manager` now forwards `split=split` on every dispatch. The e2e stub `fake_convert` had not been updated to accept it, so the stubbed converter raised before writing any output — the planned output path was correct, but no file was produced and the job was marked FAILED.

## Change

Mirror the real `convert` signature in the test stub by adding `split=False` to `fake_convert`. This is a one-line test-only fix; no production code changed.

## Verification

- `PYTHONPATH=app python -m pytest -q tests/test_archive_conversion_e2e.py` → 30 passed
- `PYTHONPATH=app python -m pytest -q tests` → 1164 passed, 1 skipped (previously 27 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQy6VP1zxCRwgk7n4sbHwR)_