### PR TITLE
docs: document Synology DSM cpus:/NanoCPUs startup failure (#248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1201,6 +1201,12 @@ The default compose files include conservative CPU/memory limits to help avoid h
 - Prefer SSD/cache for `CHD_TEMP_DIR` and CHD output to reduce array contention.
 - Avoid running other heavy services during conversion.
 - Always set container CPU/memory limits on shared hosts.
+- **Synology DSM:** DSM's Docker/Container Manager doesn't support CPU CFS
+  bandwidth control, so the default `cpus:` limit fails the container at
+  startup with `NanoCPUs can not be set, as your kernel does not support CPU
+  CFS scheduler or the cgroup is not mounted`. Remove/comment out the `cpus:`
+  lines (keep `memory:`) or switch to `cpuset: "0-1"` core pinning instead —
+  see [docs/DOCKER-COMPOSE.md#synology-dsm-and-other-cfs-less-kernels](docs/DOCKER-COMPOSE.md#synology-dsm-and-other-cfs-less-kernels).
 
 2. **Multiple Volumes:**
 ```bash

--- a/docker-compose.multi-volume.yml
+++ b/docker-compose.multi-volume.yml
@@ -37,13 +37,15 @@ services:
     # Resource limits (adjust based on your system)
     # NOTE (Synology / other CFS-less kernels): if the container fails to
     # start with "NanoCPUs can not be set, as your kernel does not support
-    # CPU CFS scheduler or the cgroup is not mounted", your host's kernel
-    # doesn't support CPU CFS bandwidth control. Delete/comment out the two
+    # CPU CFS scheduler or the cgroup is not mounted", the error covers two
+    # distinct causes — DSM's known lack of CPU CFS bandwidth control, or (on
+    # other hosts) a cgroup controller that simply isn't mounted, in which
+    # case `cpuset` below may fail the same way. Delete/comment out the two
     # `cpus:` lines below (the `memory:` limits are unaffected and still
-    # work), or replace them with a top-level `cpuset: "0-1"` to pin specific
-    # cores instead. See
+    # work; this leaves CPU usage unbounded), or replace them with a
+    # top-level `cpuset: "0-1"` to pin specific cores instead. See
     # docs/DOCKER-COMPOSE.md#synology-dsm-and-other-cfs-less-kernels for the
-    # full explanation, including why `cpuset` is not a drop-in equivalent.
+    # full explanation, including how to check which cause applies to you.
     deploy:
       resources:
         limits:

--- a/docker-compose.multi-volume.yml
+++ b/docker-compose.multi-volume.yml
@@ -35,6 +35,15 @@ services:
       - ./games/ps2:/data/ps2
     restart: unless-stopped
     # Resource limits (adjust based on your system)
+    # NOTE (Synology / other CFS-less kernels): if the container fails to
+    # start with "NanoCPUs can not be set, as your kernel does not support
+    # CPU CFS scheduler or the cgroup is not mounted", your host's kernel
+    # doesn't support CPU CFS bandwidth control. Delete/comment out the two
+    # `cpus:` lines below (the `memory:` limits are unaffected and still
+    # work), or replace them with a top-level `cpuset: "0-1"` to pin specific
+    # cores instead. See
+    # docs/DOCKER-COMPOSE.md#synology-dsm-and-other-cfs-less-kernels for the
+    # full explanation, including why `cpuset` is not a drop-in equivalent.
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,13 +51,15 @@ services:
     # Resource limits (adjust based on your system)
     # NOTE (Synology / other CFS-less kernels): if the container fails to
     # start with "NanoCPUs can not be set, as your kernel does not support
-    # CPU CFS scheduler or the cgroup is not mounted", your host's kernel
-    # doesn't support CPU CFS bandwidth control. Delete/comment out the two
+    # CPU CFS scheduler or the cgroup is not mounted", the error covers two
+    # distinct causes — DSM's known lack of CPU CFS bandwidth control, or (on
+    # other hosts) a cgroup controller that simply isn't mounted, in which
+    # case `cpuset` below may fail the same way. Delete/comment out the two
     # `cpus:` lines below (the `memory:` limits are unaffected and still
-    # work), or replace them with a top-level `cpuset: "0-1"` to pin specific
-    # cores instead. See
+    # work; this leaves CPU usage unbounded), or replace them with a
+    # top-level `cpuset: "0-1"` to pin specific cores instead. See
     # docs/DOCKER-COMPOSE.md#synology-dsm-and-other-cfs-less-kernels for the
-    # full explanation, including why `cpuset` is not a drop-in equivalent.
+    # full explanation, including how to check which cause applies to you.
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,15 @@ services:
       - ./games:/data/games
     restart: unless-stopped
     # Resource limits (adjust based on your system)
+    # NOTE (Synology / other CFS-less kernels): if the container fails to
+    # start with "NanoCPUs can not be set, as your kernel does not support
+    # CPU CFS scheduler or the cgroup is not mounted", your host's kernel
+    # doesn't support CPU CFS bandwidth control. Delete/comment out the two
+    # `cpus:` lines below (the `memory:` limits are unaffected and still
+    # work), or replace them with a top-level `cpuset: "0-1"` to pin specific
+    # cores instead. See
+    # docs/DOCKER-COMPOSE.md#synology-dsm-and-other-cfs-less-kernels for the
+    # full explanation, including why `cpuset` is not a drop-in equivalent.
     deploy:
       resources:
         limits:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -66,6 +66,13 @@ Volume precedence:
 - Put `CHD_TEMP_DIR` and CHD output on SSD or cache to cut array contention.
 - Don't run other heavy services during a conversion.
 - Always set container CPU/memory limits on a shared host.
+- **Synology DSM:** the `cpus:` limit in the default compose files fails the
+  container at startup on DSM (`NanoCPUs can not be set, as your kernel does
+  not support CPU CFS scheduler or the cgroup is not mounted`) because DSM's
+  Docker implementation lacks CPU CFS bandwidth control. Remove the `cpus:`
+  lines (the `memory:` limit still works), or pin to specific cores with a
+  top-level `cpuset: "0-1"` instead — see
+  [DOCKER-COMPOSE.md#synology-dsm-and-other-cfs-less-kernels](DOCKER-COMPOSE.md#synology-dsm-and-other-cfs-less-kernels).
 
 ## What's already in the image
 

--- a/docs/DOCKER-COMPOSE.md
+++ b/docs/DOCKER-COMPOSE.md
@@ -211,32 +211,46 @@ deploy:
 
 ### Synology DSM (and other CFS-less kernels)
 
-Synology DSM's Docker/Container Manager doesn't support CPU CFS bandwidth
-control (some other embedded/NAS kernels have the same gap), so the `cpus:`
-limit above (Docker's `NanoCPUs` setting) fails the container at startup with:
+The error covers two distinct causes — Synology DSM is the common one, but
+the same message also fires when a host's cgroup controllers simply aren't
+mounted (a Docker/host misconfiguration unrelated to Synology):
 
 ```
 Error response from daemon: NanoCPUs can not be set, as your kernel does not
 support CPU CFS scheduler or the cgroup is not mounted
 ```
 
-Compose has no way to detect this at parse time, so there's no single
+On DSM specifically, the Docker/Container Manager kernel doesn't support CPU
+CFS bandwidth control, so the `cpus:` limit above (Docker's `NanoCPUs`
+setting) fails outright — that's the documented, known-affected case below.
+If you're not on Synology, check which controllers are actually mounted
+before assuming the same fix applies: `cat /sys/fs/cgroup/cgroup.controllers`
+(cgroup v2) or `ls /sys/fs/cgroup/cpuset` (cgroup v1) — if `cpuset` isn't
+listed/present either, the `cpuset` workaround below will fail the same way
+and dropping `cpus:` entirely is the only option.
+
+Compose has no way to detect either cause at parse time, so there's no single
 compose file that works everywhere. Pick one of these instead:
 
 - **Remove the CPU limit (simplest, recommended):** delete or comment out the
   `cpus:` lines under both `limits:` and `reservations:`; keep `memory:`,
-  which is unaffected. `MAX_CONCURRENT_JOBS=1` plus the
-  `COMPRESSATORIUM_TOOL_NICE`/`COMPRESSATORIUM_TOOL_IOPRIO_*` niceness/I-O
-  priority settings already keep a conversion from saturating the host, so
-  the CPU limit is a secondary safeguard here, not a required one.
+  which is unaffected. **This leaves CPU usage unbounded** — a conversion can
+  use up to 100% of every core the container can see. `MAX_CONCURRENT_JOBS=1`
+  only limits how many jobs run at once, not how much CPU each one takes, and
+  the `COMPRESSATORIUM_TOOL_NICE`/`COMPRESSATORIUM_TOOL_IOPRIO_*` settings
+  only change scheduling *priority* relative to other processes on the host
+  (see `nice(1)`/`ionice(1)`) — they make a conversion yield under
+  contention, they don't cap it. If you need an actual CPU ceiling on a host
+  that can't use `cpus:`, use `cpuset` below instead.
 - **Pin to specific cores with `cpuset` instead:** add a top-level
   `cpuset: "0-1"` on the service (a sibling of `deploy:`, not nested under
   `resources:`) to restrict the container to specific CPU cores via the
-  `cpuset` cgroup controller, which Synology does support. **This is not a
-  drop-in replacement for `cpus:`** — `cpuset` pins to a set of cores rather
-  than capping the proportion of CPU time used, so the container can still
-  use up to 100% of each pinned core. Size the core count to the compute
-  budget you actually want.
+  `cpuset` cgroup controller, which Synology does support (see the cgroup
+  check above for other hosts). **This is not a drop-in replacement for
+  `cpus:`** — `cpuset` pins to a set of cores rather than capping the
+  proportion of CPU time used, so the container can still use up to 100% of
+  each pinned core. Size the core count to the compute budget you actually
+  want.
 
 ---
 

--- a/docs/DOCKER-COMPOSE.md
+++ b/docs/DOCKER-COMPOSE.md
@@ -209,6 +209,35 @@ deploy:
       memory: 512M     # Reserved 512MB RAM
 ```
 
+### Synology DSM (and other CFS-less kernels)
+
+Synology DSM's Docker/Container Manager doesn't support CPU CFS bandwidth
+control (some other embedded/NAS kernels have the same gap), so the `cpus:`
+limit above (Docker's `NanoCPUs` setting) fails the container at startup with:
+
+```
+Error response from daemon: NanoCPUs can not be set, as your kernel does not
+support CPU CFS scheduler or the cgroup is not mounted
+```
+
+Compose has no way to detect this at parse time, so there's no single
+compose file that works everywhere. Pick one of these instead:
+
+- **Remove the CPU limit (simplest, recommended):** delete or comment out the
+  `cpus:` lines under both `limits:` and `reservations:`; keep `memory:`,
+  which is unaffected. `MAX_CONCURRENT_JOBS=1` plus the
+  `COMPRESSATORIUM_TOOL_NICE`/`COMPRESSATORIUM_TOOL_IOPRIO_*` niceness/I-O
+  priority settings already keep a conversion from saturating the host, so
+  the CPU limit is a secondary safeguard here, not a required one.
+- **Pin to specific cores with `cpuset` instead:** add a top-level
+  `cpuset: "0-1"` on the service (a sibling of `deploy:`, not nested under
+  `resources:`) to restrict the container to specific CPU cores via the
+  `cpuset` cgroup controller, which Synology does support. **This is not a
+  drop-in replacement for `cpus:`** — `cpuset` pins to a set of cores rather
+  than capping the proportion of CPU time used, so the container can still
+  use up to 100% of each pinned core. Size the core count to the compute
+  budget you actually want.
+
 ---
 
 ## Troubleshooting
@@ -217,6 +246,11 @@ deploy:
 ```bash
 docker-compose logs
 ```
+
+If the error is `NanoCPUs can not be set, as your kernel does not support CPU
+CFS scheduler or the cgroup is not mounted` (common on Synology DSM), see
+[Synology DSM (and other CFS-less kernels)](#synology-dsm-and-other-cfs-less-kernels)
+above.
 
 ### Check health status
 ```bash

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -108,6 +108,17 @@ and #179, part of the #177 tech-debt epic).
 
 ### Fixed
 
+- **Documented the Synology DSM `cpus:`/NanoCPUs startup failure (issue #248).**
+  DSM's Docker implementation doesn't support CPU CFS bandwidth control, so the
+  default compose files' `cpus:` limit makes the container fail to start with
+  `NanoCPUs can not be set, as your kernel does not support CPU CFS scheduler
+  or the cgroup is not mounted`. The compose files, README, and
+  `docs/DOCKER-COMPOSE.md`/`docs/DEPLOYMENT.md` now flag this next to the
+  limit and document the fix: drop the `cpus:` lines (keep `memory:`), or pin
+  cores with `cpuset: "0-1"` instead (not equivalent — it pins cores rather
+  than capping CPU time). There's no compose-level way to auto-detect kernel
+  CFS support, so this remains a documented manual step on affected hosts.
+
 - **The delete-on-verify confirmation no longer crashes the view for archive
   sources.** Selecting two or more archives with **Delete sources after
   successful verification** enabled took down the whole workspace with "This


### PR DESCRIPTION
## Problem

On Synology DSM, starting either default compose file (`docker-compose.yml` or `docker-compose.multi-volume.yml`) — both of which bake in a `deploy.resources.limits.cpus` / `reservations.cpus` value by default — fails the container at startup with:

```
Error response from daemon: NanoCPUs can not be set, as your kernel does not support CPU CFS scheduler or the cgroup is not mounted
```

This is a real kernel limitation on (at least some) Synology DSM builds: they don't support CPU CFS bandwidth control, which is what Docker's `cpus:`/`NanoCPUs` setting relies on. Two related projects hit the same issue and took different approaches (linked in the issue): one skips the CPU limit when unsupported, the other swaps in `cpuset`/`CpusetCpus` — though that swap drew follow-up pushback because `cpuset` is not functionally equivalent to `cpus:` (it pins to specific cores instead of capping the proportion of CPU time used).

## Why this fix, not an auto-detecting one

Docker Compose has no host-capability conditional — there is no way to make the shipped compose files "skip the CPU limit if unsupported" at parse time. Silently defaulting every user to `cpuset` also isn't right, since it silently changes the semantics (core pinning vs. proportional CPU capping) without the operator asking for that trade-off. So this PR is docs/config only, not a behavior change:

- **`docker-compose.yml` / `docker-compose.multi-volume.yml`**: added a comment directly above the `deploy:` block explaining the failure and pointing at the two workarounds (drop `cpus:`, keep `memory:`; or replace with a top-level `cpuset: "0-1"`).
- **`docs/DOCKER-COMPOSE.md`**: new "Synology DSM (and other CFS-less kernels)" subsection under Resource Limits with the exact error text, both workarounds, and an explicit callout that `cpuset` pins cores rather than capping CPU time (not a drop-in replacement) — plus a pointer to it from Troubleshooting.
- **`docs/DEPLOYMENT.md`** and **`README.md`**: a short pointer to the same explanation, next to the existing "always set CPU/memory limits" tips, since the issue says this was hit via "the suggested resource limiting."
- **`docs/RELEASE_NOTES.md`**: one entry under Unreleased → Fixed per the repo's standing rule for user-facing changes.

Existing users on non-Synology hosts see no behavior change — the default `cpus:` limit is untouched; Synology (and similarly-limited) users now have a documented, immediate fix (delete two lines, or swap to `cpuset`) instead of hitting an opaque Docker daemon error with no guidance.

## Testing

Docs/comments only — no application code changed. Verified `cpuset` is a top-level Compose-spec service attribute (sibling of `deploy:`, not nested under `deploy.resources`) against the current Compose Specification reference before writing the guidance.

Addresses #248 — there is no compose-level way to auto-detect or work around the underlying kernel CFS-scheduler gap, so avoiding the failure on affected hosts remains a documented manual step (drop `cpus:`, or accept the `cpuset` semantics trade-off), not something the shipped compose file can silently fix for every host.

---
_Generated by [Claude Code](https://claude.ai/code)_