### PR TITLE
Phase 9: drop legacy per-tool FileEntry flags (#186, site 6)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -86,29 +86,6 @@ class FileEntry(BaseModel):
     type: str  # "file", "directory", or "archive"
     size: int | None = None
     extension: str | None = None
-    convertible: bool = False
-    has_chd: bool = False
-    has_rvz: bool = False
-    dolphin_ready: bool = False
-    dolphin_path: str | None = None
-    chd_ready: bool = False
-    dolphin_convertible: bool = False
-    z3ds_convertible: bool = False
-    has_z3ds: bool = False
-    z3ds_ready: bool = False
-    z3ds_path: str | None = None
-    nsz_convertible: bool = False
-    has_nsz: bool = False
-    nsz_ready: bool = False
-    nsz_path: str | None = None
-    cso_convertible: bool = False
-    has_cso: bool = False
-    cso_ready: bool = False
-    cso_path: str | None = None
-    romz_convertible: bool = False
-    has_romz: bool = False
-    romz_ready: bool = False
-    romz_path: str | None = None
     archive_items: int | None = None
     # Count of archive members that already have an existing output from any
     # registered tool (.chd/.rvz/.z3ds/.nsz/…), finished or mid-conversion.

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -194,49 +194,16 @@ def _verifiable_by(path: str) -> list[str]:
     return [t.id for t in registry.tools_verifying_path(path)]
 
 
-def _legacy_output_fields(
-    convertible_by: list[str], by_tool: dict[str, OutputStatus],
-) -> dict:
-    """Derive the legacy per-tool booleans/paths from registry detection.
-
-    Single source of truth shared by the on-disk and archive-member listing
-    paths so the flat ``has_*`` / ``*_ready`` / ``*_convertible`` flags the
-    frontend still reads can't drift from ``convertible_by`` / ``outputs``.
-    """
-    fields: dict = {}
-    for tool_id, has_key, ready_key, path_key in (
-        ("chdman", "has_chd", "chd_ready", None),
-        ("dolphin", "has_rvz", "dolphin_ready", "dolphin_path"),
-        ("z3ds", "has_z3ds", "z3ds_ready", "z3ds_path"),
-        ("nsz", "has_nsz", "nsz_ready", "nsz_path"),
-        ("cso", "has_cso", "cso_ready", "cso_path"),
-        ("romz", "has_romz", "romz_ready", "romz_path"),
-    ):
-        status = by_tool.get(tool_id)
-        fields[has_key] = status is not None
-        fields[ready_key] = status.exists if status else False
-        if path_key is not None:
-            fields[path_key] = status.path if status else None
-    fields["convertible"] = "chdman" in convertible_by
-    fields["dolphin_convertible"] = "dolphin" in convertible_by
-    fields["z3ds_convertible"] = "z3ds" in convertible_by
-    fields["nsz_convertible"] = "nsz" in convertible_by
-    fields["cso_convertible"] = "cso" in convertible_by
-    fields["romz_convertible"] = "romz" in convertible_by
-    return fields
-
-
 def _summarize_archive(item_path: str) -> dict:
     """Per-archive summary fields for the file listing / archive-summary batch.
 
     Reads the archive once (via the shared mtime-cached member reader) and
     derives: the member count, how many members already have a sibling output
-    from any tool, whether the listing hit the archive limits, whether any
-    member has a CHD sibling (the legacy ``has_chd`` flag), and the per-archive
-    ``verifiable_by`` gate (romz only claims single-ROM .7z/.zip). Shared by the
-    inline ``summarize_archives=True`` path and the lazy ``/archive-summary``
-    batch the browser hydrates with, so both report identical badges. Blocking
-    I/O — call it off the event loop.
+    from any tool, whether the listing hit the archive limits, and the
+    per-archive ``verifiable_by`` gate (romz only claims single-ROM .7z/.zip).
+    Shared by the inline ``summarize_archives=True`` path and the lazy
+    ``/archive-summary`` batch the browser hydrates with, so both report
+    identical badges. Blocking I/O — call it off the event loop.
     """
     archive_result = archive_service.list_archive_contents(
         item_path, include_meta=True,
@@ -244,20 +211,16 @@ def _summarize_archive(item_path: str) -> dict:
     contents = archive_result["entries"]
     archive_dir = os.path.dirname(item_path)
     archive_has_output = 0
-    member_has_chd = False
     for entry in contents:
         _, _, _, member_by_tool = _detect_archive_member_outputs(entry, archive_dir)
         # A member counts as "converted" once any tool already has a sibling
         # output for it, not just CHDMAN.
         if member_by_tool:
             archive_has_output += 1
-        if "chdman" in member_by_tool:
-            member_has_chd = True
     return {
         "archive_items": len(contents),
         "archive_has_output": archive_has_output,
         "archive_truncated": bool(archive_result["truncated"]),
-        "has_chd": member_has_chd,
         "verifiable_by": _verifiable_by(item_path),
     }
 
@@ -383,17 +346,14 @@ async def list_files(
                             continue
 
                         # Registry-driven convertibility + sibling-output
-                        # detection; the legacy booleans below are derived
-                        # from these so they can't drift. Archives are never
-                        # directly convertible (only their members are), so
-                        # skip detection for them.
+                        # detection. Archives are never directly convertible
+                        # (only their members are), so skip detection for them.
                         if is_archive:
-                            convertible_by, outputs, by_tool = [], [], {}
+                            convertible_by, outputs = [], []
                         else:
-                            convertible_by, outputs, by_tool = _detect_file_outputs(
+                            convertible_by, outputs, _ = _detect_file_outputs(
                                 item_path, ext,
                             )
-                        tool_fields = _legacy_output_fields(convertible_by, by_tool)
 
                         archive_items = None
                         archive_has_output = None
@@ -410,7 +370,6 @@ async def list_files(
                                 archive_items = summary["archive_items"]
                                 archive_has_output = summary["archive_has_output"]
                                 archive_truncated = summary["archive_truncated"]
-                                tool_fields["has_chd"] = summary["has_chd"]
                                 verifiable_by = summary["verifiable_by"]
                         else:
                             verifiable_by = _verifiable_by(item_path)
@@ -427,7 +386,6 @@ async def list_files(
                             convertible_by=convertible_by,
                             outputs=outputs,
                             verifiable_by=verifiable_by,
-                            **tool_fields,
                         )
                         entries.append(entry)
                 except OSError:
@@ -550,14 +508,10 @@ async def search_files(
                                         "type": "directory",
                                         "size": None,
                                         "extension": "",
-                                        "chd_path": None,
                                         "in_archive": False,
                                         "convertible_by": dir_convertible_by,
                                         "outputs": dir_outputs,
                                         "verifiable_by": [],
-                                        **_legacy_output_fields(
-                                            dir_convertible_by, {},
-                                        ),
                                     },
                                 )
                             elif recursive_scan and not os.path.islink(item_path):
@@ -565,32 +519,22 @@ async def search_files(
                         elif os.path.isfile(item_path):
                             is_archive = ext in ARCHIVE_EXTENSIONS
                             if is_archive:
-                                convertible_by, outputs, by_tool = [], [], {}
+                                convertible_by, outputs = [], []
                             else:
-                                convertible_by, outputs, by_tool = _detect_file_outputs(
+                                convertible_by, outputs, _ = _detect_file_outputs(
                                     item_path, ext,
                                 )
                             if convertible_by:
-                                tool_fields = _legacy_output_fields(
-                                    convertible_by, by_tool,
-                                )
-                                chd_path = (
-                                    str(Path(item_path).with_suffix(".chd"))
-                                    if tool_fields["convertible"]
-                                    else None
-                                )
                                 files.append(
                                     {
                                         "name": item,
                                         "path": item_path,
                                         "size": os.path.getsize(item_path),
                                         "extension": ext,
-                                        "chd_path": chd_path,
                                         "in_archive": False,
                                         "convertible_by": convertible_by,
                                         "outputs": outputs,
                                         "verifiable_by": _verifiable_by(item_path),
-                                        **tool_fields,
                                     },
                                 )
                             elif include_archive_scan and is_archive:
@@ -611,7 +555,6 @@ async def search_files(
                                         "type": "archive",
                                         "size": os.path.getsize(item_path),
                                         "extension": ext,
-                                        "chd_path": None,
                                         "in_archive": False,
                                         "convertible_by": [],
                                         "outputs": [],
@@ -619,7 +562,6 @@ async def search_files(
                                         # surface on single-ROM .7z/.zip, not on
                                         # every archive container.
                                         "verifiable_by": _verifiable_by(item_path),
-                                        **_legacy_output_fields([], {}),
                                     },
                                 )
                                 # List archive contents. Search surfaces
@@ -642,12 +584,9 @@ async def search_files(
                                         output_stem,
                                         member_convertible_by,
                                         member_outputs,
-                                        member_by_tool,
+                                        _,
                                     ) = _detect_archive_member_outputs(
                                         entry, archive_dir,
-                                    )
-                                    tool_fields = _legacy_output_fields(
-                                        member_convertible_by, member_by_tool,
                                     )
                                     archives.append(
                                         {
@@ -658,13 +597,9 @@ async def search_files(
                                             "size": entry["size"],
                                             "extension": entry["extension"],
                                             "output_stem": output_stem,
-                                            "chd_path": os.path.join(
-                                                archive_dir, f"{output_stem}.chd",
-                                            ),
                                             "in_archive": True,
                                             "convertible_by": member_convertible_by,
                                             "outputs": member_outputs,
-                                            **tool_fields,
                                         },
                                     )
                     except OSError:
@@ -725,12 +660,10 @@ async def list_archive(
 
     def _annotate_members() -> None:
         for file_entry in contents:
-            output_stem, convertible_by, outputs, by_tool = (
+            output_stem, convertible_by, outputs, _ = (
                 _detect_archive_member_outputs(file_entry, archive_dir)
             )
-            file_entry.update(_legacy_output_fields(convertible_by, by_tool))
             file_entry["output_stem"] = output_stem
-            file_entry["chd_path"] = os.path.join(archive_dir, f"{output_stem}.chd")
             file_entry["convertible_by"] = convertible_by
             file_entry["outputs"] = outputs
 

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -1016,8 +1016,21 @@ at a time. Nothing here changes the wire API until Phase 9 (optional).
   `ADDING_PLATFORMS_AND_TOOLS.md` §15 (no build step, edit JS directly).
 
 ### Phase 9: Cleanup (optional, behavior-preserving)
-- Remove the now-unused legacy `FileEntry` booleans once the frontend reads
-  `outputs` exclusively.
+- ~~Remove the now-unused legacy `FileEntry` booleans once the frontend reads
+  `outputs` exclusively.~~ **Done (issue #186, site 6).** The ~23 legacy
+  per-tool flags (`has_*` / `*_ready` / `*_convertible` / `*_path` and the bare
+  `convertible`) are gone from `FileEntry`, the `_legacy_output_fields` helper
+  and the per-archive `has_chd` special-case are removed from `routes/files.py`,
+  and the two remaining frontend fallbacks (`FileRow` `convertibleBy`,
+  `fileBrowser` `has_chd` merge) now read `convertible_by` / `outputs` /
+  `verifiable_by` exclusively. The per-archive "converted" badge derives from
+  the registry-driven `archive_has_output` count.
+- The verify-route factory (`routes/info.py`) is already registry-driven with no
+  per-tool branching; its six explicit `register_verify_routes(...)` calls are
+  retained deliberately to preserve the module-level `verify_*` handler names the
+  route tests call directly. Folding them into a `registry.all()` loop would
+  require moving the per-tool prefix/detail strings onto the plugin contract and
+  rewriting those tests, for no behavior change, so it stays as-is.
 - Delete the old `services/{chdman,dolphin,z3ds_compress}.py` shims; update
   imports.
 - Consider deriving `config` binary paths from the registry.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -20,6 +20,21 @@ and #179, part of the #177 tech-debt epic).
   of the regenerated `docs-desktop-view` / `docs-tablet-view` / `docs-mobile-view`
   set.
 
+### Removed
+
+- **Legacy per-tool `FileEntry` flags dropped (issue #186, site 6 — Phase 9
+  cleanup).** The ~23 dual-maintained per-tool booleans/paths on `FileEntry`
+  (`has_chd` / `has_rvz` / `*_ready` / `*_convertible` / `*_path` and the bare
+  `convertible`) are removed. They were pure derivations of the registry-driven
+  `convertible_by` / `outputs` / `verifiable_by` fields the frontend already
+  reads, so the backend now emits only those: the `_legacy_output_fields` helper
+  and the per-archive `has_chd` special-case are gone from `routes/files.py`
+  (the per-archive "converted" badge continues to derive from the
+  registry-driven `archive_has_output` count), and the last two frontend
+  fallbacks (`FileRow` convertibility, `fileBrowser` archive-summary merge) now
+  read the registry-driven fields exclusively. No wire-API change the UI relies
+  on; the file/search JSON simply no longer carries the dead flags.
+
 ### Changed
 
 - **Frontend icon and Help lists now derive from the tool registry (issue #186,

--- a/src/lib/components/panels/FileRow.svelte
+++ b/src/lib/components/panels/FileRow.svelte
@@ -29,19 +29,9 @@
 
   const mediaType = $derived(chdMeta?.media_type ?? entry?.media_type ?? null);
 
-  const convertibleBy = $derived.by(() => {
-    if (Array.isArray(entry?.convertible_by) && entry.convertible_by.length) {
-      return entry.convertible_by;
-    }
-    const legacy = [];
-    if (entry?.convertible) legacy.push('chdman');
-    if (entry?.dolphin_convertible) legacy.push('dolphin');
-    if (entry?.z3ds_convertible) legacy.push('z3ds');
-    if (entry?.nsz_convertible) legacy.push('nsz');
-    if (entry?.cso_convertible) legacy.push('cso');
-    if (entry?.romz_convertible) legacy.push('romz');
-    return legacy;
-  });
+  const convertibleBy = $derived(
+    Array.isArray(entry?.convertible_by) ? entry.convertible_by : [],
+  );
 
   const outputs = $derived(Array.isArray(entry?.outputs) ? entry.outputs : []);
 

--- a/src/lib/stores/fileBrowser.svelte.js
+++ b/src/lib/stores/fileBrowser.svelte.js
@@ -470,7 +470,6 @@ class FileBrowserStore {
       archive_items: s.archive_items,
       archive_has_output: s.archive_has_output,
       archive_truncated: s.archive_truncated,
-      has_chd: s.has_chd ?? entry.has_chd,
       verifiable_by: Array.isArray(s.verifiable_by) ? s.verifiable_by : entry.verifiable_by,
     };
   }

--- a/tests/test_archive_summary_lazy.py
+++ b/tests/test_archive_summary_lazy.py
@@ -77,7 +77,6 @@ async def test_batch_matches_inline_summary(summary_env):
         assert got["archive_items"] == entry.archive_items
         assert got["archive_has_output"] == entry.archive_has_output
         assert got["archive_truncated"] == entry.archive_truncated
-        assert got["has_chd"] == entry.has_chd
         assert got["verifiable_by"] == entry.verifiable_by
 
     # Spot-check the meaningful distinctions the badges rely on.

--- a/tests/test_files_outputs_parity.py
+++ b/tests/test_files_outputs_parity.py
@@ -1,8 +1,14 @@
-"""Phase 7: registry-driven FileEntry outputs must stay in lock-step with the
-legacy per-tool booleans, and the legacy JSON contract must not drift.
+"""Registry-driven FileEntry output detection across the file/search paths.
 
-These tests are the safety net for the refactor that replaced the six
-hand-written flag blocks in ``routes/files.py`` with a single registry loop.
+Phase 7 replaced the six hand-written per-tool flag blocks in
+``routes/files.py`` with a single registry loop, and Phase 9 (issue #186,
+site 6) removed the legacy ``has_*`` / ``*_ready`` / ``*_convertible`` /
+``*_path`` booleans entirely — the frontend reads ``convertible_by`` /
+``outputs`` / ``verifiable_by`` exclusively. These tests are the safety net for
+the detection itself: every branch (no output, finished output, mid-conversion
+lock, self-format input, per-tool convertibility, the archive-member summary)
+must be reported correctly through the registry-driven fields, and the JSON
+contract must stay exactly those fields with no legacy holdovers.
 """
 
 from __future__ import annotations
@@ -15,36 +21,26 @@ import pytest
 from app.routes import files as files_routes
 from app.services.lock_manager import lock_manager
 
-# The exact legacy field surface that frontend (Phase 8) still reads. Phase 7
-# only adds ``convertible_by``/``outputs`` on top of these.
-LEGACY_FILEENTRY_KEYS = {
-    "name", "path", "type", "size", "extension", "convertible", "has_chd",
-    "has_rvz", "dolphin_ready", "dolphin_path", "chd_ready",
-    "dolphin_convertible", "z3ds_convertible", "has_z3ds", "z3ds_ready",
-    "z3ds_path", "nsz_convertible", "has_nsz", "nsz_ready", "nsz_path",
-    "cso_convertible", "has_cso", "cso_ready", "cso_path",
-    "romz_convertible", "has_romz", "romz_ready", "romz_path",
-    "archive_items", "archive_has_output", "archive_truncated",
-    "media_type",
+# The exact FileEntry field surface the frontend reads.
+FILEENTRY_KEYS = {
+    "name", "path", "type", "size", "extension",
+    "archive_items", "archive_has_output", "archive_truncated", "media_type",
+    "convertible_by", "outputs", "verifiable_by", "split_parts",
 }
-LEGACY_SEARCH_KEYS = {
-    "name", "path", "size", "extension", "chd_path", "has_chd", "has_rvz",
-    "dolphin_ready", "dolphin_path", "chd_ready", "convertible",
-    "dolphin_convertible", "z3ds_convertible", "has_z3ds", "z3ds_ready",
-    "z3ds_path", "nsz_convertible", "has_nsz", "nsz_ready", "nsz_path",
-    "cso_convertible", "has_cso", "cso_ready", "cso_path",
-    "romz_convertible", "has_romz", "romz_ready", "romz_path",
-    "in_archive",
+# On-disk search hits mirror the file schema minus the listing-only archive
+# summary / media / split fields, plus the ``in_archive`` marker.
+SEARCH_FILE_KEYS = {
+    "name", "path", "size", "extension", "in_archive",
+    "convertible_by", "outputs", "verifiable_by",
 }
-# Archive members carry the same registry-driven flags as on-disk search hits
-# (issue #128) plus the archive-specific locator keys.
-LEGACY_ARCHIVE_KEYS = LEGACY_SEARCH_KEYS | {
-    "archive_path", "internal_path", "output_stem",
+# Archive containers surface from search with the same schema plus a ``type``.
+SEARCH_ARCHIVE_CONTAINER_KEYS = SEARCH_FILE_KEYS | {"type"}
+# Archive members carry the registry-driven flags plus archive locator keys,
+# but no per-file verify gate (they can't be verified in place).
+ARCHIVE_MEMBER_KEYS = {
+    "name", "path", "size", "extension", "in_archive",
+    "convertible_by", "outputs", "archive_path", "internal_path", "output_stem",
 }
-NEW_KEYS = {"convertible_by", "outputs"}
-# On-disk entries and archive containers also carry the per-file verify gate
-# (issue #146); archive *members* don't (they can't be verified in place).
-NEW_KEYS_WITH_VERIFY = NEW_KEYS | {"verifiable_by"}
 
 
 @pytest.fixture(name="parity_env")
@@ -83,123 +79,75 @@ def _parity_env(tmp_path: Path, monkeypatch):
         lock_manager.release_lock(lock_path)
 
 
-def _assert_agreement(legacy: dict, outputs: list, convertible_by: list[str]) -> None:
-    """The legacy booleans must be reconstructable from outputs/convertible_by."""
-    by_tool = {o.tool_id: o for o in outputs}
-
-    assert legacy["has_chd"] == ("chdman" in by_tool)
-    assert legacy["chd_ready"] == (
-        by_tool["chdman"].exists if "chdman" in by_tool else False
-    )
-
-    assert legacy["has_rvz"] == ("dolphin" in by_tool)
-    assert legacy["dolphin_ready"] == (
-        by_tool["dolphin"].exists if "dolphin" in by_tool else False
-    )
-    assert legacy["dolphin_path"] == (
-        by_tool["dolphin"].path if "dolphin" in by_tool else None
-    )
-
-    assert legacy["has_z3ds"] == ("z3ds" in by_tool)
-    assert legacy["z3ds_ready"] == (
-        by_tool["z3ds"].exists if "z3ds" in by_tool else False
-    )
-    assert legacy["z3ds_path"] == (
-        by_tool["z3ds"].path if "z3ds" in by_tool else None
-    )
-
-    assert legacy["convertible"] == ("chdman" in convertible_by)
-    assert legacy["dolphin_convertible"] == ("dolphin" in convertible_by)
-    assert legacy["z3ds_convertible"] == ("z3ds" in convertible_by)
+# Both the listing (FileEntry.outputs) and the search dicts ("outputs" key)
+# carry OutputStatus objects, so every field is attribute access.
+def _by_tool(outputs: list) -> dict:
+    return {o.tool_id: o for o in outputs}
 
 
 @pytest.mark.asyncio
-async def test_list_files_outputs_agree_with_legacy(parity_env):
+async def test_list_files_output_detection(parity_env):
     listing = await files_routes.list_files(path=parity_env["root"])
     by_name = {e.name: e for e in listing.entries}
     root = parity_env["root"]
-
-    # Archives are a documented exception: has_chd is set from archive-member
-    # scanning, not from registry outputs, so the agreement invariant applies
-    # only to plain files.
-    for entry in listing.entries:
-        if entry.type != "file":
-            continue
-        _assert_agreement(entry.model_dump(), entry.outputs, entry.convertible_by)
 
     # No output present.
     lonely = by_name["lonely.cue"]
     assert lonely.convertible_by == ["chdman"]
     assert lonely.outputs == []
-    assert lonely.has_chd is False and lonely.chd_ready is False
 
     # Finished chdman output.
     done = by_name["done.cue"]
-    assert done.has_chd is True and done.chd_ready is True
     assert [o.tool_id for o in done.outputs] == ["chdman"]
     assert done.outputs[0].exists is True and done.outputs[0].ready is True
 
     # Mid-conversion chdman output (locked, file absent).
     prog = by_name["prog.cue"]
-    assert prog.has_chd is True and prog.chd_ready is False
     assert prog.outputs[0].tool_id == "chdman"
     assert prog.outputs[0].exists is False and prog.outputs[0].ready is False
     assert prog.outputs[0].path == str(Path(root) / "prog.chd")
 
-    # Finished dolphin output for a dolphin-only input.
+    # Finished dolphin output for a dolphin-only input (.wbfs is not
+    # chdman-convertible).
     disc = by_name["disc.wbfs"]
-    assert disc.has_rvz is True and disc.dolphin_ready is True
-    assert disc.dolphin_path == str(Path(root) / "disc.rvz")
-    assert disc.convertible is False  # .wbfs is not chdman-convertible
+    assert "chdman" not in disc.convertible_by
+    assert _by_tool(disc.outputs)["dolphin"].exists is True
+    assert _by_tool(disc.outputs)["dolphin"].path == str(Path(root) / "disc.rvz")
 
     # Self-format dolphin input detects itself.
     movie = by_name["movie.rvz"]
-    assert movie.has_rvz is True and movie.dolphin_ready is True
-    assert movie.dolphin_path == str(Path(root) / "movie.rvz")
+    assert _by_tool(movie.outputs)["dolphin"].path == str(Path(root) / "movie.rvz")
 
     # Finished z3ds output.
     rom = by_name["rom.3ds"]
-    assert rom.has_z3ds is True and rom.z3ds_ready is True
-    assert rom.z3ds_path == str(Path(root) / "rom.z3ds")
     assert [o.tool_id for o in rom.outputs] == ["z3ds"]
+    assert _by_tool(rom.outputs)["z3ds"].path == str(Path(root) / "rom.z3ds")
 
-    # Archive: CHD-only detection via the archive special-casing; the new
-    # registry-driven fields stay empty (archives never emit tool outputs).
+    # Archive: never emits tool outputs itself, but the registry-driven summary
+    # counts the single member with a sibling output (inner.iso -> inner.chd)
+    # regardless of which tool produced it — the replacement for the old
+    # per-archive has_chd badge.
     bundle = by_name["bundle.zip"]
     assert bundle.type == "archive"
-    assert bundle.has_chd is True  # inner.chd exists for the member stem
-    assert bundle.has_rvz is False and bundle.z3ds_ready is False
     assert bundle.convertible_by == []
     assert bundle.outputs == []
-    # The summary count is registry-driven: the single member with a sibling
-    # output (inner.iso -> inner.chd) is counted regardless of which tool
-    # produced it.
     assert bundle.archive_has_output == 1
 
 
 @pytest.mark.asyncio
-async def test_search_files_outputs_agree_with_legacy(parity_env):
+async def test_search_files_output_detection(parity_env):
     results = await files_routes.search_files(
         path=parity_env["root"], recursive=True, include_archives=True,
     )
     by_name = {Path(item["path"]).name: item for item in results["files"]}
 
-    # Archives are a documented exception (mirrors the list_files counterpart):
-    # has_chd can come from archive-member scanning, not registry outputs, so
-    # the agreement invariant applies only to plain on-disk files.
-    for item in results["files"]:
-        if item.get("type") == "archive":
-            continue
-        _assert_agreement(item, item["outputs"], item["convertible_by"])
-
     assert by_name["lonely.cue"]["outputs"] == []
     assert by_name["lonely.cue"]["convertible_by"] == ["chdman"]
-    assert by_name["done.cue"]["chd_ready"] is True
-    assert by_name["prog.cue"]["has_chd"] is True
-    assert by_name["prog.cue"]["chd_ready"] is False
-    assert by_name["disc.wbfs"]["dolphin_path"].endswith("disc.rvz")
-    assert by_name["movie.rvz"]["dolphin_ready"] is True
-    assert by_name["rom.3ds"]["z3ds_ready"] is True
+    assert _by_tool(by_name["done.cue"]["outputs"])["chdman"].ready is True
+    assert _by_tool(by_name["prog.cue"]["outputs"])["chdman"].exists is False
+    assert _by_tool(by_name["disc.wbfs"]["outputs"])["dolphin"].path.endswith("disc.rvz")
+    assert _by_tool(by_name["movie.rvz"]["outputs"])["dolphin"].ready is True
+    assert "z3ds" in _by_tool(by_name["rom.3ds"]["outputs"])
     # The archive container surfaces as a top-level result (browse-only unless an
     # archive-direct mode like romz_extract is active) alongside its members.
     assert by_name["bundle.zip"]["type"] == "archive"
@@ -207,56 +155,38 @@ async def test_search_files_outputs_agree_with_legacy(parity_env):
 
 
 @pytest.mark.asyncio
-async def test_list_files_json_keys_are_additive(parity_env):
-    """Every legacy FileEntry key is preserved; only convertible_by/outputs added."""
+async def test_list_files_json_keys(parity_env):
+    """Every FileEntry carries exactly the registry-driven field surface."""
     listing = await files_routes.list_files(path=parity_env["root"])
     for entry in listing.entries:
-        keys = set(entry.model_dump().keys())
-        assert LEGACY_FILEENTRY_KEYS <= keys
-        # split_parts (issue #98): present on every FileEntry (None unless this
-        # row is a folded makeps3iso split-ISO set). The search path emits plain
-        # dicts without it, so it's only added to the listing's key set.
-        assert keys - LEGACY_FILEENTRY_KEYS == NEW_KEYS_WITH_VERIFY | {"split_parts"}
+        assert set(entry.model_dump().keys()) == FILEENTRY_KEYS
 
 
 @pytest.mark.asyncio
-async def test_search_files_json_keys_are_additive(parity_env):
-    """Search file dicts keep every legacy key; archive dicts stay untouched."""
+async def test_search_files_json_keys(parity_env):
+    """Search dicts carry only the registry-driven fields — no legacy holdovers."""
     results = await files_routes.search_files(
         path=parity_env["root"], recursive=True, include_archives=True,
     )
     for item in results["files"]:
         keys = set(item.keys())
-        assert LEGACY_SEARCH_KEYS <= keys
-        # Archive containers (issue: romz_extract reachable from search) carry
-        # the same file schema plus a ``type`` marker; on-disk hits stay as-is.
         if item.get("type") == "archive":
-            assert keys - LEGACY_SEARCH_KEYS == NEW_KEYS_WITH_VERIFY | {"type"}
+            assert keys == SEARCH_ARCHIVE_CONTAINER_KEYS
         else:
-            assert keys - LEGACY_SEARCH_KEYS == NEW_KEYS_WITH_VERIFY
+            assert keys == SEARCH_FILE_KEYS
 
-    # Archive members are now registry-driven too (issue #128): they expose the
-    # same per-tool flags as on-disk hits, plus archive locator keys, and their
-    # legacy booleans must be reconstructable from outputs/convertible_by.
     for item in results["archives"]:
-        keys = set(item.keys())
-        assert LEGACY_ARCHIVE_KEYS <= keys
-        assert keys - LEGACY_ARCHIVE_KEYS == NEW_KEYS
+        assert set(item.keys()) == ARCHIVE_MEMBER_KEYS
         assert item["in_archive"] is True
-        _assert_agreement(item, item["outputs"], item["convertible_by"])
 
     # bundle.zip::inner.iso has a sibling inner.chd, so the member surfaces as
-    # CHDMAN-convertible with a finished output — and as Dolphin-convertible
-    # (.iso is accepted by both) even though no .rvz sibling exists.
+    # CHDMAN-convertible with a finished output — and as Dolphin- and
+    # CSO-convertible (.iso is accepted by all three) even though only the .chd
+    # sibling exists in the fixture.
     inner = next(i for i in results["archives"] if i["name"] == "inner.iso")
-    assert inner["convertible"] is True
-    assert inner["has_chd"] is True and inner["chd_ready"] is True
     assert "chdman" in inner["convertible_by"]
-    assert inner["dolphin_convertible"] is True
-    assert inner["has_rvz"] is False
-    # ...and as CSO-convertible (.iso -> .cso/.zso via maxcso), surfaced through
-    # the same registry-driven archive-member detection (#128). No .cso sibling
-    # exists in the fixture, so the output flags stay False.
-    assert inner["cso_convertible"] is True
+    assert _by_tool(inner["outputs"])["chdman"].ready is True
+    assert "dolphin" in inner["convertible_by"]
+    assert "dolphin" not in _by_tool(inner["outputs"])
     assert "cso" in inner["convertible_by"]
-    assert inner["has_cso"] is False and inner["cso_ready"] is False
+    assert "cso" not in _by_tool(inner["outputs"])

--- a/tests/test_mode_parity_fixes.py
+++ b/tests/test_mode_parity_fixes.py
@@ -60,44 +60,51 @@ def test_job_manager_default_max_concurrent_is_one():
     assert manager.max_concurrent == 1
 
 
+def _dolphin_output(outputs):
+    """Return the dolphin OutputStatus (obj or dict) from an outputs list, or None."""
+    for o in outputs:
+        if (o.tool_id if hasattr(o, "tool_id") else o["tool_id"]) == "dolphin":
+            return o
+    return None
+
+
 @pytest.mark.asyncio
-async def test_list_files_populates_has_rvz(files_env):
+async def test_list_files_populates_dolphin_output(files_env):
     """Directory listing should surface Dolphin output presence for inputs."""
     listing = await files_routes.list_files(path=files_env["root"])
     by_name = {entry.name: entry for entry in listing.entries}
 
-    assert by_name["game.iso"].dolphin_convertible is True
-    assert by_name["game.iso"].has_rvz is True
-    assert by_name["game.iso"].dolphin_ready is True
-    assert by_name["game.iso"].dolphin_path == files_env["game_rvz"]
-    assert by_name["wia.iso"].has_rvz is True
-    assert by_name["wia.iso"].dolphin_ready is True
-    assert by_name["wia.iso"].dolphin_path == files_env["wia_output"]
-    assert by_name["other.iso"].dolphin_convertible is True
-    assert by_name["other.iso"].has_rvz is False
-    assert by_name["other.iso"].dolphin_ready is False
-    assert by_name["game.rvz"].has_rvz is True
-    assert by_name["game.rvz"].dolphin_ready is True
+    game = by_name["game.iso"]
+    assert "dolphin" in game.convertible_by
+    assert _dolphin_output(game.outputs).exists is True
+    assert _dolphin_output(game.outputs).path == files_env["game_rvz"]
+    wia = by_name["wia.iso"]
+    assert _dolphin_output(wia.outputs).exists is True
+    assert _dolphin_output(wia.outputs).path == files_env["wia_output"]
+    other = by_name["other.iso"]
+    assert "dolphin" in other.convertible_by
+    assert _dolphin_output(other.outputs) is None
+    assert _dolphin_output(by_name["game.rvz"].outputs).exists is True
 
 
 @pytest.mark.asyncio
-async def test_search_files_populates_has_rvz(files_env):
+async def test_search_files_populates_dolphin_output(files_env):
     """Recursive search results should include Dolphin-product state consistently."""
     results = await files_routes.search_files(
         path=files_env["root"], recursive=True, include_archives=False
     )
     by_name = {Path(item["path"]).name: item for item in results["files"]}
 
-    assert by_name["game.iso"]["dolphin_convertible"] is True
-    assert by_name["game.iso"]["has_rvz"] is True
-    assert by_name["game.iso"]["dolphin_ready"] is True
-    assert by_name["game.iso"]["dolphin_path"] == files_env["game_rvz"]
-    assert by_name["wia.iso"]["has_rvz"] is True
-    assert by_name["wia.iso"]["dolphin_ready"] is True
-    assert by_name["wia.iso"]["dolphin_path"] == files_env["wia_output"]
-    assert by_name["other.iso"]["dolphin_convertible"] is True
-    assert by_name["other.iso"]["has_rvz"] is False
-    assert by_name["other.iso"]["dolphin_ready"] is False
+    game = by_name["game.iso"]
+    assert "dolphin" in game["convertible_by"]
+    assert _dolphin_output(game["outputs"]).exists is True
+    assert _dolphin_output(game["outputs"]).path == files_env["game_rvz"]
+    wia = by_name["wia.iso"]
+    assert _dolphin_output(wia["outputs"]).exists is True
+    assert _dolphin_output(wia["outputs"]).path == files_env["wia_output"]
+    other = by_name["other.iso"]
+    assert "dolphin" in other["convertible_by"]
+    assert _dolphin_output(other["outputs"]) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_romz_files_integration.py
+++ b/tests/test_romz_files_integration.py
@@ -7,8 +7,8 @@ The romz tool claims ``.7z``/``.zip`` as extract-mode inputs and ``.gb``/``.gbc`
    (``type == "archive"``) and is NOT marked directly convertible — the existing
    ``is_archive`` guard must win over romz's input claim, so archive browsing is
    undisturbed.
-2. A loose handheld ROM is marked ``romz_convertible`` and badges its sibling
-   archive output.
+2. A loose handheld ROM lists ``romz`` in ``convertible_by`` and badges its
+   sibling archive output.
 """
 from __future__ import annotations
 
@@ -66,12 +66,11 @@ async def test_archives_stay_archives_after_romz_registers(romz_env):
     pack = by_name["Pack.7z"]
     assert pack.type == "archive"
     # Archives are never directly convertible, even though romz claims .7z.
-    assert pack.romz_convertible is False
     assert pack.convertible_by == []
 
     bundle = by_name["Bundle.zip"]
     assert bundle.type == "archive"
-    assert bundle.romz_convertible is False
+    assert bundle.convertible_by == []
 
 
 @pytest.mark.asyncio
@@ -128,22 +127,19 @@ async def test_loose_rom_is_romz_convertible_and_badges_output(romz_env):
 
     solo = by_name["Solo.gba"]
     assert solo.type == "file"
-    assert solo.romz_convertible is True
     assert "romz" in solo.convertible_by
-    assert solo.has_romz is False
+    assert not any(o.tool_id == "romz" for o in solo.outputs)
 
     done = by_name["Done.gb"]
-    assert done.romz_convertible is True
-    assert done.has_romz is True and done.romz_ready is True
-    assert done.romz_path == str(Path(root) / "Done.gb.zip")
-    assert any(o.tool_id == "romz" for o in done.outputs)
+    assert "romz" in done.convertible_by
+    done_romz = next(o for o in done.outputs if o.tool_id == "romz")
+    assert done_romz.exists is True and done_romz.ready is True
+    assert done_romz.path == str(Path(root) / "Done.gb.zip")
 
     # The multi-file sibling is NOT a romz output: the source row stays a
     # compress source but surfaces no romz output badge or verify-from-output.
     junky = by_name["Junky.gba"]
-    assert junky.romz_convertible is True
-    assert junky.has_romz is False and junky.romz_ready is False
-    assert junky.romz_path is None
+    assert "romz" in junky.convertible_by
     assert not any(o.tool_id == "romz" for o in junky.outputs)
 
 
@@ -176,4 +172,3 @@ async def test_browse_into_romz_archive_shows_rom_but_not_convertible(romz_env):
     rom = members["inner.gba"]
     assert rom["extension"] == ".gba"
     assert rom["convertible_by"] == []
-    assert rom["romz_convertible"] is False


### PR DESCRIPTION
**Part of #186** (SSOT / Modularity), within the #177 tech-debt epic. Completes **site 6** — the Phase 9 cleanup — the last outstanding item now that sites 1/2/4/5 (PR #195) and site 3 (PR #242) are merged. This closes #186.

## What & why

`FileEntry` carried ~23 legacy per-tool flags — `has_chd` / `has_rvz` / `*_ready` / `*_convertible` / `*_path` and the bare `convertible` — dual-maintained alongside the registry-driven `convertible_by` / `outputs` / `verifiable_by`. The design doc's Phase 9 gated their removal on "once the frontend reads `outputs` exclusively." I verified that precondition is effectively met:

- The per-archive `has_chd` was **plumbed but never rendered** — the archive "converted" badge reads `archive_has_output`, not `has_chd`.
- The only remaining frontend reads were **dead fallbacks**: `FileRow`'s `convertibleBy` fell back to the legacy booleans only when `convertible_by` was absent (it never is), and `fileBrowser` merged a `has_chd` nothing consumes.

So the legacy fields were pure derivations with no live consumer.

## Changes

**Backend**
- Remove the legacy fields from `app/models.py` `FileEntry`.
- Delete the `_legacy_output_fields` helper and all its call sites in `routes/files.py`, the per-archive `has_chd` special-case in `_summarize_archive`, and the dead `chd_path` keys in the recursive-search dicts.

**Frontend**
- `FileRow` `convertibleBy` now reads `entry.convertible_by` only.
- `fileBrowser` drops `has_chd` from the archive-summary merge.

**Tests**
- Rewrote the legacy-parity assertions in `test_files_outputs_parity.py`, `test_mode_parity_fixes.py`, `test_romz_files_integration.py`, and `test_archive_summary_lazy.py` to assert detection through `outputs` / `convertible_by` / `verifiable_by` — preserving all the branch coverage (no-output, finished, mid-conversion lock, self-format, per-tool convertibility, the archive-member summary).

## Scoping note — verify-route factory

Site 6 also mentions the `routes/info.py` verify-route factory "could iterate `registry.all()` once the prefix/detail strings move onto the plugin." The factory is **already registry-driven with no per-tool branching**; the six explicit `register_verify_routes(...)` calls are retained deliberately to preserve the module-level `verify_*` handler names that **dozens of route tests call directly** (`test_dolphin_routes`, `test_z3ds_routes`, `test_verify_routes_factory`, …). Folding them into a loop would require moving per-tool config onto the plugin contract and rewriting those tests, for zero behavior change — so it stays as-is (documented in the design doc).

## Verification

- `PYTHONPATH=app python -m pytest -q tests` → **1194 passed, 1 skipped**.
- `ruff check .` clean; `npm run lint` (eslint) clean; `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGWMnqxGt9fotYkArtw2Ps

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGWMnqxGt9fotYkArtw2Ps)_