### PR TITLE
Recognize prior success on re-queue: job-start no-op fast path (#184, site 1)

### DIFF
--- a/app/services/db.py
+++ b/app/services/db.py
@@ -129,6 +129,14 @@ class Verification(Base):
     chd_path = Column(String, primary_key=True)
     source_path = Column(String, nullable=True)
     verified_at = Column(String, nullable=False, default="")
+    # Optional snapshot of what produced this verified artifact: the conversion
+    # mode + output-shaping settings and a stat fingerprint of the complete
+    # source set and the output. Populated only by a delete-on-verify
+    # conversion (a manual /info verify leaves it NULL). Lets the job-start
+    # re-run fast path prove an on-disk output is the exact result of the
+    # current request before completing as a no-op. See
+    # docs/DESIGN_tool_plugin_architecture.md §3.3.6.
+    produced_meta = Column(JSON, nullable=True)
 
 
 class Preference(Base):

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -24,7 +24,7 @@ from services.lock_manager import lock_manager
 from services.makeps3iso import makeps3iso_service
 from services.tools import ModeKind, registry
 from services.verification_store import verification_store
-from utils.delete_plan import build_delete_plan
+from utils.delete_plan import build_delete_plan, build_delete_snapshot
 from utils.path_utils import (
     is_safe_directory_tree,
     is_within_configured_volumes,
@@ -1561,30 +1561,106 @@ class JobManager:
                 pass
         return total_size if total_size > 0 else None
 
+    @staticmethod
+    def _source_fingerprint(source_path: str) -> Optional[Dict[str, Dict[str, int]]]:
+        """Stat fingerprint of the *complete* source set for ``source_path``.
+
+        Uses ``build_delete_snapshot`` so a ``.cue`` / ``.gdi`` descriptor's
+        referenced track files are fingerprinted too — a replaced ``.bin`` track
+        (with the descriptor untouched) changes the fingerprint, which is what a
+        descriptor-only mtime check would miss. Returns ``{realpath: {size,
+        mtime_ns}}`` or ``None`` when the set can't be safely enumerated
+        (unsafe/missing tracks, a non-file), so those never qualify for a
+        fast-path reuse.
+        """
+        try:
+            snapshot = build_delete_snapshot(source_path)
+        except Exception:
+            return None
+        out: Dict[str, Dict[str, int]] = {}
+        for path, fp in (snapshot.get("fingerprints") or {}).items():
+            out[path] = {"size": int(fp["size"]), "mtime_ns": int(fp["mtime_ns"])}
+        return out or None
+
+    @staticmethod
+    def _output_fingerprint(output_path: str) -> Optional[Dict[str, int]]:
+        """Stat fingerprint (size + mtime_ns) of an output file, or ``None``."""
+        try:
+            st = os.stat(output_path, follow_symlinks=False)
+        except OSError:
+            return None
+        if not os.path.isfile(output_path):
+            return None
+        return {
+            "size": int(st.st_size),
+            "mtime_ns": int(
+                getattr(st, "st_mtime_ns", int(st.st_mtime * 1_000_000_000))
+            ),
+        }
+
+    def _build_produced_meta(self, job: ConversionJob) -> Optional[Dict[str, object]]:
+        """Snapshot of what produced this verified artifact, for the re-run fast
+        path: the mode + output-shaping settings and stat fingerprints of the
+        complete source set and the output.
+
+        Returns ``None`` (record no meta → no fast path) for an archive-member
+        source or when the source set / output can't be fingerprinted. Computed
+        right after a successful verify, while the source still exists.
+        """
+        if "::" in job.file_path:
+            # Archive members: the on-disk "source" is the whole archive and the
+            # extracted member is transient, so a reuse can't be proven cheaply.
+            return None
+        source_fp = self._source_fingerprint(job.file_path)
+        output_fp = self._output_fingerprint(job.output_path)
+        if not source_fp or not output_fp:
+            return None
+        return {
+            "mode": job.mode.value,
+            "compression": job.compression,
+            "split": bool(job.split),
+            "source": source_fp,
+            "output": output_fp,
+        }
+
+    def _produced_meta_matches(self, job: ConversionJob, meta: object) -> bool:
+        """Whether the on-disk output is the *exact* result of THIS request.
+
+        Requires the recorded producing settings (mode + compression + split) to
+        equal the current request's, the complete source set to be byte-for-byte
+        unchanged since it was verified (so a different track can't be silently
+        reused), and the output to be unchanged (so a replaced/corrupted file
+        with a fresh mtime can't pass). Any mismatch → re-convert.
+        """
+        if not isinstance(meta, dict):
+            return False
+        if (
+            meta.get("mode") != job.mode.value
+            or meta.get("compression") != job.compression
+            or bool(meta.get("split")) != bool(job.split)
+        ):
+            return False
+        if self._output_fingerprint(job.output_path) != meta.get("output"):
+            return False
+        if self._source_fingerprint(job.file_path) != meta.get("source"):
+            return False
+        return True
+
     async def _output_already_verified(self, job: ConversionJob) -> bool:
         """Whether a prior run already produced and verified this exact output.
 
         Backs the job-start "recognize prior success" fast path (issue #184,
         site 1): a re-queued job whose verified artifact is already on disk
-        completes as a no-op instead of re-spawning the converter. Kept
-        deliberately narrow so it can never deliver a surprising output:
-
-        * Only plain file conversions with default output shaping
-          (``compression is None``, ``split`` off) qualify — a request that
-          changes the output shape must re-run the converter.
-        * Directory-input and delete-on-verify jobs take the normal path (the
-          former has split-set outputs, the latter must run its guarded source
-          deletion), so this never short-circuits a pending delete.
-        * The verification store must hold a record for the output whose
-          recorded *source* is this job's source, and the on-disk source must be
-          no newer than the output (unchanged since it was verified). A record
-          without a source (e.g. a manual /info verify) or a mismatched source
-          never qualifies.
+        completes as a no-op instead of re-spawning the converter. Only a
+        verification record carrying a full ``produced_meta`` snapshot (written
+        by a prior delete-on-verify conversion) can qualify, and only when that
+        snapshot proves the on-disk output is the exact result of the current
+        request — see :meth:`_produced_meta_matches`. Directory-input and
+        delete-on-verify *requests* always take the normal path (the former has
+        split-set outputs, the latter must run its guarded source deletion).
         """
         if (
             job.delete_on_verify
-            or job.split
-            or job.compression is not None
             or job.input_kind == InputKind.DIRECTORY
             or not job.output_path
         ):
@@ -1598,36 +1674,12 @@ class JobManager:
                 "Prior-success check skipped for %s: %s", job.output_path, exc,
             )
             return False
-        if not record or not record.get("source_path"):
+        if not record:
             return False
-        return await run_in_threadpool(
-            self._verified_output_matches_source, job, record["source_path"],
-        )
-
-    @staticmethod
-    def _verified_output_matches_source(
-        job: ConversionJob, recorded_source: str,
-    ) -> bool:
-        """Off-loop check: the verified output exists and its source is unchanged.
-
-        The recorded source must be this job's source (realpath match) and the
-        on-disk source must be no newer than the output, so the output still
-        reflects the current source bytes. Any stat error is treated as "no
-        match" so a missing/racing file falls through to the normal path.
-        """
-        try:
-            if recorded_source != os.path.realpath(job.file_path):
-                return False
-            if not os.path.isfile(job.output_path):
-                return False
-            source_disk = (
-                strip_archive_path(job.file_path)
-                if "::" in job.file_path
-                else job.file_path
-            )
-            return os.path.getmtime(job.output_path) >= os.path.getmtime(source_disk)
-        except OSError:
+        meta = record.get("produced_meta")
+        if not meta:
             return False
+        return await run_in_threadpool(self._produced_meta_matches, job, meta)
 
     async def _run_job(self, job_id: str):
         try:
@@ -1814,6 +1866,10 @@ class JobManager:
             # so the existing verified output is neither re-extracted-from nor
             # deleted. Honors a cancel requested before we got here.
             if not cancel_event.is_set() and await self._output_already_verified(job):
+                # Re-check after the awaited store/stat lookups: a cancel that
+                # landed while they were in flight must win over the no-op.
+                if cancel_event.is_set():
+                    raise ConversionCancelled("Conversion cancelled")
                 self._cancelled.discard(job_id)
                 job.progress = 100
                 job.output_size = await run_in_threadpool(
@@ -2017,8 +2073,19 @@ class JobManager:
                         )
 
                     verified = True
+                    # Snapshot what produced this verified artifact (mode +
+                    # output shaping + source/output fingerprints) so a later
+                    # re-queue can recognize prior success and complete as a
+                    # no-op without re-spawning the converter (#184, site 1).
+                    # The source still exists here (delete runs below), so its
+                    # complete set can be fingerprinted.
+                    produced_meta = await run_in_threadpool(
+                        self._build_produced_meta, job,
+                    )
                     await verification_store.mark_verified(
-                        job.output_path, source_path=job.file_path
+                        job.output_path,
+                        source_path=job.file_path,
+                        produced_meta=produced_meta,
                     )
 
                     if cancel_event.is_set():

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1562,29 +1562,49 @@ class JobManager:
         return total_size if total_size > 0 else None
 
     @staticmethod
-    def _source_fingerprint(source_path: str) -> Optional[Dict[str, Dict[str, int]]]:
+    def _norm_fps(
+        fingerprints: Optional[Dict[str, Dict[str, object]]],
+    ) -> Dict[str, Dict[str, int]]:
+        """Normalize a ``{realpath: {size, mtime_ns, inode, device}}`` map to
+        plain ints, so a stored (JSON-round-tripped) fingerprint and a freshly
+        computed one compare by equality. ``inode``/``device`` are carried
+        alongside size+mtime_ns — the same four fields the delete-safety
+        snapshot trusts to authorize an irreversible delete, so a reuse is held
+        to no weaker a bar (a copy-restore lands on a new inode, a moved mount on
+        a new device)."""
+        out: Dict[str, Dict[str, int]] = {}
+        for path, fp in (fingerprints or {}).items():
+            out[path] = {
+                "size": int(fp.get("size", -1)),
+                "mtime_ns": int(fp.get("mtime_ns", -1)),
+                "inode": int(fp.get("inode", 0) or 0),
+                "device": int(fp.get("device", 0) or 0),
+            }
+        return out
+
+    def _source_fingerprint(
+        self, source_path: str,
+    ) -> Optional[Dict[str, Dict[str, int]]]:
         """Stat fingerprint of the *complete* source set for ``source_path``.
 
         Uses ``build_delete_snapshot`` so a ``.cue`` / ``.gdi`` descriptor's
         referenced track files are fingerprinted too — a replaced ``.bin`` track
-        (with the descriptor untouched) changes the fingerprint, which is what a
-        descriptor-only mtime check would miss. Returns ``{realpath: {size,
-        mtime_ns}}`` or ``None`` when the set can't be safely enumerated
-        (unsafe/missing tracks, a non-file), so those never qualify for a
-        fast-path reuse.
+        (with the descriptor untouched) changes the fingerprint, which a
+        descriptor-only check would miss. Returns ``{realpath: {size, mtime_ns,
+        inode, device}}`` or ``None`` when the set can't be safely enumerated
+        (unsafe/missing tracks, a non-file), so those never qualify for reuse.
         """
         try:
             snapshot = build_delete_snapshot(source_path)
         except Exception:
             return None
-        out: Dict[str, Dict[str, int]] = {}
-        for path, fp in (snapshot.get("fingerprints") or {}).items():
-            out[path] = {"size": int(fp["size"]), "mtime_ns": int(fp["mtime_ns"])}
-        return out or None
+        return self._norm_fps(snapshot.get("fingerprints")) or None
 
     @staticmethod
     def _output_fingerprint(output_path: str) -> Optional[Dict[str, int]]:
-        """Stat fingerprint (size + mtime_ns) of an output file, or ``None``."""
+        """Stat fingerprint (size + mtime_ns + inode + device) of an output
+        file, or ``None``. inode/device catch a replaced file that happens to
+        preserve size+mtime (e.g. a copy-restore onto a fresh inode)."""
         try:
             st = os.stat(output_path, follow_symlinks=False)
         except OSError:
@@ -1596,6 +1616,8 @@ class JobManager:
             "mtime_ns": int(
                 getattr(st, "st_mtime_ns", int(st.st_mtime * 1_000_000_000))
             ),
+            "inode": int(getattr(st, "st_ino", 0) or 0),
+            "device": int(getattr(st, "st_dev", 0) or 0),
         }
 
     def _build_produced_meta(self, job: ConversionJob) -> Optional[Dict[str, object]]:
@@ -1603,17 +1625,30 @@ class JobManager:
         path: the mode + output-shaping settings and stat fingerprints of the
         complete source set and the output.
 
+        The source fingerprint is the **pre-conversion** delete snapshot
+        (captured when the job was planned, before the converter read the
+        source), re-validated to still describe the on-disk source here. If the
+        source changed between planning and this point — e.g. mutated while the
+        converter was running — the pre-conversion snapshot no longer matches and
+        no reusable metadata is recorded, so a later re-queue can't take the
+        no-op path against an output built from now-stale bytes.
+
         Returns ``None`` (record no meta → no fast path) for an archive-member
-        source or when the source set / output can't be fingerprinted. Computed
-        right after a successful verify, while the source still exists.
+        source, when there is no pre-conversion snapshot, when the source moved
+        since planning, or when the output can't be fingerprinted.
         """
         if "::" in job.file_path:
             # Archive members: the on-disk "source" is the whole archive and the
             # extracted member is transient, so a reuse can't be proven cheaply.
             return None
-        source_fp = self._source_fingerprint(job.file_path)
+        pre = self._delete_plans.get(job.id)
+        if not pre or not pre.get("fingerprints"):
+            return None
+        source_fp = self._norm_fps(pre.get("fingerprints"))
+        if not source_fp or self._source_fingerprint(job.file_path) != source_fp:
+            return None
         output_fp = self._output_fingerprint(job.output_path)
-        if not source_fp or not output_fp:
+        if not output_fp:
             return None
         return {
             "mode": job.mode.value,

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1561,6 +1561,74 @@ class JobManager:
                 pass
         return total_size if total_size > 0 else None
 
+    async def _output_already_verified(self, job: ConversionJob) -> bool:
+        """Whether a prior run already produced and verified this exact output.
+
+        Backs the job-start "recognize prior success" fast path (issue #184,
+        site 1): a re-queued job whose verified artifact is already on disk
+        completes as a no-op instead of re-spawning the converter. Kept
+        deliberately narrow so it can never deliver a surprising output:
+
+        * Only plain file conversions with default output shaping
+          (``compression is None``, ``split`` off) qualify — a request that
+          changes the output shape must re-run the converter.
+        * Directory-input and delete-on-verify jobs take the normal path (the
+          former has split-set outputs, the latter must run its guarded source
+          deletion), so this never short-circuits a pending delete.
+        * The verification store must hold a record for the output whose
+          recorded *source* is this job's source, and the on-disk source must be
+          no newer than the output (unchanged since it was verified). A record
+          without a source (e.g. a manual /info verify) or a mismatched source
+          never qualifies.
+        """
+        if (
+            job.delete_on_verify
+            or job.split
+            or job.compression is not None
+            or job.input_kind == InputKind.DIRECTORY
+            or not job.output_path
+        ):
+            return False
+        try:
+            record = await verification_store.get_record(job.output_path)
+        except Exception as exc:
+            # Never let a verification-store hiccup skip a conversion: on any
+            # lookup failure fall through to the normal path (re-convert).
+            logger.debug(
+                "Prior-success check skipped for %s: %s", job.output_path, exc,
+            )
+            return False
+        if not record or not record.get("source_path"):
+            return False
+        return await run_in_threadpool(
+            self._verified_output_matches_source, job, record["source_path"],
+        )
+
+    @staticmethod
+    def _verified_output_matches_source(
+        job: ConversionJob, recorded_source: str,
+    ) -> bool:
+        """Off-loop check: the verified output exists and its source is unchanged.
+
+        The recorded source must be this job's source (realpath match) and the
+        on-disk source must be no newer than the output, so the output still
+        reflects the current source bytes. Any stat error is treated as "no
+        match" so a missing/racing file falls through to the normal path.
+        """
+        try:
+            if recorded_source != os.path.realpath(job.file_path):
+                return False
+            if not os.path.isfile(job.output_path):
+                return False
+            source_disk = (
+                strip_archive_path(job.file_path)
+                if "::" in job.file_path
+                else job.file_path
+            )
+            return os.path.getmtime(job.output_path) >= os.path.getmtime(source_disk)
+        except OSError:
+            return False
+
     async def _run_job(self, job_id: str):
         try:
             await self._process_job(job_id)
@@ -1740,6 +1808,33 @@ class JobManager:
         )
 
         try:
+            # Fast path: a re-queued job whose verified artifact already exists
+            # completes as a no-op rather than re-spawning the converter (issue
+            # #184, site 1). Checked before extraction / _clear_existing_output
+            # so the existing verified output is neither re-extracted-from nor
+            # deleted. Honors a cancel requested before we got here.
+            if not cancel_event.is_set() and await self._output_already_verified(job):
+                self._cancelled.discard(job_id)
+                job.progress = 100
+                job.output_size = await run_in_threadpool(
+                    self._compute_output_size, job,
+                )
+                job.status = JobStatus.COMPLETED
+                job.completed_at = datetime.now(timezone.utc)
+                job.message = "Output already verified; skipped re-conversion."
+                await self._notify_subscribers(
+                    job_id,
+                    {
+                        "type": "complete",
+                        "job_id": job_id,
+                        "output_path": job.output_path,
+                        "output_size": job.output_size,
+                        "verified": True,
+                        "source_deleted": False,
+                    },
+                )
+                return
+
             input_path = job.file_path
             if "::" in job.file_path:
                 extract_start = time.monotonic()

--- a/app/services/verification_store.py
+++ b/app/services/verification_store.py
@@ -63,27 +63,42 @@ class VerificationStore:
 
     # ------------------------------------------------------------------
 
-    def _mark_sync(self, chd_path: str, source_path: str | None) -> None:
+    def _mark_sync(
+        self,
+        chd_path: str,
+        source_path: str | None,
+        produced_meta: dict | None = None,
+    ) -> None:
         normalized = self._normalize(chd_path)
         normalized_source = self._normalize(source_path) if source_path else None
         stmt = sqlite_insert(_db.Verification).values(
             chd_path=normalized,
             source_path=normalized_source,
             verified_at=_utcnow_iso(),
+            produced_meta=produced_meta,
         )
         stmt = stmt.on_conflict_do_update(
             index_elements=["chd_path"],
             set_={
                 "source_path": stmt.excluded.source_path,
                 "verified_at": stmt.excluded.verified_at,
+                "produced_meta": stmt.excluded.produced_meta,
             },
         )
         with self._session() as session:
             session.execute(stmt)
             session.commit()
 
-    async def mark_verified(self, chd_path: str, *, source_path: str | None = None) -> None:
-        await run_in_threadpool(self._mark_sync, chd_path, source_path)
+    async def mark_verified(
+        self,
+        chd_path: str,
+        *,
+        source_path: str | None = None,
+        produced_meta: dict | None = None,
+    ) -> None:
+        await run_in_threadpool(
+            self._mark_sync, chd_path, source_path, produced_meta,
+        )
 
     def _clear_sync(self, chd_path: str) -> None:
         normalized = self._normalize(chd_path)
@@ -144,6 +159,7 @@ class VerificationStore:
                 "chd_path": row.chd_path,
                 "source_path": row.source_path,
                 "verified_at": row.verified_at,
+                "produced_meta": row.produced_meta,
             }
 
     async def get_record(self, chd_path: str) -> dict[str, str | None] | None:

--- a/app/services/verification_store.py
+++ b/app/services/verification_store.py
@@ -118,9 +118,14 @@ class VerificationStore:
             old = session.get(_db.Verification, old_normalized)
             if old is None:
                 return
-            # Preserve source_path/verified_at across the rename.
+            # Preserve source_path/verified_at AND produced_meta across the
+            # rename. Dropping produced_meta would leave the renamed record
+            # verified but ineligible for the re-run fast path (a same-filesystem
+            # rename keeps the output's inode/size/mtime, so the recorded output
+            # fingerprint still matches at the new path).
             source_path = old.source_path
             verified_at = old.verified_at
+            produced_meta = old.produced_meta
             session.delete(old)
             session.flush()
             # Upsert under the new key.
@@ -128,11 +133,13 @@ class VerificationStore:
             if existing is not None:
                 existing.source_path = source_path
                 existing.verified_at = verified_at
+                existing.produced_meta = produced_meta
             else:
                 session.add(_db.Verification(
                     chd_path=new_normalized,
                     source_path=source_path,
                     verified_at=verified_at,
+                    produced_meta=produced_meta,
                 ))
             session.commit()
 

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -674,6 +674,42 @@ gone, or changed) it returns `None`, and the caller falls back to a file-level S
 is valid for any DAT that indexes the container bytes. New cache/tool code that needs
 freshness-gated metadata must call this rather than reintroducing the two-read pattern.
 
+### 3.3.6 Re-run fast path (`JobManager._output_already_verified`)
+
+`_process_job` recognizes a prior success before it re-spawns the converter: a
+re-queued job whose target artifact is already on disk **and recorded verified
+for this exact source** completes as a no-op instead of re-running the tool
+(issue #184, site 1). The check runs at the top of the conversion `try` block —
+before archive extraction and before `_clear_existing_output` — so the existing
+verified output is neither re-extracted-from nor deleted; on a hit the job jumps
+straight to `COMPLETED` (progress 100, size via the shared
+`_compute_output_size`, a `complete` event with `verified=True`,
+`source_deleted=False`).
+
+The guard is deliberately narrow so it can never deliver a surprising output —
+`_output_already_verified` returns `True` only when **all** hold:
+
+- The job is a plain file conversion with default output shaping:
+  `input_kind == FILE`, `compression is None`, `split` off. A request that
+  changes the output shape (explicit compression, split set) must re-run the
+  converter, and directory (folder→ISO) jobs — whose split-set output is
+  disk-probed — always take the normal path.
+- `delete_on_verify` is off. A delete-on-verify job must run its guarded source
+  deletion, so it never short-circuits here.
+- `verification_store.get_record(output)` returns a record whose `source_path`
+  is **this** job's source (realpath match). A record with no source (e.g. a
+  manual `/info` verify, which stores `source_path=None`) or a different source
+  never qualifies — only a prior delete-on-verify run records an output verified
+  *with* its source, e.g. one whose verify passed but whose delete was cancelled
+  or failed, leaving the source intact for a later re-submit.
+- The on-disk source is **no newer** than the verified output
+  (`getmtime(output) >= getmtime(source)`), so the output still reflects the
+  current source bytes; a source modified since verification falls through and
+  re-converts.
+
+Any stat error in the freshness check is treated as "no match", so a
+missing/racing file falls through to the normal path rather than mis-firing.
+
 ### 3.4 `registry.py`
 
 ```python

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -677,38 +677,47 @@ freshness-gated metadata must call this rather than reintroducing the two-read p
 ### 3.3.6 Re-run fast path (`JobManager._output_already_verified`)
 
 `_process_job` recognizes a prior success before it re-spawns the converter: a
-re-queued job whose target artifact is already on disk **and recorded verified
-for this exact source** completes as a no-op instead of re-running the tool
-(issue #184, site 1). The check runs at the top of the conversion `try` block —
-before archive extraction and before `_clear_existing_output` — so the existing
-verified output is neither re-extracted-from nor deleted; on a hit the job jumps
-straight to `COMPLETED` (progress 100, size via the shared
+re-queued job whose target artifact is already on disk **and provably the exact
+result of the current request** completes as a no-op instead of re-running the
+tool (issue #184, site 1). The check runs at the top of the conversion `try`
+block — before archive extraction and before `_clear_existing_output` — so the
+existing verified output is neither re-extracted-from nor deleted; on a hit the
+job jumps straight to `COMPLETED` (progress 100, size via the shared
 `_compute_output_size`, a `complete` event with `verified=True`,
-`source_deleted=False`).
+`source_deleted=False`). A cancel is honored on both sides of the awaited
+lookups: checked before, and re-checked after `_output_already_verified` returns
+(a cancel that lands mid-lookup raises `ConversionCancelled` rather than
+completing the no-op).
 
-The guard is deliberately narrow so it can never deliver a surprising output —
-`_output_already_verified` returns `True` only when **all** hold:
+**The evidence is a `produced_meta` snapshot, not a bare "verified" flag.** A
+plain verification record proves only that *some* file at that path passed
+integrity verification at *some* time — not that the current file is that
+artifact, nor that it matches the current request's output-shaping settings, nor
+that a multi-file source (a `.cue`/`.gdi` and its tracks) is unchanged. So the
+fast path trusts **only** records carrying a `produced_meta` blob, written by a
+prior **delete-on-verify** conversion right after its verify passed (the
+`verifications.produced_meta` JSON column, Alembic migration `0003`). A manual
+`/info` verify records **no** meta and never qualifies. `_build_produced_meta`
+captures, off the event loop:
 
-- The job is a plain file conversion with default output shaping:
-  `input_kind == FILE`, `compression is None`, `split` off. A request that
-  changes the output shape (explicit compression, split set) must re-run the
-  converter, and directory (folder→ISO) jobs — whose split-set output is
-  disk-probed — always take the normal path.
-- `delete_on_verify` is off. A delete-on-verify job must run its guarded source
-  deletion, so it never short-circuits here.
-- `verification_store.get_record(output)` returns a record whose `source_path`
-  is **this** job's source (realpath match). A record with no source (e.g. a
-  manual `/info` verify, which stores `source_path=None`) or a different source
-  never qualifies — only a prior delete-on-verify run records an output verified
-  *with* its source, e.g. one whose verify passed but whose delete was cancelled
-  or failed, leaving the source intact for a later re-submit.
-- The on-disk source is **no newer** than the verified output
-  (`getmtime(output) >= getmtime(source)`), so the output still reflects the
-  current source bytes; a source modified since verification falls through and
-  re-converts.
+- `mode`, `compression`, `split` — the producing conversion's output shape.
+- `source` — a stat fingerprint (`{realpath: {size, mtime_ns}}`) of the
+  **complete** source set via `build_delete_snapshot`, so a `.cue`/`.gdi`'s
+  referenced track files are fingerprinted alongside the descriptor.
+- `output` — a `{size, mtime_ns}` fingerprint of the produced artifact (taken
+  after the disc-ID embed, so it reflects the final bytes).
 
-Any stat error in the freshness check is treated as "no match", so a
-missing/racing file falls through to the normal path rather than mis-firing.
+`_produced_meta_matches` (off the event loop) then admits the no-op only when
+**all** hold: `mode`/`compression`/`split` equal the current request's, the
+current output fingerprint equals the recorded one (so a replaced/corrupted file
+with a fresh mtime can't pass), and the current complete-source-set fingerprint
+equals the recorded one (so a changed track — not just the descriptor — forces a
+re-convert). `_output_already_verified` additionally excludes directory
+(folder→ISO) jobs (split-set outputs) and `delete_on_verify` *requests* (they
+must run their guarded source deletion), and treats any store hiccup, missing
+record, absent `produced_meta`, or un-fingerprintable source (archive members,
+unsafe/missing tracks) as "no match" — always falling through to a full
+re-convert rather than risk a surprising output.
 
 ### 3.4 `registry.py`
 

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -701,23 +701,42 @@ prior **delete-on-verify** conversion right after its verify passed (the
 captures, off the event loop:
 
 - `mode`, `compression`, `split` — the producing conversion's output shape.
-- `source` — a stat fingerprint (`{realpath: {size, mtime_ns}}`) of the
-  **complete** source set via `build_delete_snapshot`, so a `.cue`/`.gdi`'s
-  referenced track files are fingerprinted alongside the descriptor.
-- `output` — a `{size, mtime_ns}` fingerprint of the produced artifact (taken
-  after the disc-ID embed, so it reflects the final bytes).
+- `source` — a stat fingerprint (`{realpath: {size, mtime_ns, inode, device}}`)
+  of the **complete** source set. It is the job's **pre-conversion** delete
+  snapshot (captured at planning, before the converter read the source),
+  re-validated against the on-disk source at record time: if the source changed
+  between planning and verify — e.g. mutated while the converter was running —
+  the snapshot no longer matches and **no** meta is recorded, so a later
+  re-queue can't no-op against an output built from now-stale bytes.
+- `output` — a `{size, mtime_ns, inode, device}` fingerprint of the produced
+  artifact (taken after the disc-ID embed, so it reflects the final bytes).
+
+The `inode`/`device` fields are the same four stat fields the delete-safety
+snapshot trusts to authorize an *irreversible* delete (`build_delete_snapshot`),
+so a reuse — a strictly less destructive decision — is held to no weaker a bar:
+a copy-restore lands on a new inode, a moved mount on a new device, and either
+forces a re-convert.
 
 `_produced_meta_matches` (off the event loop) then admits the no-op only when
 **all** hold: `mode`/`compression`/`split` equal the current request's, the
 current output fingerprint equals the recorded one (so a replaced/corrupted file
-with a fresh mtime can't pass), and the current complete-source-set fingerprint
-equals the recorded one (so a changed track — not just the descriptor — forces a
-re-convert). `_output_already_verified` additionally excludes directory
-(folder→ISO) jobs (split-set outputs) and `delete_on_verify` *requests* (they
-must run their guarded source deletion), and treats any store hiccup, missing
-record, absent `produced_meta`, or un-fingerprintable source (archive members,
-unsafe/missing tracks) as "no match" — always falling through to a full
-re-convert rather than risk a surprising output.
+can't pass), and the current complete-source-set fingerprint equals the recorded
+one (so a changed track — not just the descriptor — forces a re-convert).
+`_output_already_verified` additionally excludes directory (folder→ISO) jobs
+(split-set outputs) and `delete_on_verify` *requests* (they must run their
+guarded source deletion), and treats any store hiccup, missing record, absent
+`produced_meta`, or un-fingerprintable source (archive members, unsafe/missing
+tracks) as "no match" — always falling through to a full re-convert rather than
+risk a surprising output.
+
+**Known limitation.** `compression` is stored as the request declared it, so
+`None` means "the tool's default." A tool that resolves its default from mutable
+settings (e.g. nsz's `NSZ_COMPRESSION_LEVEL`) could, after an operator changes
+that setting *and* a prior delete-on-verify run was cancelled after verify,
+deliver the earlier-default artifact for a `None`-compression re-queue. That is a
+compression-*level* difference on an otherwise-correct, verified artifact of the
+exact source — not a content mismatch — and is accepted rather than have every
+tool persist its resolved defaults.
 
 ### 3.4 `registry.py`
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -81,15 +81,20 @@ and #179, part of the #177 tech-debt epic).
   no longer briefly under-counts the queue.
 - **Re-queuing a job whose verified output already exists is now a no-op (issue
   #184, site 1).** When a job starts and its target artifact is already on disk and
-  recorded verified for this exact source, the pipeline recognizes the prior success
-  and completes the job without re-spawning the converter — the existing verified
-  file is neither re-extracted-from nor cleared. The fast path is deliberately narrow
-  so it can never deliver a surprising output: it applies only to plain file
-  conversions with default output shaping (no explicit compression, no split), the
-  verification record's source must match the job's source, and the on-disk source
-  must be no newer than the verified output (unchanged since it was verified).
-  Directory (folder→ISO) and delete-on-verify jobs always take the normal path — the
-  latter so its guarded source deletion still runs.
+  provably the exact result of the current request, the pipeline recognizes the prior
+  success and completes the job without re-spawning the converter — the existing
+  verified file is neither re-extracted-from nor cleared. To make this safe rather
+  than a source of surprising output, a delete-on-verify conversion now records a
+  `produced_meta` snapshot alongside the verification (new nullable
+  `verifications.produced_meta` JSON column, migration `0003`): the producing
+  mode/compression/split plus stat fingerprints of the **complete** source set (a
+  `.cue`/`.gdi` and its track files, not just the descriptor) and of the output. The
+  fast path fires only when a record carries that snapshot **and** the current
+  request's shaping settings, source-set fingerprint, and output fingerprint all
+  match it — so a different compression, a changed `.bin` track, or a replaced/
+  corrupted output all force a full re-convert. A plain `/info` verify records no
+  snapshot and never qualifies; directory (folder→ISO) and delete-on-verify jobs
+  always take the normal path (the latter so its guarded source deletion still runs).
 - **All conversion tools now share one subprocess loop.** `z3ds`, `maxcso` and `nsz`
   previously hand-rolled their own ~150-line spawn / stall-timeout / cancel / progress
   loop; they now delegate to the shared `SubprocessRunner` like `chdman`/`dolphin`/

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -79,6 +79,17 @@ and #179, part of the #177 tech-debt epic).
   An optimistic placeholder is now cleared only when its real job first arrives, not
   on every later progress update, so submitting the same file in the same mode twice
   no longer briefly under-counts the queue.
+- **Re-queuing a job whose verified output already exists is now a no-op (issue
+  #184, site 1).** When a job starts and its target artifact is already on disk and
+  recorded verified for this exact source, the pipeline recognizes the prior success
+  and completes the job without re-spawning the converter — the existing verified
+  file is neither re-extracted-from nor cleared. The fast path is deliberately narrow
+  so it can never deliver a surprising output: it applies only to plain file
+  conversions with default output shaping (no explicit compression, no split), the
+  verification record's source must match the job's source, and the on-disk source
+  must be no newer than the verified output (unchanged since it was verified).
+  Directory (folder→ISO) and delete-on-verify jobs always take the normal path — the
+  latter so its guarded source deletion still runs.
 - **All conversion tools now share one subprocess loop.** `z3ds`, `maxcso` and `nsz`
   previously hand-rolled their own ~150-line spawn / stall-timeout / cancel / progress
   loop; they now delegate to the shared `SubprocessRunner` like `chdman`/`dolphin`/

--- a/migrations/versions/0003_add_verification_produced_meta.py
+++ b/migrations/versions/0003_add_verification_produced_meta.py
@@ -1,0 +1,44 @@
+"""add_verification_produced_meta
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-07-23 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0003'
+down_revision: Union[str, Sequence[str], None] = '0002'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Tolerate a column already present. apply_migrations() documents the
+    # create_all-then-stamp path as supported: a DB built from the current ORM
+    # metadata (which already includes Verification.produced_meta) gets stamped
+    # at baseline 0001 and then migrations run forward, so an unconditional
+    # ADD COLUMN would raise "duplicate column name" there. Only add it when
+    # missing. Nullable with no backfill: existing rows (and manual /info
+    # verifies) keep produced_meta NULL, which the re-run fast path treats as
+    # "not enough evidence" and skips.
+    bind = op.get_bind()
+    columns = {c["name"] for c in sa.inspect(bind).get_columns("verifications")}
+    if "produced_meta" in columns:
+        return
+    op.add_column(
+        "verifications",
+        sa.Column("produced_meta", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    # Downgrade migrations are not supported in this project, forward-only.
+    raise NotImplementedError("downgrade not supported")

--- a/tests/test_mode_parity_fixes.py
+++ b/tests/test_mode_parity_fixes.py
@@ -5,7 +5,7 @@ import os
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 from fastapi import HTTPException
@@ -572,10 +572,15 @@ async def test_z3ds_delete_on_verify_marks_output_verified(tmp_path: Path, monke
     await manager._process_job(job.id)
 
     assert job.status == JobStatus.COMPLETED
+    # Delete-on-verify also records a produced_meta snapshot (mode + shaping +
+    # source/output fingerprints) so a later re-queue can no-op safely (#184).
     mark_verified.assert_called_once_with(
         str(output_path),
         source_path=str(source_path),
+        produced_meta=ANY,
     )
+    produced = mark_verified.call_args.kwargs["produced_meta"]
+    assert produced is not None and produced["mode"] == "z3ds_compress"
     assert not source_path.exists()
     assert output_path.exists()
     # A non-verify-class source (.3ds) leaves the tool-wide verification_store

--- a/tests/test_reconvert_noop_184.py
+++ b/tests/test_reconvert_noop_184.py
@@ -1,0 +1,222 @@
+"""Job-start "recognize prior success" fast path (issue #184, site 1).
+
+A re-queued job whose verified artifact is already on disk must complete as a
+no-op instead of re-spawning the converter. The verification store is
+monkeypatched (no DB needed) and the tool's ``convert`` is stubbed with a
+recorder that fails the test if it is ever invoked on the fast path.
+
+The guard is deliberately narrow: only plain file conversions with default
+output shaping (``compression is None``, ``split`` off) and a verification
+record whose *source* matches the job and whose output is no older than that
+source qualify. The negative tests pin each of those escape hatches so a
+future change can't silently start skipping conversions it shouldn't.
+
+Isolation: the pipeline coordinates through the process-global
+``concurrency_manager`` / ``lock_manager`` FIFO + file locks. A fresh
+``JobManager`` plus fresh, tmp-dir-bound coordinators are bound in place so a
+ticket leaked by another suite test can't wedge these (they run in-process).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import app.services.job_manager as jm_mod
+from app.models import ConversionMode, JobStatus
+from app.services.concurrency_manager import ConcurrencyManager
+from app.services.job_manager import JobManager
+from app.services.lock_manager import LockManager
+
+
+class _StubVerStore:
+    """Minimal stand-in for the verification store.
+
+    ``get_record`` returns the configured record for the output path so the
+    fast path can consult "was this output verified, and from what source".
+    """
+
+    def __init__(self, record: dict | None) -> None:
+        self._record = record
+
+    async def get_record(self, chd_path: str) -> dict | None:
+        return self._record
+
+    async def clear(self, chd_path: str) -> None:
+        # Exercised by _clear_existing_output on the re-convert (non-fast) path.
+        return None
+
+    async def mark_verified(self, chd_path: str, *, source_path: str | None = None):
+        return None
+
+
+@pytest.fixture(name="noop_env")
+def _noop_env(tmp_path: Path, monkeypatch):
+    """Fresh, isolated JobManager + coordinators; record any convert call."""
+    monkeypatch.setattr(jm_mod.settings, "max_queue_depth", 0)
+    # Bind fresh, tmp-dir-scoped coordinators so the shared cross-process FIFO
+    # and output locks from other suite tests can't interfere.
+    lock_dir = tmp_path / "locks"
+    monkeypatch.setattr(jm_mod.settings, "concurrency_lock_dir", str(lock_dir))
+    monkeypatch.setattr(
+        jm_mod, "concurrency_manager", ConcurrencyManager(1, str(lock_dir / "conc")),
+    )
+    monkeypatch.setattr(jm_mod, "lock_manager", LockManager())
+
+    calls: list[dict] = []
+
+    async def recording_convert(input_path, output_path, mode, *, compression=None,
+                                split=False, cancel_event=None):
+        calls.append({"input": input_path, "output": output_path})
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        Path(output_path).write_bytes(b"RECONVERTED")
+        yield {"progress": 100, "message": "done"}
+
+    async def noop_post_convert(input_path, output_path, mode):
+        return None
+
+    tool = jm_mod.registry.get("chdman")
+    monkeypatch.setattr(tool, "convert", recording_convert)
+    monkeypatch.setattr(tool, "post_convert", noop_post_convert)
+
+    return {
+        "tmp_path": tmp_path,
+        "calls": calls,
+        "monkeypatch": monkeypatch,
+        "mgr": JobManager(max_concurrent=1),
+    }
+
+
+def _set_record(monkeypatch, record: dict | None) -> None:
+    monkeypatch.setattr(jm_mod, "verification_store", _StubVerStore(record))
+
+
+def _seed_verified_output(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a source + a pre-existing verified output (output not older)."""
+    src = tmp_path / "Game.cue"
+    src.write_bytes(b"source")
+    out = tmp_path / "Game.chd"
+    out.write_bytes(b"VERIFIED-ARTIFACT")
+    # Output not older than the source (source unchanged since it was verified)
+    # — the freshness half of the guard.
+    src_mtime = src.stat().st_mtime
+    os.utime(out, (src_mtime, src_mtime))
+    return src, out
+
+
+@pytest.mark.asyncio
+async def test_reconvert_completes_as_noop_when_verified_output_exists(noop_env):
+    tmp_path: Path = noop_env["tmp_path"]
+    mgr: JobManager = noop_env["mgr"]
+    src, out = _seed_verified_output(tmp_path)
+    original_bytes = out.read_bytes()
+
+    _set_record(noop_env["monkeypatch"], {
+        "source_path": os.path.realpath(str(src)),
+        "verified_at": "2026-01-01T00:00:00Z",
+    })
+
+    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
+    await mgr._process_job(job.id)
+
+    # The converter was never re-spawned and the verified artifact is untouched.
+    assert noop_env["calls"] == []
+    assert out.read_bytes() == original_bytes
+    assert job.status.value == JobStatus.COMPLETED.value, job.error_message
+    assert job.progress == 100
+    assert job.output_size == len(original_bytes)
+
+
+@pytest.mark.asyncio
+async def test_reconvert_runs_when_source_is_newer_than_output(noop_env):
+    tmp_path: Path = noop_env["tmp_path"]
+    mgr: JobManager = noop_env["mgr"]
+    src, out = _seed_verified_output(tmp_path)
+    # Source modified after the output was verified: the verified output is
+    # stale, so the converter must run.
+    newer = out.stat().st_mtime + 10
+    os.utime(src, (newer, newer))
+
+    _set_record(noop_env["monkeypatch"], {
+        "source_path": os.path.realpath(str(src)),
+        "verified_at": "2026-01-01T00:00:00Z",
+    })
+
+    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
+    await mgr._process_job(job.id)
+
+    assert len(noop_env["calls"]) == 1
+    assert job.status.value == JobStatus.COMPLETED.value, job.error_message
+
+
+@pytest.mark.asyncio
+async def test_reconvert_runs_when_record_source_mismatches(noop_env):
+    tmp_path: Path = noop_env["tmp_path"]
+    mgr: JobManager = noop_env["mgr"]
+    src, _out = _seed_verified_output(tmp_path)
+
+    # The verified output was produced from a *different* source, so it is not
+    # this job's prior success — re-convert.
+    _set_record(noop_env["monkeypatch"], {
+        "source_path": str(tmp_path / "OtherSource.cue"),
+        "verified_at": "2026-01-01T00:00:00Z",
+    })
+
+    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
+    await mgr._process_job(job.id)
+
+    assert len(noop_env["calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconvert_runs_when_no_verification_record(noop_env):
+    tmp_path: Path = noop_env["tmp_path"]
+    mgr: JobManager = noop_env["mgr"]
+    src, _out = _seed_verified_output(tmp_path)
+
+    _set_record(noop_env["monkeypatch"], None)
+
+    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
+    await mgr._process_job(job.id)
+
+    assert len(noop_env["calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconvert_runs_when_record_has_no_source(noop_env):
+    tmp_path: Path = noop_env["tmp_path"]
+    mgr: JobManager = noop_env["mgr"]
+    src, _out = _seed_verified_output(tmp_path)
+
+    # A record from a manual /info verify carries no source_path, so it can't
+    # prove this job's prior success.
+    _set_record(noop_env["monkeypatch"], {
+        "source_path": None, "verified_at": "2026-01-01T00:00:00Z",
+    })
+
+    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
+    await mgr._process_job(job.id)
+
+    assert len(noop_env["calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconvert_runs_when_compression_requested(noop_env):
+    tmp_path: Path = noop_env["tmp_path"]
+    mgr: JobManager = noop_env["mgr"]
+    src, _out = _seed_verified_output(tmp_path)
+
+    # A non-default compression could change the output bytes, so the fast path
+    # must step aside and let the converter run.
+    _set_record(noop_env["monkeypatch"], {
+        "source_path": os.path.realpath(str(src)),
+        "verified_at": "2026-01-01T00:00:00Z",
+    })
+
+    job = await mgr.create_job(
+        str(src), ConversionMode.CREATECD, allow_overwrite=True, compression="cd_lzma",
+    )
+    await mgr._process_job(job.id)
+
+    assert len(noop_env["calls"]) == 1

--- a/tests/test_reconvert_noop_184.py
+++ b/tests/test_reconvert_noop_184.py
@@ -96,16 +96,23 @@ def _seed_files(tmp_path: Path) -> tuple[Path, Path, Path]:
 
 
 async def _job_with_meta(noop_env, **create_kwargs):
-    """Create a CREATECD job for the seeded .cue and the produced_meta that
-    matches the current on-disk state."""
+    """Create a CREATECD job for the seeded .cue and the produced_meta a prior
+    delete-on-verify run would have recorded for the current on-disk state
+    (built via the same fingerprint helpers the fast path compares with)."""
     tmp_path: Path = noop_env["tmp_path"]
     src, track, out = _seed_files(tmp_path)
     mgr: JobManager = noop_env["mgr"]
     job = await mgr.create_job(
         str(src), ConversionMode.CREATECD, allow_overwrite=True, **create_kwargs,
     )
-    meta = mgr._build_produced_meta(job)
-    assert meta is not None  # sanity: source set + output are fingerprintable
+    meta = {
+        "mode": "createcd",
+        "compression": create_kwargs.get("compression"),
+        "split": bool(create_kwargs.get("split", False)),
+        "source": mgr._source_fingerprint(str(src)),
+        "output": mgr._output_fingerprint(str(out)),
+    }
+    assert meta["source"] and meta["output"]  # fingerprintable
     return mgr, job, src, track, out, meta
 
 
@@ -210,6 +217,55 @@ async def test_reconvert_runs_when_no_record(noop_env):
 
     await mgr._process_job(job.id)
     assert len(noop_env["calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_build_produced_meta_uses_pre_conversion_snapshot(noop_env):
+    # With a stable source and a recorded pre-conversion snapshot, the metadata
+    # is built and pins the source/output fingerprints.
+    from app.utils.delete_plan import build_delete_snapshot
+
+    tmp_path: Path = noop_env["tmp_path"]
+    src, _track, _out = _seed_files(tmp_path)
+    mgr: JobManager = noop_env["mgr"]
+    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
+    mgr._delete_plans[job.id] = build_delete_snapshot(str(src))
+
+    meta = mgr._build_produced_meta(job)
+    assert meta is not None
+    assert meta["mode"] == "createcd"
+    assert meta["source"] == mgr._source_fingerprint(str(src))
+
+
+@pytest.mark.asyncio
+async def test_build_produced_meta_none_without_snapshot(noop_env):
+    # No pre-conversion snapshot → no reusable metadata (can't prove the source
+    # was stable through conversion).
+    tmp_path: Path = noop_env["tmp_path"]
+    src, _track, _out = _seed_files(tmp_path)
+    mgr: JobManager = noop_env["mgr"]
+    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
+    assert mgr._build_produced_meta(job) is None
+
+
+@pytest.mark.asyncio
+async def test_build_produced_meta_none_when_source_moved_since_snapshot(noop_env):
+    # Source mutated after the pre-conversion snapshot (e.g. changed while the
+    # converter ran): the snapshot no longer describes the source, so no
+    # metadata is recorded and no future no-op can misfire (P2).
+    from app.utils.delete_plan import build_delete_snapshot
+
+    tmp_path: Path = noop_env["tmp_path"]
+    src, track, _out = _seed_files(tmp_path)
+    mgr: JobManager = noop_env["mgr"]
+    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
+    mgr._delete_plans[job.id] = build_delete_snapshot(str(src))
+    # Change a track after the snapshot was taken.
+    track.write_bytes(b"mutated-mid-conversion")
+    later = os.stat(track).st_mtime + 50
+    os.utime(track, (later, later))
+
+    assert mgr._build_produced_meta(job) is None
 
 
 def test_produced_meta_round_trips_through_store(tmp_path):

--- a/tests/test_reconvert_noop_184.py
+++ b/tests/test_reconvert_noop_184.py
@@ -1,23 +1,20 @@
 """Job-start "recognize prior success" fast path (issue #184, site 1).
 
-A re-queued job whose verified artifact is already on disk must complete as a
-no-op instead of re-spawning the converter. The verification store is
-monkeypatched (no DB needed) and the tool's ``convert`` is stubbed with a
-recorder that fails the test if it is ever invoked on the fast path.
+A re-queued job whose verified artifact is already on disk completes as a no-op
+instead of re-spawning the converter — but only when a ``produced_meta``
+snapshot (written by the prior delete-on-verify conversion) proves the on-disk
+output is the *exact* result of the current request. The tests below pin every
+guard: matching mode/compression/split, an unchanged complete source set
+(including a ``.cue``'s ``.bin`` track), and an unchanged output.
 
-The guard is deliberately narrow: only plain file conversions with default
-output shaping (``compression is None``, ``split`` off) and a verification
-record whose *source* matches the job and whose output is no older than that
-source qualify. The negative tests pin each of those escape hatches so a
-future change can't silently start skipping conversions it shouldn't.
-
-Isolation: the pipeline coordinates through the process-global
-``concurrency_manager`` / ``lock_manager`` FIFO + file locks. A fresh
-``JobManager`` plus fresh, tmp-dir-bound coordinators are bound in place so a
+The tool's ``convert`` is stubbed with a recorder that fails the test if it is
+ever invoked on the fast path. Isolation: a fresh ``JobManager`` plus fresh,
+tmp-dir-bound ``concurrency_manager`` / ``lock_manager`` are bound in place so a
 ticket leaked by another suite test can't wedge these (they run in-process).
 """
 from __future__ import annotations
 
+import copy
 import os
 from pathlib import Path
 
@@ -28,14 +25,11 @@ from app.models import ConversionMode, JobStatus
 from app.services.concurrency_manager import ConcurrencyManager
 from app.services.job_manager import JobManager
 from app.services.lock_manager import LockManager
+from app.services.verification_store import VerificationStore
 
 
 class _StubVerStore:
-    """Minimal stand-in for the verification store.
-
-    ``get_record`` returns the configured record for the output path so the
-    fast path can consult "was this output verified, and from what source".
-    """
+    """Stand-in for the verification store returning one fixed record."""
 
     def __init__(self, record: dict | None) -> None:
         self._record = record
@@ -47,7 +41,7 @@ class _StubVerStore:
         # Exercised by _clear_existing_output on the re-convert (non-fast) path.
         return None
 
-    async def mark_verified(self, chd_path: str, *, source_path: str | None = None):
+    async def mark_verified(self, chd_path: str, **kwargs):
         return None
 
 
@@ -55,8 +49,6 @@ class _StubVerStore:
 def _noop_env(tmp_path: Path, monkeypatch):
     """Fresh, isolated JobManager + coordinators; record any convert call."""
     monkeypatch.setattr(jm_mod.settings, "max_queue_depth", 0)
-    # Bind fresh, tmp-dir-scoped coordinators so the shared cross-process FIFO
-    # and output locks from other suite tests can't interfere.
     lock_dir = tmp_path / "locks"
     monkeypatch.setattr(jm_mod.settings, "concurrency_lock_dir", str(lock_dir))
     monkeypatch.setattr(
@@ -92,131 +84,156 @@ def _set_record(monkeypatch, record: dict | None) -> None:
     monkeypatch.setattr(jm_mod, "verification_store", _StubVerStore(record))
 
 
-def _seed_verified_output(tmp_path: Path) -> tuple[Path, Path]:
-    """Create a source + a pre-existing verified output (output not older)."""
+def _seed_files(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """A .cue descriptor + its .bin track + a pre-existing verified output."""
     src = tmp_path / "Game.cue"
-    src.write_bytes(b"source")
+    src.write_text('FILE "Game.bin" BINARY\n', encoding="utf-8")
+    track = tmp_path / "Game.bin"
+    track.write_bytes(b"track-bytes")
     out = tmp_path / "Game.chd"
     out.write_bytes(b"VERIFIED-ARTIFACT")
-    # Output not older than the source (source unchanged since it was verified)
-    # — the freshness half of the guard.
-    src_mtime = src.stat().st_mtime
-    os.utime(out, (src_mtime, src_mtime))
-    return src, out
+    return src, track, out
+
+
+async def _job_with_meta(noop_env, **create_kwargs):
+    """Create a CREATECD job for the seeded .cue and the produced_meta that
+    matches the current on-disk state."""
+    tmp_path: Path = noop_env["tmp_path"]
+    src, track, out = _seed_files(tmp_path)
+    mgr: JobManager = noop_env["mgr"]
+    job = await mgr.create_job(
+        str(src), ConversionMode.CREATECD, allow_overwrite=True, **create_kwargs,
+    )
+    meta = mgr._build_produced_meta(job)
+    assert meta is not None  # sanity: source set + output are fingerprintable
+    return mgr, job, src, track, out, meta
+
+
+def _record(meta):
+    return {
+        "source_path": "irrelevant-superseded-by-produced_meta",
+        "verified_at": "2026-01-01T00:00:00Z",
+        "produced_meta": meta,
+    }
 
 
 @pytest.mark.asyncio
-async def test_reconvert_completes_as_noop_when_verified_output_exists(noop_env):
-    tmp_path: Path = noop_env["tmp_path"]
-    mgr: JobManager = noop_env["mgr"]
-    src, out = _seed_verified_output(tmp_path)
-    original_bytes = out.read_bytes()
+async def test_reconvert_completes_as_noop_when_meta_matches(noop_env):
+    mgr, job, _src, _track, out, meta = await _job_with_meta(noop_env)
+    original = out.read_bytes()
+    _set_record(noop_env["monkeypatch"], _record(meta))
 
-    _set_record(noop_env["monkeypatch"], {
-        "source_path": os.path.realpath(str(src)),
-        "verified_at": "2026-01-01T00:00:00Z",
-    })
-
-    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
     await mgr._process_job(job.id)
 
-    # The converter was never re-spawned and the verified artifact is untouched.
-    assert noop_env["calls"] == []
-    assert out.read_bytes() == original_bytes
+    assert noop_env["calls"] == []          # converter never re-spawned
+    assert out.read_bytes() == original     # verified artifact untouched
     assert job.status.value == JobStatus.COMPLETED.value, job.error_message
     assert job.progress == 100
-    assert job.output_size == len(original_bytes)
+    assert job.output_size == len(original)
 
 
 @pytest.mark.asyncio
-async def test_reconvert_runs_when_source_is_newer_than_output(noop_env):
-    tmp_path: Path = noop_env["tmp_path"]
-    mgr: JobManager = noop_env["mgr"]
-    src, out = _seed_verified_output(tmp_path)
-    # Source modified after the output was verified: the verified output is
-    # stale, so the converter must run.
-    newer = out.stat().st_mtime + 10
-    os.utime(src, (newer, newer))
+async def test_reconvert_runs_when_compression_differs(noop_env):
+    # Prior artifact was produced with explicit compression; this request uses
+    # the default. Same source, but a different output shape → must re-convert
+    # (P1: avoid reusing output without matching prior conversion settings).
+    mgr, job, _src, _track, _out, meta = await _job_with_meta(noop_env)
+    tampered = copy.deepcopy(meta)
+    tampered["compression"] = "cd_lzma"
+    _set_record(noop_env["monkeypatch"], _record(tampered))
 
-    _set_record(noop_env["monkeypatch"], {
-        "source_path": os.path.realpath(str(src)),
-        "verified_at": "2026-01-01T00:00:00Z",
-    })
-
-    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
     await mgr._process_job(job.id)
-
-    assert len(noop_env["calls"]) == 1
-    assert job.status.value == JobStatus.COMPLETED.value, job.error_message
-
-
-@pytest.mark.asyncio
-async def test_reconvert_runs_when_record_source_mismatches(noop_env):
-    tmp_path: Path = noop_env["tmp_path"]
-    mgr: JobManager = noop_env["mgr"]
-    src, _out = _seed_verified_output(tmp_path)
-
-    # The verified output was produced from a *different* source, so it is not
-    # this job's prior success — re-convert.
-    _set_record(noop_env["monkeypatch"], {
-        "source_path": str(tmp_path / "OtherSource.cue"),
-        "verified_at": "2026-01-01T00:00:00Z",
-    })
-
-    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
-    await mgr._process_job(job.id)
-
     assert len(noop_env["calls"]) == 1
 
 
 @pytest.mark.asyncio
-async def test_reconvert_runs_when_no_verification_record(noop_env):
-    tmp_path: Path = noop_env["tmp_path"]
-    mgr: JobManager = noop_env["mgr"]
-    src, _out = _seed_verified_output(tmp_path)
+async def test_reconvert_runs_when_mode_differs(noop_env):
+    mgr, job, _src, _track, _out, meta = await _job_with_meta(noop_env)
+    tampered = copy.deepcopy(meta)
+    tampered["mode"] = "createdvd"
+    _set_record(noop_env["monkeypatch"], _record(tampered))
 
+    await mgr._process_job(job.id)
+    assert len(noop_env["calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconvert_runs_when_track_file_changed(noop_env):
+    # The .cue descriptor is untouched but its .bin track is replaced. A
+    # descriptor-only mtime check would miss this; the full source fingerprint
+    # catches it (P1: include CUE/GDI track files in the freshness check).
+    mgr, job, _src, track, _out, meta = await _job_with_meta(noop_env)
+    _set_record(noop_env["monkeypatch"], _record(meta))
+    track.write_bytes(b"different-track-bytes-entirely")
+    later = os.stat(track).st_mtime + 50
+    os.utime(track, (later, later))
+
+    await mgr._process_job(job.id)
+    assert len(noop_env["calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconvert_runs_when_output_replaced(noop_env):
+    # The output is replaced after verification (e.g. corruption/tamper) while
+    # the source is unchanged. The output fingerprint no longer matches, so the
+    # job must not report the replacement as verified (P1: revalidate the
+    # artifact before reporting the no-op as verified).
+    mgr, job, _src, _track, out, meta = await _job_with_meta(noop_env)
+    _set_record(noop_env["monkeypatch"], _record(meta))
+    out.write_bytes(b"REPLACED-WITH-SOMETHING-ELSE")
+    later = os.stat(out).st_mtime + 50
+    os.utime(out, (later, later))
+
+    await mgr._process_job(job.id)
+    assert len(noop_env["calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconvert_runs_when_no_produced_meta(noop_env):
+    # A record without produced_meta (e.g. a manual /info verify) can't prove
+    # prior success → re-convert.
+    mgr, job, _src, _track, _out, _meta = await _job_with_meta(noop_env)
+    _set_record(noop_env["monkeypatch"], {
+        "source_path": os.path.realpath(str(_src)),
+        "verified_at": "2026-01-01T00:00:00Z",
+        "produced_meta": None,
+    })
+
+    await mgr._process_job(job.id)
+    assert len(noop_env["calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconvert_runs_when_no_record(noop_env):
+    mgr, job, *_ = await _job_with_meta(noop_env)
     _set_record(noop_env["monkeypatch"], None)
 
-    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
     await mgr._process_job(job.id)
-
     assert len(noop_env["calls"]) == 1
 
 
-@pytest.mark.asyncio
-async def test_reconvert_runs_when_record_has_no_source(noop_env):
-    tmp_path: Path = noop_env["tmp_path"]
-    mgr: JobManager = noop_env["mgr"]
-    src, _out = _seed_verified_output(tmp_path)
+def test_produced_meta_round_trips_through_store(tmp_path):
+    """The store persists and returns produced_meta unchanged (JSON column)."""
+    store = VerificationStore(store_path=str(tmp_path / "v.db"))
+    out = tmp_path / "Game.chd"
+    out.write_bytes(b"x")
+    meta = {
+        "mode": "createcd",
+        "compression": None,
+        "split": False,
+        "source": {"/vol/Game.cue": {"size": 12, "mtime_ns": 123456789}},
+        "output": {"size": 1, "mtime_ns": 111},
+    }
+    import asyncio
 
-    # A record from a manual /info verify carries no source_path, so it can't
-    # prove this job's prior success.
-    _set_record(noop_env["monkeypatch"], {
-        "source_path": None, "verified_at": "2026-01-01T00:00:00Z",
-    })
-
-    job = await mgr.create_job(str(src), ConversionMode.CREATECD, allow_overwrite=True)
-    await mgr._process_job(job.id)
-
-    assert len(noop_env["calls"]) == 1
-
-
-@pytest.mark.asyncio
-async def test_reconvert_runs_when_compression_requested(noop_env):
-    tmp_path: Path = noop_env["tmp_path"]
-    mgr: JobManager = noop_env["mgr"]
-    src, _out = _seed_verified_output(tmp_path)
-
-    # A non-default compression could change the output bytes, so the fast path
-    # must step aside and let the converter run.
-    _set_record(noop_env["monkeypatch"], {
-        "source_path": os.path.realpath(str(src)),
-        "verified_at": "2026-01-01T00:00:00Z",
-    })
-
-    job = await mgr.create_job(
-        str(src), ConversionMode.CREATECD, allow_overwrite=True, compression="cd_lzma",
-    )
-    await mgr._process_job(job.id)
-
-    assert len(noop_env["calls"]) == 1
+    asyncio.run(store.mark_verified(str(out), source_path=str(out), produced_meta=meta))
+    record = asyncio.run(store.get_record(str(out)))
+    assert record is not None
+    assert record["produced_meta"] == meta
+    # A verify with no meta leaves the column NULL.
+    other = tmp_path / "Other.chd"
+    other.write_bytes(b"y")
+    asyncio.run(store.mark_verified(str(other)))
+    other_rec = asyncio.run(store.get_record(str(other)))
+    assert other_rec is not None
+    assert other_rec["produced_meta"] is None

--- a/tests/test_reconvert_noop_184.py
+++ b/tests/test_reconvert_noop_184.py
@@ -293,3 +293,29 @@ def test_produced_meta_round_trips_through_store(tmp_path):
     other_rec = asyncio.run(store.get_record(str(other)))
     assert other_rec is not None
     assert other_rec["produced_meta"] is None
+
+
+def test_produced_meta_survives_record_move(tmp_path):
+    """Renaming a verified artifact carries produced_meta to the new path, so a
+    later re-queue at the new name can still take the fast path."""
+    import asyncio
+
+    store = VerificationStore(store_path=str(tmp_path / "v.db"))
+    old = tmp_path / "Game.chd"
+    old.write_bytes(b"x")
+    new = tmp_path / "Renamed.chd"
+    meta = {
+        "mode": "createcd",
+        "compression": None,
+        "split": False,
+        "source": {"/vol/Game.cue": {"size": 12, "mtime_ns": 1, "inode": 2, "device": 3}},
+        "output": {"size": 1, "mtime_ns": 4, "inode": 5, "device": 6},
+    }
+    asyncio.run(store.mark_verified(str(old), source_path="/vol/Game.cue",
+                                    produced_meta=meta))
+    asyncio.run(store.move(str(old), str(new)))
+
+    moved = asyncio.run(store.get_record(str(new)))
+    assert moved is not None
+    assert moved["produced_meta"] == meta
+    assert asyncio.run(store.get_record(str(old))) is None


### PR DESCRIPTION
## Summary

Closes the last open acceptance criterion of **#184** (idempotency / re-run safety, part of the #177 tech-debt epic): _"Re-queuing a job whose verified output already exists does not re-spawn the converter."_

A re-queued conversion job whose **verified artifact is already on disk and provably the exact result of the current request** now completes as a **no-op** instead of re-running the converter. The other three of #184's four sites — disc-ID embed idempotency (site 1a), background notify/prune strong-refs (site 3), the `embedded_hashes` TOCTOU (site 2), and the duplicate optimistic-placeholder count (site 4) — were already resolved by prior work; this PR finishes the remaining fast-path item.

## What changed

- **`JobManager._output_already_verified`** backs the fast path, checked at the top of `_process_job`'s conversion `try` block — **before** archive extraction and **before** `_clear_existing_output` — so the existing verified output is neither re-extracted-from nor deleted. On a hit the job jumps straight to `COMPLETED` (progress 100, size via the shared `_compute_output_size`, a `complete` event with `verified=True`). A cancel is honored on both sides of the awaited lookups.

- **The evidence is a `produced_meta` snapshot, not a bare "verified" flag.** A plain verification record only proves *some* file at that path passed verification at *some* time. So the fast path trusts **only** records carrying a `produced_meta` blob, written by a prior **delete-on-verify** conversion right after its verify passed (new nullable `verifications.produced_meta` JSON column, migration `0003`; a manual `/info` verify records none). The snapshot captures:
  - `mode` / `compression` / `split` — the producing output shape.
  - `source` — a stat fingerprint (`{realpath: {size, mtime_ns, inode, device}}`) of the **complete** source set (a `.cue`/`.gdi` **and its track files**, via `build_delete_snapshot`). It is the **pre-conversion** delete snapshot, re-validated at record time so a source mutated mid-conversion records no reusable metadata.
  - `output` — a `{size, mtime_ns, inode, device}` fingerprint of the produced artifact.

- The fast path fires only when **all** match the current request: `mode`/`compression`/`split`, the complete-source-set fingerprint, and the output fingerprint. So a different compression/mode, a changed `.bin` track, or a replaced/corrupted output all force a full re-convert. `inode`/`device` are the same four stat fields `build_delete_snapshot` already trusts to authorize an *irreversible delete*, so a reuse (strictly less destructive) is held to no weaker a bar. Directory (folder→ISO) and `delete_on_verify` requests always take the normal path; any store hiccup / missing record / absent snapshot / un-fingerprintable source falls through to a re-convert.

- `verification_store.move()` carries `produced_meta` across a rename, so a renamed artifact keeps its fast-path eligibility.

**Known limitation:** `compression` is stored as declared, so a tool that resolves its default from a mutable setting (nsz's `NSZ_COMPRESSION_LEVEL`) could deliver the earlier-default artifact for a `None`-compression re-queue after that setting changes — a compression-*level* difference on an otherwise-correct verified artifact of the exact source, not a content mismatch. Documented in DESIGN §3.3.6.

## Docs

- `docs/DESIGN_tool_plugin_architecture.md` §3.3.6 documents the new shared pipeline seam.
- `docs/RELEASE_NOTES.md` gains an Unreleased entry.

## Tests

`tests/test_reconvert_noop_184.py` covers the no-op hit and every guard escape hatch (compression/mode mismatch, changed `.cue` track, replaced output, missing/absent snapshot), the pre-conversion-snapshot behavior, and `produced_meta` store round-trip + move. Tests bind fresh, tmp-dir-scoped `ConcurrencyManager`/`LockManager`/`JobManager` instances so the process-global cross-process FIFO can't wedge them.

Full suite: `1206 passed, 1 skipped`. `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)