### PR TITLE
Validate archive member extensions before output-path derivation

### DIFF
--- a/app/routes/convert.py
+++ b/app/routes/convert.py
@@ -578,6 +578,7 @@ async def plan_job(
     output_exists = False
 
     display_filename = None
+    bad_ext_reason = _BAD_EXTENSION_REASON.get(spec.tool_id)
 
     # Handle archive files
     if "::" in file_path:
@@ -589,6 +590,11 @@ async def plan_job(
 
         if not os.path.isfile(archive_path):
             raise SkipFile(SkipReason.ARCHIVE_NOT_FOUND)
+
+        if bad_ext_reason is not None:
+            ext = _input_extension(file_path)
+            if ext not in spec.input_extensions:
+                raise SkipFile(bad_ext_reason)
 
         # Calculate output path before extraction to avoid unnecessary work.
         # Use the extension-preserving flattened name so tools whose output
@@ -632,7 +638,6 @@ async def plan_job(
     # direction is validated against the right set. chdman is handled above by
     # the .chd create/extract checks (it drops .chd from input_extensions). The
     # per-tool skip reason carries the tool-specific message.
-    bad_ext_reason = _BAD_EXTENSION_REASON.get(spec.tool_id)
     if bad_ext_reason is not None:
         ext = _input_extension(file_path)
         if ext not in spec.input_extensions:

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -66,6 +66,15 @@ and #179, part of the #177 tech-debt epic).
 
 ### Fixed
 
+- **Unsupported archive members return a 400, not a 500.** When an archive
+  member with an extension the target tool doesn't accept (e.g. `switch.zip::bad.txt`
+  for `nsz_compress`) was submitted, `plan_job` derived the output path from the
+  member suffix *before* the input-extension gate ran, so the tool's output-path
+  mapper raised an uncaught `ValueError` and the API answered HTTP 500. The
+  per-tool extension check now also runs inside the archive branch, before any
+  output-path derivation, so these inputs fail early with the intended per-tool
+  skip reason (`NSZ_BAD_EXTENSION` and friends) and a controlled 400 response.
+
 - **Verify streams no longer leak their child process on cancellation.** When an
   SSE verification client disconnects mid-stream (or the consuming task is
   otherwise cancelled), `chdman` and `dolphin-tool` `verify_stream` now wrap their

--- a/tests/test_archive_conversion_e2e.py
+++ b/tests/test_archive_conversion_e2e.py
@@ -163,6 +163,33 @@ async def test_archive_member_converts_end_to_end(e2e_env, ext, mode, out_ext):
 
 
 @pytest.mark.asyncio
+async def test_invalid_nsz_archive_member_returns_bad_extension(e2e_env):
+    """Invalid Switch archive members should fail validation before output
+    path mapping tries to derive .nsz/.xcz names from the member suffix."""
+    from fastapi import HTTPException
+
+    tmp_path: Path = e2e_env["tmp_path"]
+    archive = tmp_path / "switch.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("bad.txt", b"not-a-switch-container")
+
+    request = JobCreateRequest(
+        file_path=f"{archive}::bad.txt",
+        mode=ConversionMode.NSZ_COMPRESS,
+        duplicate_action=DuplicateAction.SKIP,
+        delete_on_verify=False,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await convert_routes.create_job(request)
+
+    status, detail = convert_routes._SKIP_HTTP[
+        convert_routes.SkipReason.NSZ_BAD_EXTENSION
+    ]
+    assert exc.value.status_code == status == 400
+    assert exc.value.detail == detail
+
+
+@pytest.mark.asyncio
 async def test_archive_chd_member_rejected_for_recompress(e2e_env):
     """Recompressing a .chd straight out of an archive is a pointless round
     trip, so chdman's copy mode keeps allows_archive_input=False and the route


### PR DESCRIPTION
### Motivation

Enabling archive inputs for extension-mapped tools meant an archive member with an unsupported suffix reached the tool's output-path mapper **before** `plan_job`'s input-extension gate ran. For NSZ, `get_output_path_for_mode` raises `ValueError("Unsupported file extension: …")` for such a member, so the request surfaced as an uncaught HTTP **500** instead of the intended `NSZ_BAD_EXTENSION` **400**.

Confirmed on current `latest`: submitting `switch.zip::bad.txt` with `nsz_compress` raises `ValueError: Unsupported file extension: .txt` inside the archive branch of `plan_job`, before any per-tool extension validation.

### Description

- In `plan_job` (`app/routes/convert.py`), hoist `bad_ext_reason = _BAD_EXTENSION_REASON.get(spec.tool_id)` above the archive branch and run the per-tool extension check **inside** the `"::"` archive branch, before deriving the archive `output_path`. Members whose extension isn't in `spec.input_extensions` now fail early with the tool's own skip reason.
- The fix is general, not NSZ-specific: it covers every tool registered in `_BAD_EXTENSION_REASON` (`dolphin`, `z3ds`, `nsz`, `cso`, `chain`, `romz`), so no extension-mapped tool can hit its output-path mapper with an unsupported archive member.
- The generic extension gate on the non-archive planning path is preserved, so on-disk inputs follow the original flow. Behaviour is otherwise unchanged: any member the late gate already rejected is still rejected (same reason, just earlier) — only the previously-uncaught `ValueError` case flips from 500 to a controlled 400.
- Add regression test `test_invalid_nsz_archive_member_returns_bad_extension` (`tests/test_archive_conversion_e2e.py`) posting `switch.zip::bad.txt` for `nsz_compress` and asserting the `NSZ_BAD_EXTENSION` 400 detail.
- Document the fix in `docs/RELEASE_NOTES.md` under Unreleased → Fixed.

### Testing

- `PYTHONPATH=app pytest -q tests` — **1186 passed, 1 skipped**.
- Verified the new test is a genuine regression test: with the source fix reverted it fails with `ValueError: Unsupported file extension: .txt`; with the fix it passes (HTTP 400).
- `ruff check .` — clean.

### Provenance

This supersedes and completes #228 (codex branch `codex/fix-unhandled-500-error-for-nsz-archive`), which could not run its async suite in its sandbox. Same fix, verified end-to-end against the full test suite here, with a RELEASE_NOTES entry added to match repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhNngp1uNSovdhKfUmKEUN

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhNngp1uNSovdhKfUmKEUN)_