### PR TITLE
ci: don't run the screenshots commit job on tag pushes

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -9,13 +9,17 @@ name: Take screenshots
 # with Oxipng, uploads the generated screenshots, then commits any changes from
 # a separate write-scoped job.
 #
-# Runs on manual dispatch and on pushes that touch the UI. Changes under
+# Runs on manual dispatch and on branch pushes that touch the UI. Changes under
 # docs/screenshots/** are intentionally NOT a trigger, so the commit this
-# workflow makes cannot trigger itself.
+# workflow makes cannot trigger itself. Tag pushes are excluded: the commit job
+# rebases onto and pushes to the pushed ref, which only works on a branch (a
+# tag checkout is a detached HEAD with nothing to push to).
 
 on:
   workflow_dispatch:
   push:
+    branches:
+      - "**"
     paths:
       - "src/**"
       - "index.html"
@@ -123,6 +127,9 @@ jobs:
           if-no-files-found: error
 
   commit-screenshots:
+    # A workflow_dispatch can still target a tag; there is no branch to commit
+    # back to in that case, so keep the screenshots as a run artifact and skip.
+    if: github.ref_type == 'branch'
     runs-on: ubuntu-latest
     needs: screenshots
     permissions:

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -25,9 +25,13 @@ This keeps them in sync with the current UI and its light/dark themes.
    (`oxipng -o 4 -i 0 --strip safe`).
 5. Commits any changes under `docs/screenshots/`.
 
-It runs on manual dispatch and on pushes that touch the UI (see the workflow's
-`paths:` list). Changes under `docs/screenshots/**` are deliberately not a
-trigger, so the commit the workflow makes cannot trigger itself.
+It runs on manual dispatch and on branch pushes that touch the UI (see the
+workflow's `paths:` list). Changes under `docs/screenshots/**` are deliberately
+not a trigger, so the commit the workflow makes cannot trigger itself. Tag
+pushes don't trigger it, and the commit job skips any run not on a branch (such
+as a manual dispatch from a tag): a tag checkout is a detached HEAD, so there is
+no branch to rebase onto and push the screenshot commit to — that run's
+screenshots stay available as the workflow's `screenshots` artifact instead.
 
 ## Running it locally
 


### PR DESCRIPTION
## Problem

Pushing the `v4.2.0` tag triggered the **Take screenshots** workflow (the tagged commit touches `package.json`, which is in the trigger's `paths:` list). The `commit-screenshots` job then checked out the tag ref — a detached HEAD — committed the refreshed PNGs, and failed at `git pull --rebase` with:

```
You are not currently on a branch.
Please specify which branch you want to rebase against.
##[error]Process completed with exit code 1
```

There's nothing for the job to do on a tag: a tag checkout has no branch to rebase onto or push the screenshot commit to. (No screenshots were lost — the tagged commit `5d720d1` is itself a screenshot update from minutes earlier, and the failed run's changes were byte-level PNG re-encodes with identical sizes.)

## Fix

- Restrict the `push` trigger to branches (`branches: ["**"]`), so tag pushes no longer trigger the workflow at all.
- Guard `commit-screenshots` with `if: github.ref_type == 'branch'`, so a `workflow_dispatch` from a tag still captures and uploads the `screenshots` artifact but skips the commit job instead of failing.
- Document the behavior in the workflow header comment and `docs/SCREENSHOTS.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2NURw59fJmJR9dwuSLtiV)_