### PR TITLE
docs: cut 4.3.0 release notes and open 4.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # Compressatorium — game-image converter (web UI + headless CLI)
 
-A FastAPI + Svelte app that wraps eight conversion tools — CHDMAN, dolphin-tool,
-z3ds, nsz, maxcso, 7z, makeps3iso, and nkit2iso — behind one tool-plugin
-architecture.
+A FastAPI + Svelte app that wraps nine conversion tools — CHDMAN, dolphin-tool,
+z3ds, nsz, maxcso, 7z, makeps3iso, nkit2iso, and jwud (JWUDTool) — behind one
+tool-plugin architecture.
 Operational runbook for agents: `AGENTS.md`. Tool plugins and shared
 infrastructure: `docs/DESIGN_tool_plugin_architecture.md`. **Adding a tool or a
 platform/mode: `docs/ADDING_PLATFORMS_AND_TOOLS.md`** — the step-by-step

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,9 +1,12 @@
 # Release Notes
 
-## Unreleased
+## 4.4.0 (unreleased)
 
-Idempotency, robustness, determinism, and modularity hardening (issues #184, #183
-and #179, part of the #177 tech-debt epic).
+A file-list release for large libraries. Selecting a whole platform folder no
+longer means ticking the header checkbox once per page — 2,000+ discs spread over
+80-odd pages is a single click — and how many rows a page shows is finally yours
+to set. Both work under every tool and mode, inside archives, and across **Search
+all** results. Sections are newest-first.
 
 ### Added
 
@@ -52,7 +55,34 @@ and #179, part of the #177 tech-debt epic).
   off a hash of the whole folder just by looking at it. Selecting everything no
   longer needs a giant page anyway, now that Select all spans pages.
 
-- **Wii U support: a new eighth tool, `jwud` (JWUDTool), converting `.wud` ↔
+### Fixed
+
+- **Shift-click no longer breaks after the page shrinks.** The shift-click range
+  anchor was an index into the page you were on, but nothing kept it inside the
+  page actually on screen. Walk to a shorter last page (or narrow the extension
+  filter, or re-sort) and the next shift-click ran off the end of the row list and
+  threw, swallowing the click. The anchor is now clamped to the current page, so
+  the range simply stops at its end. Changing rows-per-page additionally starts a
+  fresh range, since repagination re-cuts the page and extending from a row picked
+  under a different layout is surprising even when it happens to be in bounds.
+
+## 4.3.0 (2026-08-09)
+
+Two new tools take the roster to nine, and the tech-debt epic lands. **NKit → ISO**
+(`nkit2iso`) restores an NKit-shrunk GameCube or Wii disc to a playable `.iso`,
+with a one-step `nkit_to_rvz` pipeline and a synthesized NKit info endpoint; and
+**Wii U** (`jwud`) converts `.wud` ↔ `.wux`, exploiting the fact that every Wii U
+image is the same 25 GB however much of the disc a game actually uses. Alongside
+them: opt-in token authentication for the networked UI and `/api` routes, README
+screenshots that regenerate themselves in CI, and the bulk of the #177 tech-debt
+epic — idempotency, determinism, and modularity hardening (issues #184, #183, #186
+and #179) that turned several per-tool branches into plugin hooks, made extension
+matching compound-aware, and put every tool on one shared subprocess loop.
+Sections are newest-first.
+
+### Added
+
+- **Wii U support: a new ninth tool, `jwud` (JWUDTool), converting `.wud` ↔
   `.wux`.** Every Wii U disc image is exactly 25,025,314,816 bytes regardless of
   how much of the disc a game uses, so the padding compresses dramatically: WUX
   deduplicates repeated 32 KiB sectors and stores each distinct one once, and


### PR DESCRIPTION
Cuts the release notes that were never written for 4.3.0, and opens 4.4.0 for the work that landed after it.

## What was wrong

`RELEASE_NOTES.md` carried a single `## Unreleased` section holding **two releases' worth** of work, so the file stopped at `## 4.2.0` while `package.json` read `4.3.0`. The `v4.3.0` tag (`0b1077c`, 2026-08-09) had already shipped almost everything in that section — nkit2iso, jwud/Wii U, opt-in auth, automated screenshots, and the bulk of the #177 tech-debt epic — it just never got a version heading.

## The split

The section is cut at the tag boundary, verified with `git merge-base --is-ancestor` rather than by eye:

- **`## 4.3.0 (2026-08-09)`** — everything contained in the tag, dated to the tag's own commit, with a lead paragraph in the style of the 4.2.0 / 4.1.0 leads.
- **`## 4.4.0 (unreleased)`** — the three commits that came after it: the cross-page **Select all** and the **rows-per-page** picker (#259).

Only three commits exist after `v4.3.0` — the `package.json` sync, #259, and a screenshots refresh — so the 4.4.0 section is exactly #259's user-facing surface.

### On the Fixed entry

4.4.0 gets one `### Fixed` bullet, for the shift-click range-anchor crash. #259 fixed three bugs, but the other two were introduced *and* fixed inside that branch and never reached a released build, so they're deliberately left out. The anchor crash is different: it was reachable in 4.3.0 without any of the new UI — walking to a shorter last page was enough — so it's a genuine user-facing fix and belongs in the notes.

## Corrected in passing

The jwud entry described it as **"a new eighth tool"**. The registry carries nine (`chdman`, `dolphin`, `z3ds`, `nsz`, `cso`, `romz`, `makeps3iso`, `nkit`, `jwud`) — nkit2iso was the eighth and jwud the ninth, as PR #256's own title says. Both tools landed in the same cycle, which is presumably how the count slipped.

`CLAUDE.md`'s summary line had the same stale count and omitted `jwud` from its list entirely. `README.md` and `docs/DESIGN_tool_plugin_architecture.md` already said nine, so `CLAUDE.md` was the odd one out. **This is the one change outside the release notes** — a one-line doc sync, easy to drop if you'd rather keep it separate.

## Version handling

`package.json` deliberately stays at `4.3.0`. The repo's flow tags first and syncs the version after (`57b8f85 chore: sync package.json to v4.3.0 [skip ci]` follows the tag), so the bump belongs to whoever cuts 4.4.0, not to this commit. `tests/test_version_ssot.py` only couples `package.json` to the served version and asserts nothing about the notes' headings, so nothing here disturbs it.

4.4.0 is the right number: #259 adds features and breaks nothing, so it's a minor bump under the versioning this project already follows.

---
_Generated by [Claude Code](https://claude.ai/code/session_0187fF5QFqj9tyDkx328trjM)_