### PR TITLE
README: disambiguate duplicate "Environment Variables" headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ workflow (queue, verify, delete-on-verify, archives) is in the
 - ROMs must be **decrypted** before compression (encrypted ROMs will not work).
 - Decompression (`z3ds_decompress`) does not offer delete-on-verify: the restored ROM is not itself a verify-class file, so the compressed source can't be confirmed before deletion.
 
-### Environment Variables
+### 3DS Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -678,7 +678,7 @@ shared picker behavior, including the Reset-to-default button.)
   be committed. The file only needs to be readable by uid 999 (`converter`).
 * Keys are never logged.
 
-### Environment Variables
+### Switch Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -764,7 +764,7 @@ for it yet).
 * An `.iso` row can be handled by CHDMAN, Dolphin, or CSO; the primary-tool picker
   decides which one acts on it.
 
-### Environment Variables
+### CSO Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -831,7 +831,7 @@ default; ext4, NTFS, and exFAT targets don't need it.
 - The makeps3iso binary (GPL-3.0, from `bucanero/ps3iso-utils`) is built into the
   Docker image and builds on both `linux/amd64` and `linux/arm64`.
 
-### Environment Variables
+### PS3 ISO Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|


### PR DESCRIPTION
## Problem

Every in-README link to "Environment variables" pointed at
`https://github.com/pacnpal/compressatorium#environment-variables`. GitHub
anchors are generated from heading text and only de-duplicated with `-1`,
`-2`, ... suffixes in document order — and the README had **five** headings
literally titled "Environment Variables": one per tool section (3DS, Switch,
CSO, PS3 ISO) plus the global section. That made `#environment-variables`
resolve to the *first* one (the 3DS section), so the two links intended for
the global "Environment Variables" section (used from the 3DS and PS3 ISO
sections) never actually reached it — its real anchor was
`#environment-variables-4`.

## Fix

Renamed the four tool-specific headings so each is unique:

- `### Environment Variables` (3DS) → `### 3DS Environment Variables`
- `### Environment Variables` (Switch) → `### Switch Environment Variables`
- `### Environment Variables` (CSO) → `### CSO Environment Variables`
- `### Environment Variables` (PS3 ISO) → `### PS3 ISO Environment Variables`

The global `## Environment Variables` heading is untouched. Since it's now
the *only* heading with that exact text, GitHub gives it the plain
`#environment-variables` anchor — which is exactly what the two existing
links (`[Environment Variables](#environment-variables)` in the 3DS and PS3
ISO sections) already point at, so no link text needed to change.

Verified no two headings in the file now share identical text for
"Environment Variables", and grepped the whole file for every
`environment-variables` / "Environment Variables" occurrence to confirm all
headings and links were covered. Purely a docs change — 4 lines changed, no
other reformatting.

Closes #247

---
_Generated by [Claude Code](https://claude.ai/code)_
