### PR TITLE
fix: name makeps3iso in the FastAPI app description

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -321,7 +321,8 @@ app = FastAPI(
     title="Compressatorium",
     description=(
         "Web UI for converting game files with chdman, dolphin-tool, "
-        "z3ds_compressor, nsz, maxcso, and 7z (handheld ROM archives)"
+        "z3ds_compressor, nsz, maxcso, 7z (handheld ROM archives), "
+        "and makeps3iso (PS3 folder to ISO)"
     ),
     version=get_version(),
     lifespan=lifespan,


### PR DESCRIPTION
## Summary

The FastAPI `description=` in `app/main.py` — the blurb shown at `/docs` — listed six of the seven conversion tools, omitting **makeps3iso** (PS3 folder → ISO). The API docs therefore under-reported what the app can do.

Spotted while auditing the tool-addition guide in #253, which has a checklist item requiring this string to name every tool. Split out here to keep that PR docs-only.

## Change

```diff
     description=(
         "Web UI for converting game files with chdman, dolphin-tool, "
-        "z3ds_compressor, nsz, maxcso, and 7z (handheld ROM archives)"
+        "z3ds_compressor, nsz, maxcso, 7z (handheld ROM archives), "
+        "and makeps3iso (PS3 folder to ISO)"
     ),
```

The list now matches the seven tools registered in `app/services/tools/__init__.py`. The synthetic `chain` tool is deliberately not listed — it has no binary and exposes one composite mode (`cso_to_chd`) built from tools already named.

## Testing

- `PYTHONPATH=app python -m pytest -q tests` → 1211 passed, 1 skipped
- `ruff check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014WasQD562Uwg9nJg7AXSrk

---
_Generated by [Claude Code](https://claude.ai/code/session_014WasQD562Uwg9nJg7AXSrk)_