### PR TITLE
fix: harden release workflow shell inputs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -83,19 +83,27 @@ jobs:
         id: version
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag version: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Version from release tag: ${VERSION}"
 
       - name: Sync version to package.json
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
+          VERSION_SYNC_TOKEN: ${{ secrets.VERSION_SYNC_TOKEN }}
         run: |
-          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+          npm version "$RELEASE_VERSION" --no-git-tag-version --allow-same-version
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
           if ! git diff --cached --quiet; then
-            git commit -m "chore: sync package.json to v${{ steps.version.outputs.version }} [skip ci]"
-            git remote set-url origin https://x-access-token:${{ secrets.VERSION_SYNC_TOKEN }}@github.com/${{ github.repository }}.git
-            git push origin HEAD:${{ github.event.release.target_commitish }}
+            git commit -m "chore: sync package.json to v${RELEASE_VERSION} [skip ci]"
+            git remote set-url origin "https://x-access-token:${VERSION_SYNC_TOKEN}@github.com/${{ github.repository }}.git"
+            git push origin "HEAD:${TARGET_COMMITISH}"
           fi
 
       - name: Extract Docker metadata
@@ -231,28 +239,33 @@ jobs:
 
     steps:
       - name: Generate summary
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          IMAGE_DIGEST: ${{ needs.build.outputs.image-digest }}
+          IMAGE_TAGS: ${{ needs.build.outputs.image-tags }}
         run: |
-          echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Release" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Release:** \`${{ github.event.release.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Prerelease:** \`${{ github.event.release.prerelease }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Images Published" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Registry | Image |" >> $GITHUB_STEP_SUMMARY
-          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Docker Hub | \`${{ env.DOCKERHUB_IMAGE }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| GitHub | \`${{ env.GHCR_IMAGE }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Build Details" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Digest:** \`${{ needs.build.outputs.image-digest }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Platforms:** \`${{ env.PLATFORMS }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Tags" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ needs.build.outputs.image-tags }}" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "## Docker Build Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Release" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Release:** \`${RELEASE_TAG}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Prerelease:** \`${RELEASE_PRERELEASE}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Images Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Registry | Image |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Docker Hub | \`${DOCKERHUB_IMAGE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| GitHub | \`${GHCR_IMAGE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Build Details" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Digest:** \`${IMAGE_DIGEST}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Platforms:** \`${PLATFORMS}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Tags" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "$IMAGE_TAGS" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation

The release workflow (`.github/workflows/docker-image.yml`) interpolated release-controlled values — `GITHUB_REF_NAME`, `steps.version.outputs.version`, and `github.event.release.target_commitish` — directly into shell `run:` steps and `git` commands. A release tag (or `target_commitish`) containing shell metacharacters could inject arbitrary commands into the runner during a `release: published` event, giving attacker-controlled input a path to the `VERSION_SYNC_TOKEN` secret and push credentials.

This completes #225 (originally opened from `codex/fix-release-tag-command-injection`) on the current `latest` base.

### Description

- **Validate the version before it reaches any later interpolation.** The `Extract version from release tag` step now checks the stripped tag against a SemVer-like pattern and fails the step when it doesn't match, so `steps.version.outputs.version` can only ever hold `[0-9A-Za-z.+-]` characters. The write to `$GITHUB_OUTPUT` is quoted.
- **Pass release-derived values through the environment in the sync step.** `RELEASE_VERSION`, `TARGET_COMMITISH`, and `VERSION_SYNC_TOKEN` are provided via step `env:` and referenced as quoted shell expansions (`"$RELEASE_VERSION"`, `"HEAD:${TARGET_COMMITISH}"`) instead of `${{ … }}` interpolation. The `git remote set-url` URL and the `git push` refspec are quoted so `target_commitish` can't break out of the command.
- **Harden the summary step.** `tag_name`, `prerelease`, the image digest, and image tags move into step `env:` variables, and every write to `$GITHUB_STEP_SUMMARY` is quoted. The static workflow-level `env:` values (`DOCKERHUB_IMAGE`, `GHCR_IMAGE`, `PLATFORMS`) are referenced as real shell variables.

After the change, the only remaining `${{ … }}` uses of release-controlled values are inside `env:` blocks, the job `outputs:` mapping, and action `with:` inputs — none are raw shell, and the version output is SemVer-constrained at its source.

### Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker-image.yml'))"` — YAML parses cleanly.
- Grep audit confirms no release-controlled value is interpolated into a `run:` shell block, and no unquoted `>> $GITHUB_OUTPUT` / `>> $GITHUB_STEP_SUMMARY` redirections remain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPQwZ5N6kv1vo5754quQvH)_