### PR TITLE
refactor: turn three per-tool branches into plugin hooks (overwrite_targets, is_ready, per-spec chain resolution)

### DIFF
--- a/app/routes/info.py
+++ b/app/routes/info.py
@@ -926,17 +926,15 @@ async def get_romz_info(
 async def list_tools():
     """Which tools the frontend should show.
 
-    A tool is unavailable when its runtime prerequisites are missing. Today the
-    only gated tool is Switch (nsz), which needs the operator's prod.keys; when
-    they aren't found it is reported unavailable so the UI hides it entirely.
+    A tool is unavailable when its own ``is_ready()`` says its runtime
+    prerequisites are missing — today that's Switch (nsz), which needs the
+    operator's prod.keys, but the check is the plugin's, not this route's, so
+    any future gated tool is covered by implementing the hook.
     """
-    nsz_ready = await run_in_threadpool(nsz_service.keys_available)
     available, unavailable = [], []
     for tool in registry.all():
-        if tool.id == "nsz" and not nsz_ready:
-            unavailable.append(tool.id)
-        else:
-            available.append(tool.id)
+        target = available if await tool.is_ready() else unavailable
+        target.append(tool.id)
     return {"available": available, "unavailable": unavailable}
 
 

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -21,7 +21,6 @@ from services.chd_metadata_store import chd_metadata_store
 from services.chdman import ConversionCancelled, chdman_service
 from services.concurrency_manager import concurrency_manager
 from services.lock_manager import lock_manager
-from services.makeps3iso import makeps3iso_service
 from services.tools import ModeKind, registry
 from services.verification_store import verification_store
 from utils.delete_plan import build_delete_plan, build_delete_snapshot
@@ -810,46 +809,43 @@ class JobManager:
         """
         if not job.allow_overwrite or not job.output_path:
             return
-        if job.input_kind == InputKind.DIRECTORY:
-            # makeps3iso output is a single .iso OR a split set (.0/.1/…); clear
-            # all of it via the tool's own part-aware cleanup. But a destination
-            # that already exists as a *directory* named like the output can't be
-            # cleared by remove_outputs (its os.remove() fails on a dir and is
-            # suppressed); makeps3iso would then write *inside* it while the job
-            # still reports the bare path as its output. Reject rather than
-            # corrupt — mirroring the non-file guard on the file-job path below.
-            if await run_in_threadpool(os.path.isdir, job.output_path):
-                raise RuntimeError("Output path exists and is not a file")
-            await run_in_threadpool(
-                makeps3iso_service.remove_outputs, job.output_path,
-            )
-            await verification_store.clear(job.output_path)
-            return
-        # Clear the primary output and every companion the mode wrote beside it
-        # (enumerated from the tool, not re-derived). Companions are cleared even
-        # when the primary is already gone: a lone companion (e.g. a stray
-        # extractcd .bin whose .cue was deleted) is what made
-        # check_output_conflicts authorize the overwrite, so it must not be left
-        # to collide with the new output. Validate the whole set first — a
+        # Tool-neutral: the mode's own plugin enumerates everything to sweep
+        # (primary + companions, or for makeps3iso the base plus any numbered
+        # split parts). Directory-input jobs take this same path — there is no
+        # per-tool branch here, so a second folder-input tool gets correct
+        # cleanup instead of inheriting makeps3iso's part logic.
+        #
+        # Companions are cleared even when the primary is already gone: a lone
+        # companion (e.g. a stray extractcd .bin whose .cue was deleted) is what
+        # made check_output_conflicts authorize the overwrite, so it must not be
+        # left to collide with the new output. Validate the whole set first — a
         # non-file occupant (a directory squatting on the primary or a companion
         # name) can't be unlinked, so reject before removing anything rather than
         # deleting the primary and then failing against the stray occupant.
-        targets = [
-            job.output_path,
-            *registry.for_mode(job.mode.value).companion_outputs(
-                job.output_path, job.mode.value,
-            ),
-        ]
+        targets = registry.for_mode(job.mode.value).overwrite_targets(
+            job.output_path, job.mode.value,
+        )
+        removed = await run_in_threadpool(self._sweep_overwrite_targets, targets)
+        if removed:
+            await verification_store.clear(job.output_path)
+
+    @staticmethod
+    def _sweep_overwrite_targets(targets: list[str]) -> bool:
+        """Validate then unlink ``targets``; return whether anything was removed.
+
+        Blocking stat/unlink work, kept in one sync helper so the caller can run
+        the whole check-then-remove sequence off the event loop in a single hop
+        (it must stay atomic with respect to its own validation pass).
+        """
         for target in targets:
             if os.path.exists(target) and not os.path.isfile(target):
                 raise RuntimeError("Output path exists and is not a file")
-        primary_removed = False
+        removed = False
         for target in targets:
             if os.path.isfile(target):
                 os.remove(target)
-                primary_removed = primary_removed or target == job.output_path
-        if primary_removed:
-            await verification_store.clear(job.output_path)
+                removed = True
+        return removed
 
     def _get_queued_and_processing_jobs(self) -> tuple[list[str], list[str]]:
         """Get lists of queued and processing job IDs.

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -822,30 +822,50 @@ class JobManager:
         # non-file occupant (a directory squatting on the primary or a companion
         # name) can't be unlinked, so reject before removing anything rather than
         # deleting the primary and then failing against the stray occupant.
-        targets = registry.for_mode(job.mode.value).overwrite_targets(
-            job.output_path, job.mode.value,
+        tool = registry.for_mode(job.mode.value)
+        mode, output_path = job.mode.value, job.output_path
+
+        # Enumeration is inside the hop, not before it: a tool's
+        # ``overwrite_targets`` may probe the disk (makeps3iso walks .0/.1/…),
+        # which would otherwise block the event loop on a slow/network volume.
+        await run_in_threadpool(
+            lambda: self._sweep_overwrite_targets(
+                tool.overwrite_targets(output_path, mode),
+            ),
         )
-        removed = await run_in_threadpool(self._sweep_overwrite_targets, targets)
-        if removed:
-            await verification_store.clear(job.output_path)
+        # Unconditional: an authorized overwrite replaces whatever lives at this
+        # path, so a verification record for it is stale even when the sweep
+        # removed nothing — the prior output may have been deleted by something
+        # else while the job sat in the queue. Letting the record survive would
+        # report the freshly built, unverified artifact as verified.
+        await verification_store.clear(output_path)
 
     @staticmethod
-    def _sweep_overwrite_targets(targets: list[str]) -> bool:
-        """Validate then unlink ``targets``; return whether anything was removed.
+    def _sweep_overwrite_targets(targets: list[str]) -> None:
+        """Validate then unlink ``targets``.
 
-        Blocking stat/unlink work, kept in one sync helper so the caller can run
-        the whole check-then-remove sequence off the event loop in a single hop
-        (it must stay atomic with respect to its own validation pass).
+        Blocking stat/unlink work, kept in one sync helper so the caller runs
+        the whole enumerate-check-remove sequence off the event loop in a single
+        hop (the check must stay atomic with respect to its own removals).
+
+        Uses ``lexists``/``islink`` rather than ``exists``/``isfile``: both of
+        the latter *follow* symlinks and so report False for a **dangling** one,
+        which would leave it in place for the converter to write through —
+        potentially landing the output outside the validated volume. Unlinking a
+        symlink removes the link itself and never its target, so a link sitting
+        on an authorized-overwrite path is safe to clear; anything else that
+        isn't a regular file (a directory, a device node) can't be unlinked at
+        all and is rejected before anything is removed.
         """
+        def _removable(path: str) -> bool:
+            return os.path.islink(path) or os.path.isfile(path)
+
         for target in targets:
-            if os.path.exists(target) and not os.path.isfile(target):
+            if os.path.lexists(target) and not _removable(target):
                 raise RuntimeError("Output path exists and is not a file")
-        removed = False
         for target in targets:
-            if os.path.isfile(target):
+            if os.path.lexists(target) and _removable(target):
                 os.remove(target)
-                removed = True
-        return removed
 
     def _get_queued_and_processing_jobs(self) -> tuple[list[str], list[str]]:
         """Get lists of queued and processing job IDs.

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -216,16 +216,31 @@ class MakePs3IsoService:
         yield {"progress": 100, "message": message}
 
     @classmethod
+    def output_artifacts(cls, output_path: str) -> list[str]:
+        """The base output *and* any numbered split parts, base first.
+
+        Everything a run of this tool may have put on disk for ``output_path``,
+        including the states only a *failed* run produces: a mid-split failure
+        can leave both the not-yet-renamed base and some numbered parts, which
+        never coexist after a successful build. Deliberately not
+        ``split_parts`` (which stops at the base when it exists) — that one
+        describes a finished output, this one describes everything to sweep.
+
+        Backs both the failure cleanup here and the plugin's
+        ``overwrite_targets``, so the two can't drift.
+        """
+        return [output_path, *cls._numbered_parts(output_path)]
+
+    @classmethod
     def remove_outputs(cls, output_path: str) -> None:
         """Synchronously unlink the base output *and* any split parts.
 
-        Used both for failure cleanup here and for authorized overwrite cleanup
-        by the job pipeline (which gates the call on ``allow_overwrite``). A
-        mid-split failure can leave both the not-yet-renamed base and some
-        numbered parts, so clear both unconditionally (don't go through
-        ``split_parts``, which stops at the base when it exists).
+        Failure cleanup. Authorized-overwrite cleanup goes through the job
+        pipeline's tool-neutral path instead (``overwrite_targets``), which
+        additionally rejects non-file occupants rather than silently skipping
+        them the way this ``suppress(OSError)`` does.
         """
-        for target in [output_path, *cls._numbered_parts(output_path)]:
+        for target in cls.output_artifacts(output_path):
             with contextlib.suppress(OSError):
                 os.remove(target)
 

--- a/app/services/tools/base.py
+++ b/app/services/tools/base.py
@@ -143,6 +143,20 @@ class ToolPlugin(Protocol):
         instead of blocking until the current file finishes.
         """
 
+    async def is_ready(self) -> bool:
+        """Whether this tool's runtime prerequisites are met.
+
+        A tool that cannot run at all in the current deployment — a missing
+        user-supplied key file, an absent optional binary — reports ``False``
+        so ``GET /api/tools`` lists it as unavailable and the frontend hides
+        it entirely, rather than offering a converter that can only fail at
+        job time. Default ``True``: most tools ship with everything they need.
+
+        Async because a readiness probe may touch the disk (nsz searches the
+        configured volumes for ``prod.keys``); implementations that block
+        should hop to a threadpool rather than stall the event loop.
+        """
+
     def active_pids(self) -> list[int]:
         """Return PIDs of in-flight subprocesses for this tool."""
 
@@ -150,6 +164,22 @@ class ToolPlugin(Protocol):
         self, input_path: str, output_path: str, mode: str,
     ) -> None:
         """Optional post-processing hook after a successful conversion."""
+
+    def overwrite_targets(self, output_path: str, mode: str) -> list[str]:
+        """Every path to clear before an **authorized** overwrite, primary first.
+
+        The superset of ``companion_outputs``: it includes ``output_path``
+        itself, and it enumerates artifacts a prior *failed* run may have left
+        behind even when they can't coexist with a finished output (a
+        makeps3iso ``-s`` build interrupted mid-split leaves both the
+        not-yet-renamed base and some numbered parts). ``companion_outputs``
+        describes a *successful* output set and is the wrong list to delete
+        from; this one describes everything the overwrite must sweep.
+
+        The job pipeline calls this instead of branching on tool identity, and
+        rejects the whole overwrite if any entry exists as a non-file, so an
+        override must list paths, never remove them.
+        """
 
     def companion_outputs(self, output_path: str, mode: str) -> list[str]:
         """Sibling output paths this mode writes beside ``output_path``.
@@ -227,6 +257,11 @@ class BaseTool:
         # Default: no embedded hash; callers fall back to file-level SHA1.
         return []
 
+    async def is_ready(self) -> bool:
+        # Default: nothing to check. Tools gated on a user-supplied secret or
+        # an optional binary override this (see nsz / prod.keys).
+        return True
+
     async def post_convert(
         self, input_path: str, output_path: str, mode: str,
     ) -> None:
@@ -241,3 +276,10 @@ class BaseTool:
         # parts) override this with their own disk-aware probe.
         exts = self.spec(mode).companion_exts
         return [str(Path(output_path).with_suffix(ext)) for ext in exts]
+
+    def overwrite_targets(self, output_path: str, mode: str) -> list[str]:
+        # Default: the finished output set — the primary plus its companions.
+        # Correct for every mode whose failed runs leave nothing a successful
+        # run wouldn't. makeps3iso overrides (a mid-split failure can leave the
+        # base *and* numbered parts, which never coexist on success).
+        return [output_path, *self.companion_outputs(output_path, mode)]

--- a/app/services/tools/chain.py
+++ b/app/services/tools/chain.py
@@ -100,19 +100,29 @@ class ChainTool(BaseTool):
         )
 
     def detect_output(self, input_path: str) -> OutputStatus | None:
+        """Badge the source when the chain's own product already exists.
+
+        Resolved per chain spec rather than against a literal ``.chd``: the
+        candidate extension comes from whichever mode accepts this input, so a
+        second chain with a different final format badges its own output
+        instead of silently probing the first chain's.
+        """
         source = Path(input_path)
-        if source.suffix.lower() not in self.input_extensions:
-            return None
-        candidate = str(source.with_suffix(".chd"))
-        file_exists, is_locked = lock_manager.check_file_status(candidate)
-        if not (file_exists or is_locked):
-            return None
-        return OutputStatus(
-            tool_id=self.id,
-            exists=file_exists,
-            ready=file_exists and not is_locked,
-            path=candidate,
-        )
+        ext = source.suffix.lower()
+        for spec in self.modes:
+            if ext not in spec.input_extensions or not spec.output_ext:
+                continue
+            candidate = str(source.with_suffix(spec.output_ext))
+            file_exists, is_locked = lock_manager.check_file_status(candidate)
+            if not (file_exists or is_locked):
+                continue
+            return OutputStatus(
+                tool_id=self.id,
+                exists=file_exists,
+                ready=file_exists and not is_locked,
+                path=candidate,
+            )
+        return None
 
     # --------------------------------------------------------------- convert
     def convert(
@@ -235,22 +245,41 @@ class ChainTool(BaseTool):
         ensure_headroom(targets, margin_bytes=margin)
 
     # ------------------------------------------------------ verify / info
-    def _final_tool(self):
-        spec = self.modes[0]
+    def _spec_for_output(self, path: str):
+        """The chain spec whose final product ``path`` is.
+
+        Verify/info arrive with a path and no mode, so the chain is identified
+        by its output extension. Falls back to the first spec when nothing
+        matches, which is also the single-chain case today.
+        """
+        ext = Path(path).suffix.lower()
+        for spec in self.modes:
+            if spec.output_ext and spec.output_ext.lower() == ext:
+                return spec
+        return self.modes[0]
+
+    def _final_tool(self, path: str):
+        """The registered tool that owns verify/info for ``path``.
+
+        Resolved from the matching spec's ``verify_step`` rather than
+        ``modes[0]``, so a second chain ending in a different tool delegates to
+        *its* final tool instead of the first chain's.
+        """
+        spec = self._spec_for_output(path)
         step = spec.steps[spec.verify_step]
         return self._registry.get(step.tool_id)
 
     async def verify(self, path: str) -> dict:
-        return await self._final_tool().verify(path)
+        return await self._final_tool(path).verify(path)
 
     def verify_stream(self, path: str) -> AsyncGenerator[dict, None]:
-        return self._final_tool().verify_stream(path)
+        return self._final_tool(path).verify_stream(path)
 
     async def info(self, path: str) -> dict:
-        return await self._final_tool().info(path)
+        return await self._final_tool(path).info(path)
 
     def info_model(self, raw: dict, path: str) -> "BaseModel":
-        return self._final_tool().info_model(raw, path)
+        return self._final_tool(path).info_model(raw, path)
 
     def active_pids(self) -> list[int]:
         seen: set[int] = set()

--- a/app/services/tools/makeps3iso.py
+++ b/app/services/tools/makeps3iso.py
@@ -126,6 +126,19 @@ class MakePs3IsoTool(BaseTool):
             if part != output_path
         ]
 
+    def overwrite_targets(
+        self, output_path: str, mode: str,  # noqa: ARG002 - single-mode tool
+    ) -> list[str]:
+        """Base ISO + every numbered part, whether or not the base exists.
+
+        Wider than ``companion_outputs`` on purpose: that one reports the
+        *finished* set (parts only when there is no bare ``.iso``), but an
+        overwrite must also sweep the both-present state a ``-s`` build leaves
+        when it fails mid-split. Enumeration only — the pipeline does the
+        non-file check and the unlinking.
+        """
+        return self._service.output_artifacts(output_path)
+
     def convert(
         self,
         input_path: str,

--- a/app/services/tools/nsz.py
+++ b/app/services/tools/nsz.py
@@ -126,5 +126,17 @@ class NszTool(BaseTool):
     def info_model(self, raw: dict, path: str) -> NszInfo:
         return NszInfo(**self._basic_info_fields(raw))
 
+    async def is_ready(self) -> bool:
+        """Switch content is encrypted, so nsz is useless without ``prod.keys``.
+
+        The app ships none (they're console-specific and copyrighted); the
+        operator supplies their own. Until they do, report unavailable so the
+        UI hides the tool rather than offering jobs that can only fail.
+
+        ``keys_available`` can walk the configured volumes, so it goes to a
+        threadpool.
+        """
+        return await run_in_threadpool(self._service.keys_available)
+
     def active_pids(self) -> list[int]:
         return self._service.active_pids()

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -238,6 +238,20 @@ class ToolPlugin(Protocol):
     # size-sum and in-use tracking enumerate, instead of each re-encoding the
     # per-mode suffix. output_path itself is never included.
     def companion_outputs(self, output_path: str, mode: str) -> list[str]: ...
+
+    # Every path an authorized overwrite must sweep, primary FIRST. A superset
+    # of companion_outputs: it includes output_path, and it enumerates states
+    # only a *failed* run leaves (a makeps3iso -s build interrupted mid-split
+    # leaves the not-yet-renamed base AND numbered parts, which never coexist
+    # on success — so companion_outputs, which describes a finished output,
+    # would under-report). Enumeration only; the pipeline validates and unlinks.
+    def overwrite_targets(self, output_path: str, mode: str) -> list[str]: ...
+
+    # Runtime prerequisites met? False => GET /api/tools reports the tool
+    # unavailable and the frontend hides it, instead of offering jobs that can
+    # only fail. Default True; nsz overrides (prod.keys). Async because the
+    # probe may touch disk.
+    async def is_ready(self) -> bool: ...
 ```
 
 `BaseTool(ABC)` provides shared defaults so concrete tools stay tiny:
@@ -283,6 +297,15 @@ class BaseTool:
     # directory scans; modes with no companion_exts return [].
     def companion_outputs(self, output_path, mode) -> list[str]:
         return [str(Path(output_path).with_suffix(e)) for e in self.spec(mode).companion_exts]
+
+    # Default: the finished output set. Correct for every mode whose failed
+    # runs leave nothing a successful run wouldn't; makeps3iso overrides.
+    def overwrite_targets(self, output_path, mode) -> list[str]:
+        return [output_path, *self.companion_outputs(output_path, mode)]
+
+    # Default: nothing to check.
+    async def is_ready(self) -> bool:
+        return True
 
     # subclasses implement: output_path, convert (via self._runner.run),
     # verify_stream, info, info_model
@@ -630,9 +653,16 @@ The first user, **`MakePs3IsoTool`** (`folder_to_iso`, the only
     (single `.iso` **or** the whole split set) **only when `allow_overwrite` was
     granted** — so a set that appears after planning is never deleted out from
     under a skip/rename decision (the per-path `acquire_lock` only sees the bare
-    name). makeps3iso's part-aware `remove_outputs` stays the directory-mode
-    cleanup primitive (it clears a mid-split base + parts that `split_parts`
-    would not), with `companion_outputs` clearing file-mode siblings.
+    name). The sweep is **tool-neutral**: it asks the owning plugin for
+    `overwrite_targets()` and applies the same validate-then-unlink pass to
+    every mode, file or directory. `MakePs3IsoTool` overrides that hook to
+    return the base plus every numbered part (via the service's
+    `output_artifacts`, which also backs its failure cleanup so the two can't
+    drift) — wider than `companion_outputs`, which reports only the finished
+    set. This used to be an `input_kind == DIRECTORY` branch calling
+    `makeps3iso_service.remove_outputs` directly, which meant a *second*
+    directory-input tool would have had its outputs swept by makeps3iso's
+    part logic.
   - **Completed size:** the completion block sums `output_path` plus
     `companion_outputs()`, so a split build (whose numbered parts replace the
     bare `.iso`) and an extractcd `.cue` + `.bin` both report a real
@@ -824,6 +854,23 @@ def register_verify_routes(router, tool: ToolPlugin):
 queue/done/2-second-heartbeat machinery that is copy-pasted ~6× in `info.py`
 today. Endpoint **paths stay identical** (a `tool_id → url_prefix` alias map
 keeps `chd`, `dolphin`, `z3ds`), so the frontend and API are unchanged.
+
+#### Tool availability (`is_ready` / `GET /api/tools`)
+
+`GET /api/tools` splits `registry.all()` into `{"available", "unavailable"}` by
+awaiting each plugin's `is_ready()`; `App.svelte` feeds the result to
+`ui.applyToolAvailability()`, which hides unavailable tools everywhere (the
+sidebar and dashboard both derive from `registry.all()` minus `ui.hiddenTools`,
+and the active tool falls back to a visible one).
+
+The readiness check belongs to the plugin, not the route. `BaseTool.is_ready`
+returns `True`; `NszTool` overrides it with a threadpooled
+`keys_available()` because Switch content is encrypted and the operator must
+supply their own `prod.keys` (§16 of `ADDING_PLATFORMS_AND_TOOLS.md`). The
+route previously computed `nsz_service.keys_available()` itself and branched on
+`tool.id == "nsz"`, so no *other* tool could ever be gated — a second
+secret-dependent tool would have been advertised in the UI while being unable
+to run.
 
 ### 3.6 Generic `FileEntry` outputs (`models.py`, `routes/files.py`)
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -7,6 +7,38 @@ and #179, part of the #177 tech-debt epic).
 
 ### Added
 
+- **Two per-tool branches on shared paths became plugin hooks
+  (`overwrite_targets`, `is_ready`).** Both were single-tool special cases
+  sitting on code every tool runs through, so a *second* tool of the same shape
+  would have silently inherited the first one's behavior.
+
+  `JobManager._clear_existing_output` branched on `input_kind == DIRECTORY` and
+  called `makeps3iso_service.remove_outputs` directly, so any future
+  folder-input tool would have had its outputs swept by makeps3iso's split-part
+  logic — the wrong files deleted and its own companions left behind, with no
+  error. The sweep now asks the owning plugin for `ToolPlugin.overwrite_targets()`
+  and runs one validate-then-unlink pass for every mode, file or directory.
+  `BaseTool` defaults it to the primary plus `companion_outputs`;
+  `MakePs3IsoTool` overrides it with the base plus every numbered part, sharing
+  one `MakePs3IsoService.output_artifacts` enumerator with its failure cleanup
+  so the two can't drift. The blocking stat/unlink pass also moved off the event
+  loop for file jobs, matching what directory jobs already did.
+
+  `GET /api/tools` computed `nsz_service.keys_available()` and branched on
+  `tool.id == "nsz"`, so only Switch could ever be hidden; a second tool needing
+  operator-supplied keys would have been advertised in the UI while unable to
+  run. Availability now awaits each plugin's `ToolPlugin.is_ready()` (default
+  `True`; `NszTool` overrides it with the threadpooled keys probe).
+
+  No API or behavior change for existing tools — the makeps3iso and nsz paths
+  behave exactly as before. One deliberate refinement: an authorized overwrite
+  now clears the output's verification record whenever it removes *any*
+  artifact, not only the primary, so a stale record can't outlive a
+  primary-absent sweep. Tests: new `tests/test_tool_seams_generalized.py` pins
+  both hooks against a *synthetic* second tool, which is what catches a
+  regression back to an id/kind branch (asserting on makeps3iso or nsz alone
+  passes either way).
+
 - **Web UI/API authentication (opt-in).** Optional token authentication for the networked UI and `/api` routes, gated behind `COMPRESSATORIUM_ENABLE_AUTH` (default off). When enabled, operators can set `COMPRESSATORIUM_AUTH_TOKEN` (or legacy `CHD_AUTH_TOKEN`), or let the app generate a persistent token in `/config/auth_token`; `/health` remains unauthenticated for container health checks. The token is accepted only in request headers (HTTP Basic, `Authorization: Bearer`, or `X-Compressatorium-Token`) — never the URL query string — and state-changing requests are restricted to same-origin callers to prevent CSRF via cached browser credentials.
 
 - **Automated Web UI screenshots.** The screenshots embedded in the README are

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -39,13 +39,25 @@ and #179, part of the #177 tech-debt epic).
   path and no mode).
 
   No API or behavior change for existing tools — the makeps3iso, nsz and
-  `cso_to_chd` paths behave exactly as before. One deliberate refinement: an authorized overwrite
-  now clears the output's verification record whenever it removes *any*
-  artifact, not only the primary, so a stale record can't outlive a
-  primary-absent sweep. Tests: new `tests/test_tool_seams_generalized.py` pins
-  both hooks against a *synthetic* second tool, which is what catches a
-  regression back to an id/kind branch (asserting on makeps3iso or nsz alone
-  passes either way).
+  `cso_to_chd` paths behave exactly as before. Two deliberate refinements while
+  the sweep was being unified:
+
+  - **A dangling symlink on an output path is now removed rather than ignored.**
+    `os.path.exists`/`isfile` both follow symlinks and report `False` for a
+    dangling one, so the old file-job check skipped it silently and the
+    converter could write *through* the link — landing the output wherever it
+    pointed, outside the validated volume. The sweep now tests with
+    `lexists`/`islink` (unlinking a symlink removes the link, never its target)
+    and still rejects any other non-file occupant before removing anything.
+  - **An authorized overwrite always clears the output's verification record**,
+    even when the sweep removed nothing. If something else deleted the prior
+    output while the job sat queued, the record would otherwise survive and
+    report the freshly built, unverified artifact as verified.
+
+  Tests: new `tests/test_tool_seams_generalized.py` pins each hook against a
+  *synthetic* second tool (a fake directory tool, a gated non-nsz tool, a
+  `.foo`→`.bar` `ChainSpec`), which is what catches a regression back to an
+  id/kind branch — asserting on the single existing instance passes either way.
 
 - **Web UI/API authentication (opt-in).** Optional token authentication for the networked UI and `/api` routes, gated behind `COMPRESSATORIUM_ENABLE_AUTH` (default off). When enabled, operators can set `COMPRESSATORIUM_AUTH_TOKEN` (or legacy `CHD_AUTH_TOKEN`), or let the app generate a persistent token in `/config/auth_token`; `/health` remains unauthenticated for container health checks. The token is accepted only in request headers (HTTP Basic, `Authorization: Bearer`, or `X-Compressatorium-Token`) — never the URL query string — and state-changing requests are restricted to same-origin callers to prevent CSRF via cached browser credentials.
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -30,8 +30,16 @@ and #179, part of the #177 tech-debt epic).
   run. Availability now awaits each plugin's `ToolPlugin.is_ready()` (default
   `True`; `NszTool` overrides it with the threadpooled keys probe).
 
-  No API or behavior change for existing tools — the makeps3iso and nsz paths
-  behave exactly as before. One deliberate refinement: an authorized overwrite
+  A third instance of the same pattern, in `ChainTool`: `detect_output`
+  hard-coded a `.chd` candidate and `_final_tool()` read `self.modes[0]`, so a
+  second `ChainSpec` would have badged the first chain's product and delegated
+  verify/info to the first chain's final tool. Both now resolve per spec —
+  `detect_output` takes the candidate extension from whichever mode accepts the
+  input, and verify/info resolve the owning spec by output extension (they get a
+  path and no mode).
+
+  No API or behavior change for existing tools — the makeps3iso, nsz and
+  `cso_to_chd` paths behave exactly as before. One deliberate refinement: an authorized overwrite
   now clears the output's verification record whenever it removes *any*
   artifact, not only the primary, so a stale record can't outlive a
   primary-absent sweep. Tests: new `tests/test_tool_seams_generalized.py` pins

--- a/tests/test_companion_outputs_182.py
+++ b/tests/test_companion_outputs_182.py
@@ -181,11 +181,22 @@ def test_candidate_paths_skips_directory_companion_scan(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_clear_existing_output_removes_lone_companion(tmp_path):
+async def test_clear_existing_output_removes_lone_companion(tmp_path, monkeypatch):
     # Overwrite was authorized because a stray .bin exists even though the .cue
     # primary is gone; the clear must still remove the lone .bin so it can't
     # collide with the new output.
+    import app.services.job_manager as jm_module
     from app.services.job_manager import job_manager
+
+    # Removing *any* artifact invalidates the output's verification record, so
+    # the clear reaches the store even when the primary was already gone. Stub
+    # it — this suite has no DB engine (see the sibling PS3 test).
+    cleared: list[str] = []
+
+    async def _record_clear(path):
+        cleared.append(path)
+
+    monkeypatch.setattr(jm_module.verification_store, "clear", _record_clear)
 
     bin_path = tmp_path / "Game.bin"
     bin_path.write_bytes(b"data")
@@ -204,6 +215,7 @@ async def test_clear_existing_output_removes_lone_companion(tmp_path):
     await job_manager._clear_existing_output(job)
 
     assert not bin_path.exists()
+    assert cleared == [str(tmp_path / "Game.cue")]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_seams_generalized.py
+++ b/tests/test_tool_seams_generalized.py
@@ -1,0 +1,211 @@
+"""The two tool seams that used to hard-code a single tool's identity.
+
+Both were per-tool branches sitting on a shared path, so a *second* tool of the
+same shape would have silently inherited the first tool's behavior:
+
+* ``JobManager._clear_existing_output`` called ``makeps3iso_service.remove_outputs``
+  for every ``InputKind.DIRECTORY`` job — a second folder-input tool would have
+  had its outputs swept by makeps3iso's split-part logic (silent corruption,
+  not an error).
+* ``GET /api/tools`` branched on ``tool.id == "nsz"`` to decide availability —
+  a second key-gated tool could never be hidden, so the UI would advertise a
+  converter that can only fail at job time.
+
+They are now the ``overwrite_targets`` and ``is_ready`` plugin hooks. These
+tests pin the generic behavior with a *synthetic* second tool, which is the
+only way to catch a regression back to an id/kind branch: asserting on
+makeps3iso or nsz alone passes either way.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.models import ConversionJob, ConversionMode, InputKind, JobStatus
+from app.services.tools import registry
+from app.services.tools.base import BaseTool
+
+
+# --- overwrite_targets --------------------------------------------------------
+
+def test_base_default_is_primary_plus_companions():
+    # The default covers every ordinary mode: extractcd's .cue primary plus its
+    # .bin sidecar, primary first.
+    assert registry.for_mode("extractcd").overwrite_targets(
+        "/data/Game.cue", "extractcd",
+    ) == ["/data/Game.cue", "/data/Game.bin"]
+
+
+def test_base_default_is_just_the_primary_for_a_single_file_mode():
+    assert registry.for_mode("createcd").overwrite_targets(
+        "/data/Game.chd", "createcd",
+    ) == ["/data/Game.chd"]
+
+
+def test_makeps3iso_sweeps_base_and_parts_together(tmp_path):
+    """The state ``companion_outputs`` deliberately won't report.
+
+    A ``-s`` build that failed mid-split leaves the not-yet-renamed base *and*
+    numbered parts — a combination a successful build never produces, so
+    ``split_parts`` (and thus ``companion_outputs``) stops at the base and
+    hides the parts. ``overwrite_targets`` must still enumerate all of it or
+    the stale parts survive the overwrite and collide with the new output.
+    """
+    base = tmp_path / "MyGame.iso"
+    base.write_bytes(b"partial")
+    (tmp_path / "MyGame.iso.0").write_bytes(b"0")
+    (tmp_path / "MyGame.iso.1").write_bytes(b"1")
+    tool = registry.get("makeps3iso")
+
+    # companion_outputs reports nothing here (the base exists, so it wins)...
+    assert tool.companion_outputs(str(base), "folder_to_iso") == []
+    # ...but the overwrite still has to sweep the orphaned parts.
+    assert tool.overwrite_targets(str(base), "folder_to_iso") == [
+        str(base), f"{base}.0", f"{base}.1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_directory_job_clear_uses_the_hook_not_makeps3iso(tmp_path, monkeypatch):
+    """A directory job must sweep via its own plugin, not makeps3iso's.
+
+    The regression this guards: ``_clear_existing_output`` branching on
+    ``InputKind.DIRECTORY`` and calling ``makeps3iso_service.remove_outputs``.
+    A synthetic directory tool whose overwrite set is deliberately *not*
+    makeps3iso-shaped (a ``.sidecar``, no numbered parts) catches that — under
+    the old code its sidecar survived and a stray ``.0`` was deleted instead.
+    """
+    import app.services.job_manager as jm_module
+    from app.services.job_manager import job_manager
+
+    out = tmp_path / "Built.iso"
+    out.write_bytes(b"iso")
+    sidecar = tmp_path / "Built.sidecar"
+    sidecar.write_bytes(b"meta")
+    # Not in this tool's overwrite set: makeps3iso's logic would remove it.
+    stray_part = tmp_path / "Built.iso.0"
+    stray_part.write_bytes(b"unrelated")
+
+    class _FakeDirTool:
+        id = "fakedir"
+
+        def overwrite_targets(self, output_path, mode):  # noqa: ARG002
+            return [output_path, f"{Path(output_path).with_suffix('.sidecar')}"]
+
+    monkeypatch.setattr(
+        jm_module.registry, "for_mode", lambda _mode: _FakeDirTool(),
+    )
+
+    async def _noop_clear(_path):
+        return None
+
+    monkeypatch.setattr(jm_module.verification_store, "clear", _noop_clear)
+
+    job = ConversionJob(
+        id="fakedir-clear",
+        file_path=str(tmp_path / "SourceFolder"),
+        filename="SourceFolder",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=str(out),
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=True,
+    )
+
+    await job_manager._clear_existing_output(job)
+
+    assert not out.exists()
+    assert not sidecar.exists(), "the tool's own companion must be swept"
+    assert stray_part.exists(), "makeps3iso's part logic must not be applied"
+
+
+@pytest.mark.asyncio
+async def test_directory_job_still_rejects_a_non_file_primary(tmp_path, monkeypatch):
+    """The old branch's one real guard survives the generalization.
+
+    A directory squatting on the output name can't be unlinked, and makeps3iso
+    would write *inside* it while the job still reported the bare path as its
+    output. The tool-neutral sweep rejects it for the same reason the file path
+    always did.
+
+    (A directory on a *part* name needs no guard: ``_numbered_parts`` only
+    enumerates files, so it is never a sweep target — and a split build would
+    fail outright trying to create that part, rather than corrupting anything.)
+    """
+    import app.services.job_manager as jm_module
+    from app.services.job_manager import job_manager
+
+    out = tmp_path / "MyGame.iso"
+    out.mkdir()
+
+    async def _noop_clear(_path):
+        return None
+
+    monkeypatch.setattr(jm_module.verification_store, "clear", _noop_clear)
+
+    job = ConversionJob(
+        id="ps3-nonfile-primary",
+        file_path=str(tmp_path / "MyGame"),
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=str(out),
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=True,
+    )
+
+    with pytest.raises(RuntimeError, match="not a file"):
+        await job_manager._clear_existing_output(job)
+    assert out.is_dir(), "left intact, not partially clobbered"
+
+
+# --- is_ready -----------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_base_tool_is_ready_by_default():
+    class _Plain(BaseTool):
+        id = "plain"
+        display_name = "Plain"
+
+    assert await _Plain("/bin/true").is_ready() is True
+
+
+@pytest.mark.asyncio
+async def test_every_registered_tool_implements_the_hook():
+    # Cheap contract check: the route awaits this on every tool, so a plugin
+    # that forgot it (or returned a non-awaitable) would 500 the endpoint.
+    for tool in registry.all():
+        assert isinstance(await tool.is_ready(), bool)
+
+
+@pytest.mark.asyncio
+async def test_list_tools_hides_any_unready_tool(monkeypatch):
+    """Availability is driven by the hook, not by a hard-coded tool id.
+
+    Gating a tool that is *not* nsz is the regression test: under the old
+    ``tool.id == "nsz"`` branch this tool stayed available no matter what its
+    readiness said.
+    """
+    from app.routes import info as info_routes
+
+    # Patch through the route's own registry: `services.tools` (what app code
+    # imports under PYTHONPATH=app) and `app.services.tools` (what tests import)
+    # are distinct module objects with distinct singletons, so patching the
+    # latter would not be visible here.
+    victim = info_routes.registry.get("cso")
+
+    async def _not_ready():
+        return False
+
+    monkeypatch.setattr(victim, "is_ready", _not_ready)
+
+    result = await info_routes.list_tools()
+
+    assert "cso" in result["unavailable"]
+    assert "cso" not in result["available"]
+    # Everything else is unaffected.
+    assert "chdman" in result["available"]

--- a/tests/test_tool_seams_generalized.py
+++ b/tests/test_tool_seams_generalized.py
@@ -163,6 +163,81 @@ async def test_directory_job_still_rejects_a_non_file_primary(tmp_path, monkeypa
     assert out.is_dir(), "left intact, not partially clobbered"
 
 
+@pytest.mark.asyncio
+async def test_sweep_unlinks_a_dangling_symlink(tmp_path, monkeypatch):
+    """A dangling symlink on the output path must not survive the sweep.
+
+    ``os.path.exists``/``isfile`` both follow symlinks and report False for a
+    dangling one, so an existence check built on them skips it silently — and
+    the converter then writes *through* the link, landing the output wherever
+    it points, outside the validated volume. Unlinking removes the link, not
+    its target.
+    """
+    import app.services.job_manager as jm_module
+    from app.services.job_manager import job_manager
+
+    out = tmp_path / "MyGame.iso"
+    out.symlink_to(tmp_path / "does-not-exist")
+    assert not out.exists() and out.is_symlink()  # the blind spot
+
+    async def _noop_clear(_path):
+        return None
+
+    monkeypatch.setattr(jm_module.verification_store, "clear", _noop_clear)
+
+    job = ConversionJob(
+        id="ps3-dangling-link",
+        file_path=str(tmp_path / "MyGame"),
+        filename="MyGame",
+        mode=ConversionMode.FOLDER_TO_ISO,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=str(out),
+        input_kind=InputKind.DIRECTORY,
+        allow_overwrite=True,
+    )
+
+    await job_manager._clear_existing_output(job)
+
+    assert not out.is_symlink(), "the link itself must be removed"
+
+
+@pytest.mark.asyncio
+async def test_verification_cleared_even_when_nothing_was_swept(tmp_path, monkeypatch):
+    """The record is stale whether or not the old output was still there.
+
+    If something else deleted the prior output while the job sat queued, the
+    sweep removes nothing — but a new artifact is about to be written at that
+    path, so a surviving record would mark it verified without verifying it.
+    """
+    import app.services.job_manager as jm_module
+    from app.services.job_manager import job_manager
+
+    cleared: list[str] = []
+
+    async def _record_clear(path):
+        cleared.append(path)
+
+    monkeypatch.setattr(jm_module.verification_store, "clear", _record_clear)
+
+    out = tmp_path / "Gone.chd"  # never created
+    job = ConversionJob(
+        id="vanished-output",
+        file_path=str(tmp_path / "Game.cue"),
+        filename="Game.cue",
+        mode=ConversionMode.CREATECD,
+        status=JobStatus.PROCESSING,
+        created_at=datetime.now(timezone.utc),
+        output_path=str(out),
+        input_kind=InputKind.FILE,
+        allow_overwrite=True,
+    )
+
+    await job_manager._clear_existing_output(job)
+
+    assert cleared == [str(out)]
+
+
 # --- ChainTool: per-spec resolution instead of modes[0] -----------------------
 
 def _second_chain_spec():

--- a/tests/test_tool_seams_generalized.py
+++ b/tests/test_tool_seams_generalized.py
@@ -163,6 +163,58 @@ async def test_directory_job_still_rejects_a_non_file_primary(tmp_path, monkeypa
     assert out.is_dir(), "left intact, not partially clobbered"
 
 
+# --- ChainTool: per-spec resolution instead of modes[0] -----------------------
+
+def _second_chain_spec():
+    """A synthetic second chain: .foo -> .bar, verified by its own final tool."""
+    from app.services.tools.spec import ChainSpec, ChainStep, ModeKind
+
+    return ChainSpec(
+        mode="foo_to_bar",
+        tool_id="chain",
+        kind=ModeKind.CREATE,
+        label="FOO to BAR",
+        group="chain",
+        output_ext=".bar",
+        input_extensions=frozenset({".foo"}),
+        steps=(
+            ChainStep(tool_id="cso", mode="cso_decompress", weight=0.5, output_ratio=2.0),
+            ChainStep(tool_id="z3ds", mode="z3ds_compress", weight=0.5, output_ratio=1.0),
+        ),
+        intermediate_exts=(".iso",),
+        verify_step=1,
+    )
+
+
+def test_chain_detect_output_uses_each_specs_own_extension(tmp_path, monkeypatch):
+    # Regression: detect_output hard-coded a ".chd" candidate, so a second chain
+    # ending in another format probed the *first* chain's product.
+    chain = registry.get("chain")
+    monkeypatch.setattr(chain, "modes", (*chain.modes, _second_chain_spec()))
+
+    source = tmp_path / "Game.foo"
+    source.write_bytes(b"src")
+    # Only the .bar product exists; a ".chd" probe would miss it entirely.
+    (tmp_path / "Game.bar").write_bytes(b"out")
+
+    status = chain.detect_output(str(source))
+
+    assert status is not None
+    assert status.path == str(tmp_path / "Game.bar")
+
+
+def test_chain_final_tool_resolves_per_output_extension(monkeypatch):
+    # Regression: _final_tool() read modes[0], so every chain's verify/info was
+    # delegated to the first chain's final tool.
+    chain = registry.get("chain")
+    monkeypatch.setattr(chain, "modes", (*chain.modes, _second_chain_spec()))
+
+    # The shipped chain still verifies through chdman...
+    assert chain._final_tool("/data/Game.chd").id == "chdman"
+    # ...while the synthetic one routes to its own verify_step tool.
+    assert chain._final_tool("/data/Game.bar").id == "z3ds"
+
+
 # --- is_ready -----------------------------------------------------------------
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Three single-tool special cases were sitting on paths that **every** tool runs through. Each was correct for the one tool that exists today and wrong for the second one — so they'd have failed quietly, at the moment someone added a tool, which is the worst time to find out. Surfaced while auditing the tool-addition guide in #253, which currently documents the first two as "generalize this first" warnings.

All three now follow the repo's modularity rule: extend the shared seam rather than branch on tool identity.

## 1. `overwrite_targets` — the one that could corrupt

`JobManager._clear_existing_output` branched on `input_kind == DIRECTORY` and called `makeps3iso_service.remove_outputs` directly. A second folder-input tool would have had its outputs swept by **makeps3iso's split-part logic**: the wrong files deleted, its own companions left behind to collide with the new output, and no error raised. Silent, not loud.

The sweep now asks the owning plugin for `overwrite_targets()` and runs one validate-then-unlink pass for every mode, file or directory alike.

The hook is deliberately **wider than `companion_outputs`**, and that distinction is the substance of the change rather than a detail:

- `companion_outputs` describes a *finished* output set. For makeps3iso it's disk-probed via `split_parts`, which stops at the base when the base exists — so it reports **nothing** when both a base and numbered parts are present.
- That both-present state is exactly what a `-s` build leaves when it **fails mid-split**. An overwrite has to sweep it; a naive reuse of `companion_outputs` would leave orphaned `.0`/`.1` parts to collide with the next build.

`MakePs3IsoTool.overwrite_targets` therefore returns the base plus every numbered part, and both it and the service's failure cleanup read a single `MakePs3IsoService.output_artifacts` enumerator so they can't drift apart.

## 2. `is_ready` — the one that lies to the user

`GET /api/tools` computed `nsz_service.keys_available()` itself and branched on `tool.id == "nsz"`. No other tool could ever be reported unavailable, so a second tool needing operator-supplied keys would be advertised in the UI while unable to run a single job.

Availability now awaits each plugin's `is_ready()` — `BaseTool` returns `True`, `NszTool` overrides with the threadpooled keys probe. The route no longer knows any tool's name.

## 3. Per-spec chain resolution

Found by review during this PR, same class of bug: `ChainTool.detect_output` hard-coded a `.chd` candidate and `_final_tool()` read `self.modes[0]`, so a second `ChainSpec` would have badged the first chain's product and delegated verify/info to the first chain's final tool. `detect_output` now takes the candidate extension from whichever mode accepts the input, and verify/info resolve the owning spec by output extension (they arrive with a path and no mode, so that's the available key).

## Behavior

No API change. makeps3iso, nsz and `cso_to_chd` behave exactly as before.

Two deliberate refinements, called out because they aren't pure refactoring — both from review:

- **A dangling symlink on an output path is now removed rather than ignored.** `os.path.exists`/`isfile` both *follow* symlinks and return `False` for a dangling one, so the sweep neither rejected nor unlinked it and the converter could write **through** the link, landing the output outside the validated volume. Now checked with `lexists`/`islink` — unlinking a symlink removes the link, never its target — while any other non-file occupant is still rejected before anything is removed. Note this blind spot **pre-existed on the file path**; this PR had extended it to directory jobs, which `remove_outputs`' unconditional `os.remove` was covering. The fix closes both.
- **An authorized overwrite always clears the output's verification record**, even when the sweep removed nothing. If something else deleted the prior output while the job sat queued, the record would survive and report the freshly built, unverified artifact as verified. This also drops the `removed` bookkeeping and restores the old directory branch's semantics.

Blocking stat/unlink work — including target *enumeration*, which probes `.0`/`.1`/… on disk — now happens in a single threadpool hop. The old directory branch did this; the file branch didn't.

## Testing

- Full suite: **1223 passed, 1 skipped** (12 new). `ruff check .` clean. Markdown lint unchanged from baseline. Codacy: 0 issues.
- New `tests/test_tool_seams_generalized.py` pins each hook against a **synthetic second tool** — a fake directory tool, a gated non-`nsz` tool, a `.foo`→`.bar` `ChainSpec`. That's the point: asserting on the single existing instance passes under both the old and new code, so it would not catch a regression back to an id/kind branch. The directory test gives its fake tool a `.sidecar` companion and plants a stray `.iso.0`, then asserts the sidecar is swept and the stray is *not* — which fails against the old implementation.
- Plus regression tests for both refinements: a dangling symlink on a `folder_to_iso` output, and an overwrite whose target vanished before the sweep.
- One existing test needed a `verification_store.clear` stub it previously didn't reach, matching its sibling PS3 test; its behavioral assertion is unchanged.

## Docs

`docs/DESIGN_tool_plugin_architecture.md` gets both hooks in the `ToolPlugin` contract and `BaseTool` defaults, a rewritten overwrite bullet in §3.3.4, and a new "Tool availability" subsection under §3.5. Changelog entry in `docs/RELEASE_NOTES.md`.

**Sequencing:** #253 documents the first two spots as things a contributor must generalize *before* adding such a tool. Once this merges those warnings should become "use hook X" — I'll push that follow-up to #253, in whichever order they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014WasQD562Uwg9nJg7AXSrk