### PR TITLE
Report status for every tool, and never wait on a child process unbounded (#263)

### DIFF
--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -27,7 +27,6 @@ from utils.path_utils import (
     get_volume_name_for_path,
     is_configured_volume_root,
     is_within_configured_volumes,
-    match_extension,
 )
 
 router = APIRouter()

--- a/app/services/chdman.py
+++ b/app/services/chdman.py
@@ -207,7 +207,7 @@ class ChdmanService:
                             line = part.strip()
                             if line:
                                 output_lines.append(line)
-                                progress = self._parse_progress(line)
+                                progress = self._parse_progress(line) or 0
                                 yield {
                                     "type": "progress",
                                     "progress": progress,
@@ -220,7 +220,7 @@ class ChdmanService:
                             line = part.strip()
                             if line:
                                 output_lines.append(line)
-                                progress = self._parse_progress(line)
+                                progress = self._parse_progress(line) or 0
                                 yield {
                                     "type": "progress",
                                     "progress": progress,
@@ -233,7 +233,7 @@ class ChdmanService:
             if buffer.strip():
                 line = buffer.strip()
                 output_lines.append(line)
-                progress = self._parse_progress(line)
+                progress = self._parse_progress(line) or 0
                 yield {"type": "progress", "progress": progress, "message": line}
 
             await process.wait()
@@ -280,13 +280,20 @@ class ChdmanService:
             # The process has already exited or no longer exists; nothing left to terminate.
             pass
 
-    def _parse_progress(self, line: str) -> int:
-        """Parse chdman output for progress percentage."""
+    def _parse_progress(self, line: str) -> int | None:
+        """Parse chdman output for progress percentage, None if the line has none.
+
+        None -- not 0 -- for a non-progress line (a banner, a status message).
+        The runner reads "a percent was parsed" as proof the tool reports its own
+        progress and stands its size-growth fallback down; a 0 sentinel made the
+        very first banner line look like a report and disabled the fallback for
+        the whole run (issue #263).
+        """
         # chdman outputs: "Compressing, 45.2% complete..."
         match = re.search(r"(\d+(?:\.\d+)?)\s*%", line)
         if match:
             return min(99, int(float(match.group(1))))
-        return 0
+        return None
 
     def _parse_info(self, output: str) -> dict:
         """Parse chdman info output into structured data."""

--- a/app/services/chdman.py
+++ b/app/services/chdman.py
@@ -99,6 +99,7 @@ class ChdmanService:
             parse_progress=self._parse_progress,
             cancel_event=cancel_event,
             fail_label="chdman",
+            mode=mode,
         ):
             yield update
 

--- a/app/services/dolphin_tool.py
+++ b/app/services/dolphin_tool.py
@@ -114,6 +114,7 @@ class DolphinToolService:
             cancel_event=cancel_event,
             heartbeat=True,
             fail_label="dolphin-tool",
+            mode=mode,
         ):
             yield update
 

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1507,6 +1507,14 @@ class JobManager:
         Jobs in the verify phase are exempt. Verification emits no progress and
         legitimately runs for many minutes on a large image, so warning on it
         would report healthy work as stalled.
+
+        Deliberately touches no filesystem. Running at the default log level
+        means running for every processing job on every heartbeat, and the mount
+        this is meant to report on is precisely the one where ``stat`` blocks in
+        uninterruptible I/O -- which would freeze the event loop it is diagnosing.
+        ``idle_for`` comes from the in-memory progress clock, and the job message
+        already carries bytes written and rate for tools using the size-growth
+        fallback.
         """
         if settings.debug_progress_timeout <= 0:
             return
@@ -1514,40 +1522,26 @@ class JobManager:
         for job in list(self.jobs.values()):
             if job.status != JobStatus.PROCESSING or job.id in self._verifying:
                 continue
-            output_size = None
-            output_idle = None
-            if job.output_path and os.path.exists(job.output_path):
-                try:
-                    output_size = os.path.getsize(job.output_path)
-                except OSError:
-                    output_size = None
-                if output_size is not None:
-                    last_size = self._last_output_size.get(job.id)
-                    last_size_at = self._last_output_size_at.get(job.id, now)
-                    if last_size is None or output_size != last_size:
-                        self._last_output_size[job.id] = output_size
-                        self._last_output_size_at[job.id] = now
-                    else:
-                        output_idle = now - last_size_at
             last_progress = self._last_progress_at.get(job.id, now)
             idle_for = now - last_progress
             if idle_for < settings.debug_progress_timeout:
                 continue
-            last_stall = self._last_stall_log_at.get(job.id, 0)
-            if now - last_stall < settings.debug_progress_timeout:
+            # None, not 0, for "never logged": monotonic() counts from boot, so
+            # a 0 sentinel reads as "logged at boot" and suppressed the first
+            # warning for the first debug_progress_timeout seconds of uptime.
+            last_stall = self._last_stall_log_at.get(job.id)
+            if last_stall is not None and now - last_stall < settings.debug_progress_timeout:
                 continue
             self._last_stall_log_at[job.id] = now
             logger.warning(
                 "Stalled job %s idle=%.1fs progress=%s message=%s input=%s output=%s "
-                "output_size=%s output_idle=%s started_at=%s",
+                "started_at=%s",
                 job.id,
                 idle_for,
                 job.progress,
                 job.message,
                 job.file_path,
                 job.output_path,
-                output_size,
-                output_idle,
                 job.started_at,
             )
 

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -2261,16 +2261,14 @@ class JobManager:
                 if cancel_event.is_set():
                     continue
                 now = time.monotonic()
-                # Only *advancing* progress counts as activity. Several tools
-                # emit a keep-alive every couple of seconds whose message
-                # changes while the percentage does not (dolphin's
-                # "Converting... (Ns)"), and treating each arrival as activity
-                # made this clock unable to distinguish a working job from a
-                # hung one -- which is precisely what the stalled-job warning
-                # reads (issue #263). Output growth advances the percentage via
-                # the runner's size fallback, so a job that is writing still
-                # refreshes this even when its tool prints nothing.
-                if update["progress"] > job.progress:
+                # The runner tells us which updates were real forward movement
+                # (a percentage that advanced, or the output file growing) and
+                # which were keep-alives. Don't re-derive it: counting every
+                # arrival makes a heartbeating-but-hung job look alive, and
+                # counting only percentage changes makes a healthy job look
+                # stalled once the size fallback pins at 95% or when its mode
+                # has no size ratio at all (issue #263).
+                if update.get("activity"):
                     self._last_progress_at[job_id] = now
                 job.progress = update["progress"]
                 job.message = update["message"]

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -113,6 +113,10 @@ class JobManager:
         # it runs (a cancel notification or history prune silently dropped).
         self._background_tasks: Set[asyncio.Task] = set()
         self._delete_plans: Dict[str, Dict[str, object]] = {}
+        # Jobs currently inside the verify phase. Verification emits no progress
+        # and can legitimately run for many minutes, so the stalled-job warning
+        # skips them rather than reporting healthy work as wedged.
+        self._verifying: set[str] = set()
         self._last_progress_at: Dict[str, float] = {}
         self._last_progress_log_at: Dict[str, float] = {}
         self._last_stall_log_at: Dict[str, float] = {}
@@ -1491,6 +1495,62 @@ class JobManager:
 
         return cleanup_counter
 
+    def _log_stalled_jobs(self) -> None:
+        """Warn about a PROCESSING job whose progress has gone quiet.
+
+        Runs at the default log level and *outside* the DEBUG-only heartbeat
+        block: a job wedged mid-conversion is precisely the state `is_stuck()`
+        cannot see -- it bails early on any PROCESSING conversion -- so without
+        this the sole trace of a frozen queue was a debug line nobody would find
+        (issue #263).
+
+        Jobs in the verify phase are exempt. Verification emits no progress and
+        legitimately runs for many minutes on a large image, so warning on it
+        would report healthy work as stalled.
+        """
+        if settings.debug_progress_timeout <= 0:
+            return
+        now = time.monotonic()
+        for job in list(self.jobs.values()):
+            if job.status != JobStatus.PROCESSING or job.id in self._verifying:
+                continue
+            output_size = None
+            output_idle = None
+            if job.output_path and os.path.exists(job.output_path):
+                try:
+                    output_size = os.path.getsize(job.output_path)
+                except OSError:
+                    output_size = None
+                if output_size is not None:
+                    last_size = self._last_output_size.get(job.id)
+                    last_size_at = self._last_output_size_at.get(job.id, now)
+                    if last_size is None or output_size != last_size:
+                        self._last_output_size[job.id] = output_size
+                        self._last_output_size_at[job.id] = now
+                    else:
+                        output_idle = now - last_size_at
+            last_progress = self._last_progress_at.get(job.id, now)
+            idle_for = now - last_progress
+            if idle_for < settings.debug_progress_timeout:
+                continue
+            last_stall = self._last_stall_log_at.get(job.id, 0)
+            if now - last_stall < settings.debug_progress_timeout:
+                continue
+            self._last_stall_log_at[job.id] = now
+            logger.warning(
+                "Stalled job %s idle=%.1fs progress=%s message=%s input=%s output=%s "
+                "output_size=%s output_idle=%s started_at=%s",
+                job.id,
+                idle_for,
+                job.progress,
+                job.message,
+                job.file_path,
+                job.output_path,
+                output_size,
+                output_idle,
+                job.started_at,
+            )
+
     async def _debug_loop(self):
         cleanup_counter = 0
         while self._running:
@@ -1499,6 +1559,10 @@ class JobManager:
 
                 # Handle background maintenance tasks
                 cleanup_counter = await self._handle_background_maintenance(cleanup_counter)
+
+                # Before the DEBUG gate: this warning must reach a default-level
+                # log, not just a debug one.
+                self._log_stalled_jobs()
 
                 if not logger.isEnabledFor(logging.DEBUG):
                     continue
@@ -1590,55 +1654,6 @@ class JobManager:
                         output_size,
                         output_idle,
                     )
-
-                if settings.debug_progress_timeout > 0:
-                    now = time.monotonic()
-                    for job in jobs:
-                        if job.status != JobStatus.PROCESSING:
-                            continue
-                        output_size = None
-                        output_idle = None
-                        if job.output_path and os.path.exists(job.output_path):
-                            try:
-                                output_size = os.path.getsize(job.output_path)
-                            except OSError:
-                                output_size = None
-                            if output_size is not None:
-                                last_size = self._last_output_size.get(job.id)
-                                last_size_at = self._last_output_size_at.get(
-                                    job.id, now
-                                )
-                                if last_size is None or output_size != last_size:
-                                    self._last_output_size[job.id] = output_size
-                                    self._last_output_size_at[job.id] = now
-                                else:
-                                    output_idle = now - last_size_at
-                        last_progress = self._last_progress_at.get(job.id, now)
-                        idle_for = now - last_progress
-                        if idle_for < settings.debug_progress_timeout:
-                            continue
-                        last_stall = self._last_stall_log_at.get(job.id, 0)
-                        if now - last_stall < settings.debug_progress_timeout:
-                            continue
-                        self._last_stall_log_at[job.id] = now
-                        # WARNING, not DEBUG: a job silently wedged mid-conversion
-                        # is the one state `is_stuck()` cannot see (it only fires
-                        # when jobs are queued and *none* are processing), so at
-                        # the default log level this was the sole trace of a
-                        # frozen queue -- and it was invisible (issue #263).
-                        logger.warning(
-                            "Stalled job %s idle=%.1fs progress=%s message=%s input=%s output=%s "
-                            "output_size=%s output_idle=%s started_at=%s",
-                            job.id,
-                            idle_for,
-                            job.progress,
-                            job.message,
-                            job.file_path,
-                            job.output_path,
-                            output_size,
-                            output_idle,
-                            job.started_at,
-                        )
 
                 for pid in chdman_service.active_pids():
                     proc_io_path = f"/proc/{pid}/io"
@@ -2322,9 +2337,13 @@ class JobManager:
                         },
                     )
 
-                    verify_result = await registry.for_mode(job.mode.value).verify(
-                        job.output_path
-                    )
+                    self._verifying.add(job_id)
+                    try:
+                        verify_result = await registry.for_mode(job.mode.value).verify(
+                            job.output_path
+                        )
+                    finally:
+                        self._verifying.discard(job_id)
                     if not verify_result.get("valid"):
                         raise RuntimeError(
                             f"Verification failed: {verify_result.get('message')}"

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -1621,7 +1621,12 @@ class JobManager:
                         if now - last_stall < settings.debug_progress_timeout:
                             continue
                         self._last_stall_log_at[job.id] = now
-                        logger.debug(
+                        # WARNING, not DEBUG: a job silently wedged mid-conversion
+                        # is the one state `is_stuck()` cannot see (it only fires
+                        # when jobs are queued and *none* are processing), so at
+                        # the default log level this was the sole trace of a
+                        # frozen queue -- and it was invisible (issue #263).
+                        logger.warning(
                             "Stalled job %s idle=%.1fs progress=%s message=%s input=%s output=%s "
                             "output_size=%s output_idle=%s started_at=%s",
                             job.id,

--- a/app/services/job_manager.py
+++ b/app/services/job_manager.py
@@ -2077,6 +2077,11 @@ class JobManager:
 
         job.status = JobStatus.PROCESSING
         job.started_at = datetime.now(timezone.utc)
+        # Restart the progress clock at the moment work actually begins. It was
+        # last set when the job was created, so a job that waited in the queue
+        # longer than debug_progress_timeout -- routine on a deep queue -- would
+        # otherwise be reported stalled the instant it started running.
+        self._last_progress_at[job_id] = time.monotonic()
         processing_now = sum(
             1 for candidate in self.jobs.values() if candidate.status == JobStatus.PROCESSING
         )
@@ -2255,10 +2260,20 @@ class JobManager:
             ):
                 if cancel_event.is_set():
                     continue
+                now = time.monotonic()
+                # Only *advancing* progress counts as activity. Several tools
+                # emit a keep-alive every couple of seconds whose message
+                # changes while the percentage does not (dolphin's
+                # "Converting... (Ns)"), and treating each arrival as activity
+                # made this clock unable to distinguish a working job from a
+                # hung one -- which is precisely what the stalled-job warning
+                # reads (issue #263). Output growth advances the percentage via
+                # the runner's size fallback, so a job that is writing still
+                # refreshes this even when its tool prints nothing.
+                if update["progress"] > job.progress:
+                    self._last_progress_at[job_id] = now
                 job.progress = update["progress"]
                 job.message = update["message"]
-                now = time.monotonic()
-                self._last_progress_at[job_id] = now
                 if logger.isEnabledFor(logging.DEBUG):
                     last_log = self._last_progress_log_at.get(job_id, 0)
                     if now - last_log >= settings.debug_progress_interval:

--- a/app/services/jwudtool.py
+++ b/app/services/jwudtool.py
@@ -528,6 +528,7 @@ class JwudToolService:
             complete_message=f"Wii U {verb} complete",
             nice_via_wrapper=True,
             require_output=True,
+            mode=mode,
         ):
             if update.get("progress", 0) >= 100:
                 continue

--- a/app/services/makeps3iso.py
+++ b/app/services/makeps3iso.py
@@ -157,7 +157,7 @@ class MakePs3IsoService:
         self,
         input_path: str,
         output_path: str,
-        mode: str = "folder_to_iso",  # noqa: ARG002 - single-mode tool
+        mode: str = "folder_to_iso",
         *,
         compression: str | None = None,  # noqa: ARG002 - no compression knob
         split: bool = False,
@@ -183,6 +183,7 @@ class MakePs3IsoService:
                 fail_label="makeps3iso",
                 complete_message="ISO build complete",
                 output_growth_paths=growth_paths,
+                mode=mode,
             ):
                 # Hold back the runner's terminal 100% so the readback message
                 # is the final update the job records.

--- a/app/services/maxcso.py
+++ b/app/services/maxcso.py
@@ -35,7 +35,6 @@ from services.subprocess_runner import (
     SubprocessRunner,
     ioprio_prefix,
     nice_prefix,
-    output_size_progress,
     verify_timeout,
 )
 
@@ -91,8 +90,6 @@ MAXCSO_OUTPUT_BY_MODE = {
 }
 
 # Rough output:input size ratios, used only to smooth the progress bar.
-_COMPRESS_RATIO = 0.5    # compressed output is ~50% of the source
-_DECOMPRESS_RATIO = 2.0  # decompressed .iso is ~2x the compressed source
 
 # Compression-effort presets. The UI sends one of these tokens (see the `cso`
 # entry in src/lib/tools/registry.js); each maps to the maxcso trial flags that
@@ -209,25 +206,12 @@ class MaxcsoService:
         # delete a pre-existing output_path, since maxcso has written nothing.
         cmd = self._build_command(input_path, output_path, mode, compression)
 
-        try:
-            input_size = os.path.getsize(input_path)
-        except OSError:
-            input_size = 0
-        ratio = _DECOMPRESS_RATIO if decompress else _COMPRESS_RATIO
-        expected_size = max(1, int(input_size * ratio))
-
-        def _size_progress(size: int) -> dict:
-            return {
-                "progress": output_size_progress(size, expected_size),
-                "message": f"Working... ({size // (1024 * 1024)} MB)",
-            }
-
         yield {"progress": 1, "message": f"Starting CSO {verb}..."}
 
         # maxcso applies nice/ionice as command wrappers in _build_command
         # (nice_via_wrapper) to avoid preexec_fn, and prints no parseable percent
-        # (its TTY bar goes silent on a pipe), so size_progress estimates the bar
-        # from the growing -o file.
+        # (its TTY bar goes silent on a pipe), so the runner's size-growth
+        # fallback reports status from the growing -o file.
         try:
             async for update in self._runner.run(
                 cmd,
@@ -238,7 +222,7 @@ class MaxcsoService:
                 cancel_event=cancel_event,
                 fail_label="maxcso",
                 complete_message=f"CSO {verb} complete",
-                size_progress=_size_progress,
+                mode=mode,
                 nice_via_wrapper=True,
             ):
                 yield update

--- a/app/services/nkit2iso.py
+++ b/app/services/nkit2iso.py
@@ -359,7 +359,7 @@ class Nkit2IsoService:
         self,
         input_path: str,
         output_path: str,
-        mode: str = "nkit_restore",  # noqa: ARG002 - single-mode tool
+        mode: str = "nkit_restore",
         *,
         compression: str | None = None,  # noqa: ARG002 - NKit restore has no codec
         cancel_event: asyncio.Event | None = None,
@@ -390,6 +390,7 @@ class Nkit2IsoService:
                 fail_label="nkit2iso",
                 complete_message="NKit restore complete (CRC32 verified)",
                 require_output=True,
+                mode=mode,
             ):
                 if _NOT_EXACT_MARKER in update.get("message", ""):
                     not_exact = True

--- a/app/services/nsz.py
+++ b/app/services/nsz.py
@@ -33,7 +33,6 @@ from services.subprocess_runner import (
     SubprocessRunner,
     ioprio_prefix,
     nice_prefix,
-    output_size_progress,
     verify_timeout,
 )
 from utils.junk import is_junk_entry
@@ -50,8 +49,6 @@ NSZ_OUTPUT_FORMATS = {
 }
 
 # Rough output:input size ratios, used only to smooth the progress bar.
-_COMPRESS_RATIO = 0.6   # compressed output is ~60% of the source
-_DECOMPRESS_RATIO = 1.7  # decompressed output is ~1.7x the source
 
 # Key filenames nsz/homebrew tools use.
 _KEY_FILENAMES = ("prod.keys", "keys.txt")
@@ -351,25 +348,12 @@ class NszService:
                            env, cancel_event, compression=None) -> AsyncGenerator[dict, None]:
         cmd = self._build_command(input_path, work_dir, mode, compression)
 
-        try:
-            input_size = os.path.getsize(input_path)
-        except OSError:
-            input_size = 0
-        ratio = _DECOMPRESS_RATIO if mode == "nsz_decompress" else _COMPRESS_RATIO
-        expected_size = max(1, int(input_size * ratio))
-
-        def _size_progress(size: int) -> dict:
-            return {
-                "progress": output_size_progress(size, expected_size),
-                "message": f"Working... ({size // (1024 * 1024)} MB)",
-            }
-
         yield {"progress": 1, "message": f"Starting Switch {verb}..."}
 
         # nsz names the file itself inside work_dir, so the runner watches
         # produced_path for growth/stall. nice/ionice are command wrappers in
         # _build_command (nice_via_wrapper) and the private keys-home env is
-        # forwarded; nsz prints no parseable percent, so size_progress drives the
+        # forwarded; nsz prints no parseable percent, so the runner's fallback drives the
         # bar. The terminal 100% is held back — convert() emits it after the
         # os.replace onto the real output_path. require_output makes the runner
         # raise (with the stdout tail) when nsz exits 0 but leaves no produced
@@ -383,7 +367,7 @@ class NszService:
             cancel_event=cancel_event,
             fail_label="nsz",
             complete_message=f"Switch {verb} complete",
-            size_progress=_size_progress,
+            mode=mode,
             nice_via_wrapper=True,
             env=env,
             require_output=True,

--- a/app/services/romz.py
+++ b/app/services/romz.py
@@ -432,6 +432,7 @@ class RomzService:
                 cwd=run_cwd,
                 fail_label="7z",
                 complete_message=complete_message,
+                mode=mode,
             ):
                 yield update
             if mode == ROMZ_EXTRACT_MODE:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -473,6 +473,9 @@ class SubprocessRunner:
         # error fires, the subprocess, the cancel-watcher task and the PID entry
         # are always cleaned up rather than leaked.
         cancel_task = None
+        # Bound before the try: the finally cancels this, so an early failure
+        # must not hit an unbound name and mask the real error.
+        size_probe: asyncio.Task | None = None
         try:
             if self._logger.isEnabledFor(logging.DEBUG):
                 self._logger.debug(
@@ -480,7 +483,8 @@ class SubprocessRunner:
                     self._owner, process.pid, " ".join(cmd),
                 )
 
-            stall_timeout = compute_progress_stall_timeout(
+            stall_timeout = await run_in_threadpool(
+                compute_progress_stall_timeout,
                 input_path=input_path,
                 base_timeout=getattr(settings, "progress_timeout", 0),
                 timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
@@ -535,7 +539,8 @@ class SubprocessRunner:
             expected_size = 0
             if ratio:
                 try:
-                    expected_size = max(1, int(os.path.getsize(input_path) * ratio))
+                    input_size = await run_in_threadpool(os.path.getsize, input_path)
+                    expected_size = max(1, int(input_size * ratio))
                 except OSError:
                     expected_size = 0
 
@@ -545,7 +550,9 @@ class SubprocessRunner:
                     if len(output_lines) > 30:
                         output_lines.pop(0)
 
-            def _measure_output() -> int | None:
+            probed_size: int | None = None
+
+            def _measure_output_sync() -> int | None:
                 # Summed size of the growth-probe target(s). Default is the
                 # single output_path; output_growth_paths widens it to a set
                 # whose total grows monotonically even as filenames change
@@ -563,6 +570,29 @@ class SubprocessRunner:
                     except OSError:
                         continue
                 return total if found else None
+
+            def _measure_output() -> int | None:
+                """Most recent output size, measured off the event loop.
+
+                ``getsize`` on an unresponsive mount blocks in uninterruptible
+                I/O, and inline that would freeze the entire event loop --
+                including the stall watchdog and the ``reap()`` ladder that exist
+                to rescue exactly this situation (issue #263). So the probe runs
+                in a worker thread and is *never awaited*: each tick reads the
+                last completed measurement and kicks off the next. Single-flight,
+                so a wedged mount costs one blocked thread for the life of the
+                job rather than one per tick. The cost is that the size is one
+                tick (~2s) stale, which no consumer here cares about.
+                """
+                nonlocal size_probe, probed_size
+                if size_probe is None or size_probe.done():
+                    if size_probe is not None and not size_probe.cancelled():
+                        with contextlib.suppress(Exception):
+                            probed_size = size_probe.result()
+                    size_probe = asyncio.ensure_future(
+                        run_in_threadpool(_measure_output_sync)
+                    )
+                return probed_size
 
             def _update_output_activity(now: float):
                 nonlocal last_output_size, last_activity_at
@@ -763,6 +793,8 @@ class SubprocessRunner:
             yield {"progress": 100, "message": complete_message}
         finally:
             self.untrack_pid(process.pid)
+            if size_probe is not None and not size_probe.done():
+                size_probe.cancel()
             if cancel_task:
                 cancel_task.cancel()
                 try:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -625,6 +625,9 @@ class SubprocessRunner:
                         output_lines.pop(0)
 
             probed_size: int | None = None
+            # Whether any probe has ever finished. Distinguishes "no measurement
+            # yet" from "measured, and there is no output file".
+            probe_completed = False
 
             def _measure_output_sync() -> int | None:
                 # Summed size of the growth-probe target(s). Default is the
@@ -658,9 +661,10 @@ class SubprocessRunner:
                 job rather than one per tick. The cost is that the size is one
                 tick (~2s) stale, which no consumer here cares about.
                 """
-                nonlocal size_probe, probed_size
+                nonlocal size_probe, probed_size, probe_completed
                 if size_probe is None or size_probe.done():
                     if size_probe is not None and not size_probe.cancelled():
+                        probe_completed = True
                         with contextlib.suppress(Exception):
                             probed_size = size_probe.result()
                     size_probe = asyncio.ensure_future(
@@ -725,6 +729,14 @@ class SubprocessRunner:
                 if stall_timeout <= 0:
                     return False
                 _update_output_activity(now)
+                if not probe_completed:
+                    # No growth measurement has landed yet: the probe is off the
+                    # event loop and read one tick later, so the very first
+                    # checks have nothing to judge by. Never call a stall on the
+                    # absence of a measurement -- with a stall timeout shorter
+                    # than the ~2s probe cadence that would kill a converter
+                    # whose output is growing steadily.
+                    return False
                 if now - last_activity_at < stall_timeout:
                     return False
                 stall_error = (

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import logging
 import os
 import shutil
@@ -40,7 +41,6 @@ from collections.abc import AsyncGenerator, Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 
 from config import settings
-from fastapi.concurrency import run_in_threadpool
 from services.timeout_policy import compute_progress_stall_timeout
 
 
@@ -48,14 +48,28 @@ class ConversionCancelled(Exception):
     """Raised when a conversion is cancelled before completion."""
 
 
-# Output-size probes run here rather than on the default threadpool. A `stat`
-# wedged in uninterruptible I/O cannot be cancelled -- Python can abandon the
-# future but not the OS thread -- so on a dead mount every job would strand one
-# worker forever and a deep queue would drain the shared pool, taking down every
-# other `run_in_threadpool` caller with it. A small dedicated pool caps that
-# damage: once these workers are stuck, further probes simply never run and the
-# size signal goes quiet, which the callers already handle as "no new sample".
-_SIZE_PROBE_POOL = ThreadPoolExecutor(max_workers=2, thread_name_prefix="size-probe")
+# Hard bound on a filesystem probe taken on the spawn path, where there is no
+# stall loop yet to rescue a wait that never returns.
+_STAT_TIMEOUT = 10.0
+
+
+async def _bounded_probe(pool: ThreadPoolExecutor, func, *args, **kwargs):
+    """Run a blocking filesystem probe with a hard bound. None on timeout/error.
+
+    A ``stat`` on an unresponsive mount blocks in uninterruptible I/O and cannot
+    be cancelled -- Python can abandon the future but never the OS thread. So a
+    probe is bounded in time and its thread is simply written off if it never
+    comes back; the caller continues without that measurement rather than
+    waiting on it, which is the whole point of issue #263.
+    """
+    loop = asyncio.get_running_loop()
+    try:
+        return await asyncio.wait_for(
+            loop.run_in_executor(pool, functools.partial(func, *args, **kwargs)),
+            timeout=_STAT_TIMEOUT,
+        )
+    except (asyncio.TimeoutError, OSError):
+        return None
 
 
 # Bounds on reaping a subprocess: how long to let it exit on its own once its
@@ -456,9 +470,37 @@ class SubprocessRunner:
         rather than a bare "no output" message. Used by nsz, whose ``output_path``
         is the temp file the runner already watches.
         """
+        # One probe worker per run, deliberately not a shared pool. A filesystem
+        # call wedged in uninterruptible I/O occupies its thread forever, so a
+        # shared pool would let two bad mounts starve every later job of the
+        # growth signal -- and a healthy job with no native percentage would then
+        # be killed by the stall watchdog while writing perfectly well. Per-run
+        # isolation means a dead mount costs one abandoned thread for that job
+        # and nothing for the next.
+        probe_pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="size-probe")
+
         output_dir = os.path.dirname(output_path)
         if output_dir:
-            await run_in_threadpool(os.makedirs, output_dir, exist_ok=True)
+            # Bounded like every other filesystem call here: an unresponsive
+            # output mount must fail this job, not hang it -- and hanging here,
+            # before the child exists, would freeze the whole queue behind it
+            # (issue #263).
+            try:
+                await asyncio.wait_for(
+                    asyncio.get_running_loop().run_in_executor(
+                        probe_pool,
+                        functools.partial(os.makedirs, output_dir, exist_ok=True),
+                    ),
+                    timeout=_STAT_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                probe_pool.shutdown(wait=False)
+                raise RuntimeError(
+                    f"{fail_label}: output directory {output_dir} stopped responding"
+                ) from None
+            except BaseException:
+                probe_pool.shutdown(wait=False)
+                raise
 
         def _preexec():
             apply_nice(self._owner)
@@ -490,7 +532,7 @@ class SubprocessRunner:
         # error fires, the subprocess, the cancel-watcher task and the PID entry
         # are always cleaned up rather than leaked.
         cancel_task = None
-        # Bound before the try: the finally cancels this, so an early failure
+        # Bound before the try: the finally tears these down, so an early failure
         # must not hit an unbound name and mask the real error.
         size_probe: asyncio.Task | None = None
         try:
@@ -500,13 +542,20 @@ class SubprocessRunner:
                     self._owner, process.pid, " ".join(cmd),
                 )
 
-            stall_timeout = await run_in_threadpool(
+            # Sizing the adaptive stall timeout stats the input. On a dead
+            # mount that must not hang the spawn path, so fall back to the
+            # non-adaptive baseline rather than waiting -- a watchdog with a
+            # rough bound beats no watchdog.
+            stall_timeout = await _bounded_probe(
+                probe_pool,
                 compute_progress_stall_timeout,
                 input_path=input_path,
                 base_timeout=getattr(settings, "progress_timeout", 0),
                 timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
                 timeout_cap=getattr(settings, "progress_timeout_cap", 0),
             )
+            if stall_timeout is None:
+                stall_timeout = max(0, int(getattr(settings, "progress_timeout", 0) or 0))
             # Seed the progress floor with the caller's preamble (e.g. the
             # service's "Starting..." yield at 1/5%) so an early non-parseable
             # stdout line — which emits last_progress_value — can't drop the bar
@@ -557,11 +606,12 @@ class SubprocessRunner:
             ratio = size_ratio_for(mode)
             expected_size = 0
             if ratio:
-                try:
-                    input_size = await run_in_threadpool(os.path.getsize, input_path)
+                # Unbounded here would hang the job after the child is already
+                # running, with no stall loop yet to end it. No sample just means
+                # no percentage; the bytes/rate message needs no ratio.
+                input_size = await _bounded_probe(probe_pool, os.path.getsize, input_path)
+                if input_size is not None:
                     expected_size = max(1, int(input_size * ratio))
-                except OSError:
-                    expected_size = 0
 
             def _record_line(line: str) -> None:
                 if not output_lines or output_lines[-1] != line:
@@ -610,7 +660,7 @@ class SubprocessRunner:
                             probed_size = size_probe.result()
                     size_probe = asyncio.ensure_future(
                         asyncio.get_running_loop().run_in_executor(
-                            _SIZE_PROBE_POOL, _measure_output_sync,
+                            probe_pool, _measure_output_sync,
                         )
                     )
                 return probed_size
@@ -828,6 +878,9 @@ class SubprocessRunner:
             self.untrack_pid(process.pid)
             if size_probe is not None and not size_probe.done():
                 size_probe.cancel()
+            # wait=False: never join. A wedged probe thread is abandoned with the
+            # executor rather than holding the job open behind it.
+            probe_pool.shutdown(wait=False)
             if cancel_task:
                 cancel_task.cancel()
                 try:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -47,6 +47,13 @@ class ConversionCancelled(Exception):
     """Raised when a conversion is cancelled before completion."""
 
 
+# Bounds on reaping a subprocess: how long to let it exit on its own once its
+# output stream closes, then the SIGTERM and SIGKILL grace periods.
+_EXIT_GRACE = 60.0
+_TERM_GRACE = 5.0
+_KILL_GRACE = 10.0
+
+
 # --- Shared process-priority / timeout policy -----------------------------
 #
 # These knobs (nice level, I/O priority, info/verify timeouts) govern *every*
@@ -146,6 +153,50 @@ def _split_stream_lines(buffer: str) -> tuple[list[str], str]:
     return [s.strip() for s in segments[:-1] if s.strip()], remainder
 
 
+# Expected output size as a multiple of the input, per conversion mode. The
+# single source of truth for the size-growth progress estimate: one table here
+# rather than a `_COMPRESS_RATIO`/`_DECOMPRESS_RATIO` pair and an
+# `expected_size` closure re-derived inside every tool service. A mode absent
+# from the table still reports status -- it falls back to the bytes-written
+# message, which needs no ratio -- so a new tool is never *required* to add a
+# row, and adding one only sharpens its percentage estimate. The ratio only
+# smooths the bar (see `output_size_progress`), so an approximate value is fine.
+SIZE_RATIOS: dict[str, float] = {
+    # dolphin-tool: RVZ/WIA/GCZ compression, and decompression back to ISO.
+    "dolphin_rvz": 0.5, "dolphin_wia": 0.5, "dolphin_gcz": 0.7,
+    "dolphin_iso": 2.0,
+    # maxcso: PSP/PS2 CSO family.
+    "cso_compress": 0.5, "cso2_compress": 0.5, "zso_compress": 0.5,
+    "dax_compress": 0.5, "cso_decompress": 2.0,
+    # nsz: Switch NSP/XCI <-> NSZ/XCZ.
+    "nsz_compress": 0.6, "nsz_decompress": 1.7,
+    # z3ds: 3DS CIA/3DS <-> Z3DS.
+    "z3ds_compress": 0.5, "z3ds_decompress": 2.0,
+}
+
+
+def size_ratio_for(mode: str | None) -> float | None:
+    """Expected output/input size ratio for ``mode`` (None when unknown)."""
+    return SIZE_RATIOS.get(mode) if mode else None
+
+
+def output_size_message(size: int, started_at: float) -> str:
+    """Status line for a size-growth tick: bytes written and the current rate.
+
+    The shared human-readable half of the size-growth progress signal (the
+    numeric half is :func:`output_size_progress`). A tool that is merely *slow*
+    -- a conversion crawling against a saturated array or a stalled share --
+    must read as slow rather than as indistinguishable from a hang, so the
+    message carries an absolute (MB written) and a derivative (MB/min): the
+    first keeps climbing, the second collapses toward zero. Rate is expressed
+    per minute because the case worth diagnosing is the pathological one, where
+    a per-second figure rounds to ``0.0`` and tells the user nothing.
+    """
+    written_mb = size / (1024 * 1024)
+    elapsed_min = max(time.monotonic() - started_at, 1e-9) / 60.0
+    return f"Working... ({written_mb:,.0f} MB written, {written_mb / elapsed_min:,.1f} MB/min)"
+
+
 def output_size_progress(current: int, expected_size: int) -> int:
     """Estimate a 5-95% progress value from output-file growth.
 
@@ -193,6 +244,57 @@ class SubprocessRunner:
     def active_pids(self) -> list[int]:
         with self._pid_lock:
             return list(self._active_pids)
+
+    async def reap(self, process, *, exit_timeout: float = _EXIT_GRACE) -> bool:
+        """Wait for ``process`` to exit, bounded at every step. True if reaped.
+
+        The shared teardown for every subprocess this module spawns. A child
+        blocked in uninterruptible I/O (``D`` state -- a stalled mount, a drive
+        that stopped answering) does not die on ``SIGTERM`` *or* ``SIGKILL``:
+        the signal is only delivered once the kernel I/O returns, which may be
+        never. A bare ``await process.wait()`` on such a child therefore blocks
+        its job forever, and because ``MAX_CONCURRENT_JOBS=1`` runs jobs inline
+        in the dispatcher, every job queued behind it too (issue #263).
+
+        So each step is bounded and the ladder terminates: wait ``exit_timeout``
+        for a voluntary exit (skipped when 0 -- teardown paths have already
+        stopped reading), then ``SIGTERM`` + grace, then ``SIGKILL`` + grace.
+        Returning ``False`` means the child outlived ``SIGKILL`` and has been
+        abandoned -- it keeps its pipes and one OS process until the kernel
+        unblocks it, which is the unavoidable cost of not hanging the queue.
+        Callers turn that into a failed job.
+        """
+        if process.returncode is not None:
+            return True
+
+        async def _wait(timeout: float) -> bool:
+            if timeout <= 0:
+                return process.returncode is not None
+            try:
+                await asyncio.wait_for(process.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                return False
+            return True
+
+        if await _wait(exit_timeout):
+            return True
+
+        with contextlib.suppress(ProcessLookupError):
+            process.terminate()
+        if await _wait(_TERM_GRACE):
+            return True
+
+        with contextlib.suppress(ProcessLookupError):
+            process.kill()
+        if await _wait(_KILL_GRACE):
+            return True
+
+        self._logger.error(
+            "%s pid=%s survived SIGKILL (likely blocked in uninterruptible I/O); "
+            "abandoning it so the job fails instead of stalling the queue",
+            self._owner, process.pid,
+        )
+        return False
 
     async def run_capture(
         self,
@@ -261,15 +363,9 @@ class SubprocessRunner:
                 cancel_wait.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await cancel_wait
-            if process.returncode is None:
-                try:
-                    process.terminate()
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except asyncio.TimeoutError:
-                    process.kill()
-                    await process.wait()
-                except ProcessLookupError:
-                    pass
+            # exit_timeout=0: nothing is reading the child's output any more, so
+            # go straight to signalling instead of waiting out a voluntary exit.
+            await self.reap(process, exit_timeout=0)
             if not comm.done():
                 comm.cancel()
             # CancelledError is a BaseException, so it is NOT covered by
@@ -294,7 +390,7 @@ class SubprocessRunner:
         complete_message: str = "Conversion complete",
         cwd: str | None = None,
         output_growth_paths: Callable[[], list[str]] | None = None,
-        size_progress: Callable[[int], dict | None] | None = None,
+        mode: str | None = None,
         nice_via_wrapper: bool = False,
         env: Mapping[str, str] | None = None,
         require_output: bool = False,
@@ -316,15 +412,19 @@ class SubprocessRunner:
         makeps3iso ``-s`` renames the base ``.iso`` to ``.iso.0`` and then writes
         ``.iso.1``/…, which the bare ``output_path`` probe would stop seeing.
 
-        ``size_progress(output_size) -> dict | None`` turns the measured output
-        size into a progress update for tools whose CLI prints no parseable
-        percent (its TTY bar goes silent on a pipe): on each output-growth tick
-        the runner calls it and yields its ``{"progress", "message"}``, clamped
-        to never drop below the current floor. ``parse_progress`` still wins when
-        it returns a percent. See :func:`output_size_progress` for the shared
-        estimate. ``initial_progress`` seeds that floor with the caller's preamble
-        (e.g. a service's "Starting..." yield at 1/5%) so an early non-parseable
-        line cannot drop the bar below it.
+        **Every run reports status, with no per-tool wiring.** ``parse_progress``
+        is the preferred signal and always wins: as soon as it returns a real
+        percent, that tool is reporting for itself. When it never does — the
+        common case, since most of these CLIs draw a TTY bar that falls silent
+        on a pipe — the runner falls back to the growing output file, emitting
+        bytes-written and a MB/min rate (:func:`output_size_message`) so a slow
+        job is visibly slow rather than indistinguishable from a hung one. Pass
+        ``mode`` to additionally get a percentage from :data:`SIZE_RATIOS`; a
+        mode absent from that table still gets the message, so a new tool needs
+        no wiring to be observable and a ratio only sharpens the bar.
+        ``initial_progress`` seeds the floor with the caller's preamble (e.g. a
+        service's "Starting..." yield at 1/5%) so an early non-parseable line
+        cannot drop the bar below it.
 
         ``nice_via_wrapper`` skips the ``preexec_fn`` renice when the caller has
         already prefixed ``cmd`` with ``nice``/``ionice`` command wrappers
@@ -427,6 +527,17 @@ class SubprocessRunner:
             buffer = ""
             output_lines: list[str] = []
             stall_error: str | None = None
+            abandoned_error: str | None = None
+            # Native stdout parsing is the preferred signal; the size-growth
+            # fallback below only speaks while this stays False.
+            saw_native_progress = False
+            ratio = size_ratio_for(mode)
+            expected_size = 0
+            if ratio:
+                try:
+                    expected_size = max(1, int(os.path.getsize(input_path) * ratio))
+                except OSError:
+                    expected_size = 0
 
             def _record_line(line: str) -> None:
                 if not output_lines or output_lines[-1] != line:
@@ -463,15 +574,23 @@ class SubprocessRunner:
                     last_activity_at = now
 
             def _size_update(now: float) -> dict | None:
-                # Size-based progress for tools whose CLI prints no parseable
-                # percent (maxcso/nsz/z3ds): on each output-growth tick, refresh
-                # the stall clock, advance the progress floor, and return the
-                # tool's {"progress","message"} update to yield. The emitted
-                # progress is clamped to the floor so a size estimate can never
-                # drop the bar below a higher parsed/seeded value. No-op (returns
-                # None) for every existing caller, which leaves size_progress unset.
+                # Status from output-file growth, the universal fallback for a
+                # tool whose stdout tells us nothing: every conversion writes a
+                # file, so a growing file is a progress signal even when the CLI
+                # prints no parseable percent (its TTY bar goes silent on a pipe)
+                # -- which is most of them. This is what makes a merely *slow*
+                # job legible instead of indistinguishable from a hung one
+                # (issue #263).
+                #
+                # Native parsing wins whenever it works: once a real percent has
+                # been parsed, that tool is reporting for itself and the fallback
+                # stands down rather than fighting it for the message line. A
+                # percentage is emitted only for a mode with a known size ratio;
+                # otherwise the bar holds at its floor and the message alone
+                # carries the news, which needs no ratio and so costs a new tool
+                # no wiring at all.
                 nonlocal last_output_size, last_activity_at, last_progress_value
-                if size_progress is None:
+                if saw_native_progress:
                     return None
                 size = _measure_output()
                 if size is None:
@@ -480,15 +599,16 @@ class SubprocessRunner:
                     return None
                 last_output_size = size
                 last_activity_at = now
-                update = size_progress(size)
-                if update is not None:
-                    pct = update.get("progress")
-                    if isinstance(pct, int):
-                        if pct < last_progress_value:
-                            update = {**update, "progress": last_progress_value}
-                        elif pct > last_progress_value:
-                            last_progress_value = pct
-                return update
+                progress = last_progress_value
+                if expected_size:
+                    # Clamped to the floor: an estimate must never walk the bar
+                    # backward from a higher seeded value.
+                    progress = max(progress, output_size_progress(size, expected_size))
+                    last_progress_value = progress
+                return {
+                    "progress": progress,
+                    "message": output_size_message(size, start),
+                }
 
             async def _check_stall(now: float) -> bool:
                 nonlocal stall_error
@@ -533,6 +653,11 @@ class SubprocessRunner:
                     update = _size_update(now)
                     if update is not None:
                         yield update
+                        # A size update carries strictly more than the generic
+                        # heartbeat (bytes and a rate, not just elapsed seconds),
+                        # so it stands in for one rather than being overwritten
+                        # by one on the same tick.
+                        last_heartbeat_at = now
                     if await _check_stall(now):
                         break
                     if heartbeat and now - last_heartbeat_at >= 2:
@@ -553,9 +678,11 @@ class SubprocessRunner:
                     _record_line(line)
                     now = time.monotonic()
                     progress = parse_progress(line)
-                    if progress is not None and progress > last_progress_value:
-                        last_progress_value = progress
-                        last_activity_at = now
+                    if progress is not None:
+                        saw_native_progress = True
+                        if progress > last_progress_value:
+                            last_progress_value = progress
+                            last_activity_at = now
                     # Clamp to the running floor (incl. initial_progress) so a
                     # parsed value below it can't move the bar backward.
                     yield {"progress": last_progress_value, "message": line}
@@ -571,16 +698,23 @@ class SubprocessRunner:
                 _record_line(line)
                 now = time.monotonic()
                 progress = parse_progress(line)
-                if progress is not None and progress > last_progress_value:
-                    last_progress_value = progress
-                    last_activity_at = now
+                if progress is not None:
+                    saw_native_progress = True
+                    if progress > last_progress_value:
+                        last_progress_value = progress
+                        last_activity_at = now
                 yield {"progress": last_progress_value, "message": line}
                 update = _size_update(time.monotonic())
                 if update is not None:
                     yield update
                 await _check_stall(time.monotonic())
 
-            await process.wait()
+            if not await self.reap(process):
+                abandoned_error = (
+                    f"{fail_label} did not exit and could not be killed "
+                    f"(pid {process.pid}); it is likely blocked on unresponsive "
+                    "storage. Abandoning it so the queue can continue."
+                )
             if self._logger.isEnabledFor(logging.DEBUG):
                 self._logger.debug(
                     "%s pid=%s exit=%s", self._owner, process.pid, process.returncode,
@@ -596,6 +730,11 @@ class SubprocessRunner:
             # is valid and must not be deleted as a false cancellation.
             if cancelled_by_request:
                 raise ConversionCancelled("Conversion cancelled")
+
+            # Nothing below can be trusted for an abandoned child: it has no
+            # return code and never will.
+            if abandoned_error:
+                raise RuntimeError(abandoned_error)
 
             if process.returncode != 0:
                 tail = "\n".join(output_lines[-6:])
@@ -630,12 +769,6 @@ class SubprocessRunner:
                     await cancel_task
                 except asyncio.CancelledError:
                     pass
-            if process.returncode is None:
-                try:
-                    process.terminate()
-                    await asyncio.wait_for(process.wait(), timeout=5)
-                except asyncio.TimeoutError:
-                    process.kill()
-                    await process.wait()
-                except ProcessLookupError:
-                    pass
+            # exit_timeout=0: nothing is reading the child's output any more, so
+            # go straight to signalling instead of waiting out a voluntary exit.
+            await self.reap(process, exit_timeout=0)

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -123,6 +123,14 @@ _FIRST_SAMPLE_GRACE = 6.0
 # whose responsiveness is in question.
 _PROBE_INTERVAL = 2.0
 
+# Floor for the stall timeout. Growth is sampled every _PROBE_INTERVAL and read
+# a tick later, so the detector cannot resolve a window shorter than a few
+# sample periods: below that, "no growth observed" only means "not looked at
+# recently", and a converter writing steadily gets killed for it. Clamped rather
+# than trusted, so no configuration can ask the watchdog for a precision it does
+# not have.
+_MIN_STALL_TIMEOUT = 3 * _PROBE_INTERVAL
+
 _EXIT_GRACE = 60.0
 _TERM_GRACE = 5.0
 _KILL_GRACE = 10.0
@@ -598,6 +606,14 @@ class SubprocessRunner:
                 )
             except asyncio.TimeoutError:
                 stall_timeout = max(0, int(getattr(settings, "progress_timeout", 0) or 0))
+            if 0 < stall_timeout < _MIN_STALL_TIMEOUT:
+                self._logger.warning(
+                    "Stall timeout of %ss is below the %ss sampling floor; using %ss. "
+                    "A shorter window cannot tell a stalled converter from one that "
+                    "simply has not been sampled yet.",
+                    stall_timeout, _MIN_STALL_TIMEOUT, _MIN_STALL_TIMEOUT,
+                )
+                stall_timeout = _MIN_STALL_TIMEOUT
             # Seed the progress floor with the caller's preamble (e.g. the
             # service's "Starting..." yield at 1/5%) so an early non-parseable
             # stdout line — which emits last_progress_value — can't drop the bar

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -37,6 +37,7 @@ import shutil
 import threading
 import time
 from collections.abc import AsyncGenerator, Callable, Mapping
+from concurrent.futures import ThreadPoolExecutor
 
 from config import settings
 from fastapi.concurrency import run_in_threadpool
@@ -45,6 +46,16 @@ from services.timeout_policy import compute_progress_stall_timeout
 
 class ConversionCancelled(Exception):
     """Raised when a conversion is cancelled before completion."""
+
+
+# Output-size probes run here rather than on the default threadpool. A `stat`
+# wedged in uninterruptible I/O cannot be cancelled -- Python can abandon the
+# future but not the OS thread -- so on a dead mount every job would strand one
+# worker forever and a deep queue would drain the shared pool, taking down every
+# other `run_in_threadpool` caller with it. A small dedicated pool caps that
+# damage: once these workers are stuck, further probes simply never run and the
+# size signal goes quiet, which the callers already handle as "no new sample".
+_SIZE_PROBE_POOL = ThreadPoolExecutor(max_workers=2, thread_name_prefix="size-probe")
 
 
 # Bounds on reaping a subprocess: how long to let it exit on its own once its
@@ -180,7 +191,7 @@ def size_ratio_for(mode: str | None) -> float | None:
     return SIZE_RATIOS.get(mode) if mode else None
 
 
-def output_size_message(size: int, started_at: float) -> str:
+def output_size_message(size: int, delta_bytes: int, delta_seconds: float) -> str:
     """Status line for a size-growth tick: bytes written and the current rate.
 
     The shared human-readable half of the size-growth progress signal (the
@@ -188,13 +199,19 @@ def output_size_message(size: int, started_at: float) -> str:
     -- a conversion crawling against a saturated array or a stalled share --
     must read as slow rather than as indistinguishable from a hang, so the
     message carries an absolute (MB written) and a derivative (MB/min): the
-    first keeps climbing, the second collapses toward zero. Rate is expressed
-    per minute because the case worth diagnosing is the pathological one, where
-    a per-second figure rounds to ``0.0`` and tells the user nothing.
+    first keeps climbing, the second collapses toward zero.
+
+    The rate is measured **between consecutive samples**, not as total bytes
+    over total elapsed time. A cumulative average is dominated by whatever the
+    conversion did first: a job that writes gigabytes quickly and then crawls
+    would keep advertising hundreds of MB/min long after it slowed to nothing,
+    destroying the one distinction this line exists to make. Rate is per minute
+    because the case worth diagnosing is the pathological one, where a
+    per-second figure rounds to ``0.0`` and says nothing.
     """
     written_mb = size / (1024 * 1024)
-    elapsed_min = max(time.monotonic() - started_at, 1e-9) / 60.0
-    return f"Working... ({written_mb:,.0f} MB written, {written_mb / elapsed_min:,.1f} MB/min)"
+    per_min = (delta_bytes / (1024 * 1024)) / (max(delta_seconds, 1e-9) / 60.0)
+    return f"Working... ({written_mb:,.0f} MB written, {per_min:,.1f} MB/min)"
 
 
 def output_size_progress(current: int, expected_size: int) -> int:
@@ -497,6 +514,8 @@ class SubprocessRunner:
             last_progress_value = initial_progress
             last_output_size: int | None = None
             last_activity_at = time.monotonic()
+            # Start of the current rate window (last observed growth).
+            last_growth_at = last_activity_at
             start = last_activity_at
             last_heartbeat_at = start
 
@@ -590,7 +609,9 @@ class SubprocessRunner:
                         with contextlib.suppress(Exception):
                             probed_size = size_probe.result()
                     size_probe = asyncio.ensure_future(
-                        run_in_threadpool(_measure_output_sync)
+                        asyncio.get_running_loop().run_in_executor(
+                            _SIZE_PROBE_POOL, _measure_output_sync,
+                        )
                     )
                 return probed_size
 
@@ -620,6 +641,7 @@ class SubprocessRunner:
                 # carries the news, which needs no ratio and so costs a new tool
                 # no wiring at all.
                 nonlocal last_output_size, last_activity_at, last_progress_value
+                nonlocal last_growth_at
                 if saw_native_progress:
                     return None
                 size = _measure_output()
@@ -627,7 +649,10 @@ class SubprocessRunner:
                     return None
                 if last_output_size is not None and size <= last_output_size:
                     return None
+                delta_bytes = size - (last_output_size or 0)
+                delta_seconds = now - last_growth_at
                 last_output_size = size
+                last_growth_at = now
                 last_activity_at = now
                 progress = last_progress_value
                 if expected_size:
@@ -637,7 +662,7 @@ class SubprocessRunner:
                     last_progress_value = progress
                 return {
                     "progress": progress,
-                    "message": output_size_message(size, start),
+                    "message": output_size_message(size, delta_bytes, delta_seconds),
                 }
 
             async def _check_stall(now: float) -> bool:
@@ -739,7 +764,15 @@ class SubprocessRunner:
                     yield update
                 await _check_stall(time.monotonic())
 
-            if not await self.reap(process):
+            # A cancel or a stall already sent TERM (and KILL). Waiting out the
+            # voluntary-exit grace again would hold the queue's only slot for
+            # another minute for no reason, so go straight to the ladder.
+            already_signalled = stall_error is not None or (
+                cancel_event is not None and cancel_event.is_set()
+            )
+            if not await self.reap(
+                process, exit_timeout=0 if already_signalled else _EXIT_GRACE,
+            ):
                 abandoned_error = (
                     f"{fail_label} did not exit and could not be killed "
                     f"(pid {process.pid}); it is likely blocked on unresponsive "

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -53,23 +53,34 @@ class ConversionCancelled(Exception):
 _STAT_TIMEOUT = 10.0
 
 
-async def _bounded_probe(pool: ThreadPoolExecutor, func, *args, **kwargs):
-    """Run a blocking filesystem probe with a hard bound. None on timeout/error.
+async def _bounded_probe(func, *args, **kwargs):
+    """Run a one-shot blocking filesystem call with a hard bound.
+
+    Raises :class:`asyncio.TimeoutError` if it does not finish within
+    :data:`_STAT_TIMEOUT`; every other exception propagates untouched. The
+    timeout is signalled rather than folded into a ``None`` return because some
+    of these calls (``os.makedirs``) return ``None`` on success, and each caller
+    wants a different fallback anyway.
 
     A ``stat`` on an unresponsive mount blocks in uninterruptible I/O and cannot
-    be cancelled -- Python can abandon the future but never the OS thread. So a
-    probe is bounded in time and its thread is simply written off if it never
-    comes back; the caller continues without that measurement rather than
-    waiting on it, which is the whole point of issue #263.
+    be cancelled -- Python can abandon the future but never the OS thread. Each
+    call therefore gets its **own** disposable executor, shut down without
+    joining: a wedged probe writes off exactly one thread and cannot occupy a
+    worker that anything else depends on. Sharing one would let a hung
+    input-side stat starve the continuous output-growth probe, leaving a job
+    whose output is writing perfectly well with no status and no watchdog
+    activity until the stall timeout killed it.
     """
-    loop = asyncio.get_running_loop()
+    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="fs-probe")
     try:
         return await asyncio.wait_for(
-            loop.run_in_executor(pool, functools.partial(func, *args, **kwargs)),
+            asyncio.get_running_loop().run_in_executor(
+                pool, functools.partial(func, *args, **kwargs),
+            ),
             timeout=_STAT_TIMEOUT,
         )
-    except (asyncio.TimeoutError, OSError):
-        return None
+    finally:
+        pool.shutdown(wait=False)
 
 
 # Bounds on reaping a subprocess: how long to let it exit on its own once its
@@ -470,14 +481,11 @@ class SubprocessRunner:
         rather than a bare "no output" message. Used by nsz, whose ``output_path``
         is the temp file the runner already watches.
         """
-        # One probe worker per run, deliberately not a shared pool. A filesystem
-        # call wedged in uninterruptible I/O occupies its thread forever, so a
-        # shared pool would let two bad mounts starve every later job of the
-        # growth signal -- and a healthy job with no native percentage would then
-        # be killed by the stall watchdog while writing perfectly well. Per-run
-        # isolation means a dead mount costs one abandoned thread for that job
-        # and nothing for the next.
-        probe_pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="size-probe")
+        # A worker dedicated to this run's output-growth probe, and to nothing
+        # else. Per-run so one dead mount cannot starve later jobs of the growth
+        # signal; exclusive to growth probing so a hung input-side stat cannot
+        # either. A wedged probe costs this one thread, abandoned at teardown.
+        growth_pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="growth-probe")
 
         output_dir = os.path.dirname(output_path)
         if output_dir:
@@ -486,21 +494,11 @@ class SubprocessRunner:
             # before the child exists, would freeze the whole queue behind it
             # (issue #263).
             try:
-                await asyncio.wait_for(
-                    asyncio.get_running_loop().run_in_executor(
-                        probe_pool,
-                        functools.partial(os.makedirs, output_dir, exist_ok=True),
-                    ),
-                    timeout=_STAT_TIMEOUT,
-                )
+                await _bounded_probe(os.makedirs, output_dir, exist_ok=True)
             except asyncio.TimeoutError:
-                probe_pool.shutdown(wait=False)
                 raise RuntimeError(
                     f"{fail_label}: output directory {output_dir} stopped responding"
                 ) from None
-            except BaseException:
-                probe_pool.shutdown(wait=False)
-                raise
 
         def _preexec():
             apply_nice(self._owner)
@@ -535,6 +533,10 @@ class SubprocessRunner:
         # Bound before the try: the finally tears these down, so an early failure
         # must not hit an unbound name and mask the real error.
         size_probe: asyncio.Task | None = None
+        # Set once the ladder has already run and given up, so teardown does not
+        # repeat TERM/KILL on a child known to be unkillable -- that second pass
+        # is another 15s holding the queue's only slot for no possible gain.
+        reap_failed = False
         try:
             if self._logger.isEnabledFor(logging.DEBUG):
                 self._logger.debug(
@@ -546,15 +548,15 @@ class SubprocessRunner:
             # mount that must not hang the spawn path, so fall back to the
             # non-adaptive baseline rather than waiting -- a watchdog with a
             # rough bound beats no watchdog.
-            stall_timeout = await _bounded_probe(
-                probe_pool,
-                compute_progress_stall_timeout,
-                input_path=input_path,
-                base_timeout=getattr(settings, "progress_timeout", 0),
-                timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
-                timeout_cap=getattr(settings, "progress_timeout_cap", 0),
-            )
-            if stall_timeout is None:
+            try:
+                stall_timeout = await _bounded_probe(
+                    compute_progress_stall_timeout,
+                    input_path=input_path,
+                    base_timeout=getattr(settings, "progress_timeout", 0),
+                    timeout_per_gib=getattr(settings, "progress_timeout_per_gib", 0),
+                    timeout_cap=getattr(settings, "progress_timeout_cap", 0),
+                )
+            except asyncio.TimeoutError:
                 stall_timeout = max(0, int(getattr(settings, "progress_timeout", 0) or 0))
             # Seed the progress floor with the caller's preamble (e.g. the
             # service's "Starting..." yield at 1/5%) so an early non-parseable
@@ -609,7 +611,10 @@ class SubprocessRunner:
                 # Unbounded here would hang the job after the child is already
                 # running, with no stall loop yet to end it. No sample just means
                 # no percentage; the bytes/rate message needs no ratio.
-                input_size = await _bounded_probe(probe_pool, os.path.getsize, input_path)
+                try:
+                    input_size = await _bounded_probe(os.path.getsize, input_path)
+                except (asyncio.TimeoutError, OSError):
+                    input_size = None
                 if input_size is not None:
                     expected_size = max(1, int(input_size * ratio))
 
@@ -660,7 +665,7 @@ class SubprocessRunner:
                             probed_size = size_probe.result()
                     size_probe = asyncio.ensure_future(
                         asyncio.get_running_loop().run_in_executor(
-                            probe_pool, _measure_output_sync,
+                            growth_pool, _measure_output_sync,
                         )
                     )
                 return probed_size
@@ -823,6 +828,7 @@ class SubprocessRunner:
             if not await self.reap(
                 process, exit_timeout=0 if already_signalled else _EXIT_GRACE,
             ):
+                reap_failed = True
                 abandoned_error = (
                     f"{fail_label} did not exit and could not be killed "
                     f"(pid {process.pid}); it is likely blocked on unresponsive "
@@ -880,7 +886,7 @@ class SubprocessRunner:
                 size_probe.cancel()
             # wait=False: never join. A wedged probe thread is abandoned with the
             # executor rather than holding the job open behind it.
-            probe_pool.shutdown(wait=False)
+            growth_pool.shutdown(wait=False)
             if cancel_task:
                 cancel_task.cancel()
                 try:
@@ -889,4 +895,5 @@ class SubprocessRunner:
                     pass
             # exit_timeout=0: nothing is reading the child's output any more, so
             # go straight to signalling instead of waiting out a voluntary exit.
-            await self.reap(process, exit_timeout=0)
+            if not reap_failed:
+                await self.reap(process, exit_timeout=0)

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -117,6 +117,12 @@ async def _bounded_probe(func: Callable, *args: object, **kwargs: object) -> obj
 # cannot disable the watchdog.
 _FIRST_SAMPLE_GRACE = 6.0
 
+# Minimum spacing between output-size samples. The read loop turns over once per
+# stdout chunk, so without this a chatty converter would set the probe rate --
+# hundreds of threads and metadata round-trips per second against the very mount
+# whose responsiveness is in question.
+_PROBE_INTERVAL = 2.0
+
 _EXIT_GRACE = 60.0
 _TERM_GRACE = 5.0
 _KILL_GRACE = 10.0
@@ -635,6 +641,7 @@ class SubprocessRunner:
             buffer = ""
             output_lines: list[str] = []
             stall_error: str | None = None
+            last_message = ""
             abandoned_error: str | None = None
             # Native stdout parsing is the preferred signal; the size-growth
             # fallback below only speaks while this stays False.
@@ -659,6 +666,7 @@ class SubprocessRunner:
                         output_lines.pop(0)
 
             probed_size: int | None = None
+            last_probe_at = 0.0
             # Whether any probe has ever finished. Distinguishes "no measurement
             # yet" from "measured, and there is no output file".
             probe_completed = False
@@ -695,12 +703,16 @@ class SubprocessRunner:
                 job rather than one per tick. The cost is that the size is one
                 tick (~2s) stale, which no consumer here cares about.
                 """
-                nonlocal size_probe, probed_size, probe_completed
-                if size_probe is None or size_probe.done():
-                    if size_probe is not None and not size_probe.cancelled():
+                nonlocal size_probe, probed_size, probe_completed, last_probe_at
+                if size_probe is not None and size_probe.done():
+                    if not size_probe.cancelled():
                         probe_completed = True
                         with contextlib.suppress(Exception):
                             probed_size = size_probe.result()
+                    size_probe = None
+                now = time.monotonic()
+                if size_probe is None and now - last_probe_at >= _PROBE_INTERVAL:
+                    last_probe_at = now
                     size_probe = _probe_in_daemon_thread(_measure_output_sync)
                 return probed_size
 
@@ -731,8 +743,6 @@ class SubprocessRunner:
                 # no wiring at all.
                 nonlocal last_output_size, last_activity_at, last_progress_value
                 nonlocal last_growth_at
-                if saw_native_progress:
-                    return None
                 size = _measure_output()
                 if size is None:
                     return None
@@ -743,6 +753,18 @@ class SubprocessRunner:
                 last_output_size = size
                 last_growth_at = now
                 last_activity_at = now
+                if saw_native_progress:
+                    # The tool speaks for itself, so don't replace its status
+                    # line -- but a file that is still growing is still
+                    # liveness, and a native tool can sit on one integer
+                    # percentage for many minutes on a large image. Republish
+                    # the current status carrying the flag so the job manager's
+                    # clock sees it (issue #263).
+                    return {
+                        "progress": last_progress_value,
+                        "message": last_message,
+                        "activity": True,
+                    }
                 progress = last_progress_value
                 if expected_size:
                     # Clamped to the floor: an estimate must never walk the bar
@@ -847,6 +869,7 @@ class SubprocessRunner:
                             advanced = True
                     # Clamp to the running floor (incl. initial_progress) so a
                     # parsed value below it can't move the bar backward.
+                    last_message = line
                     update = {"progress": last_progress_value, "message": line}
                     if advanced:
                         update["activity"] = True
@@ -870,6 +893,7 @@ class SubprocessRunner:
                         last_progress_value = progress
                         last_activity_at = now
                         advanced = True
+                last_message = line
                 update = {"progress": last_progress_value, "message": line}
                 if advanced:
                     update["activity"] = True
@@ -897,6 +921,14 @@ class SubprocessRunner:
             if self._logger.isEnabledFor(logging.DEBUG):
                 self._logger.debug(
                     "%s pid=%s exit=%s", self._owner, process.pid, process.returncode,
+                )
+
+            if abandoned_error:
+                # Abandonment outranks the stall that triggered it: the child is
+                # still alive and still holding its output, which is the part an
+                # operator has to act on.
+                raise RuntimeError(
+                    f"{stall_error} {abandoned_error}" if stall_error else abandoned_error
                 )
 
             if stall_error:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -38,7 +38,6 @@ import shutil
 import threading
 import time
 from collections.abc import AsyncGenerator, Callable, Mapping
-from concurrent.futures import ThreadPoolExecutor
 
 from config import settings
 from services.timeout_policy import compute_progress_stall_timeout
@@ -51,6 +50,39 @@ class ConversionCancelled(Exception):
 # Hard bound on a filesystem probe taken on the spawn path, where there is no
 # stall loop yet to rescue a wait that never returns.
 _STAT_TIMEOUT = 10.0
+
+
+def _probe_in_daemon_thread(func: Callable[[], object]) -> asyncio.Future:
+    """Run a blocking filesystem call on a throwaway daemon thread.
+
+    Deliberately not a ``ThreadPoolExecutor``. Its workers are joined during
+    interpreter shutdown, so a probe wedged on a dead mount would stop the
+    container from restarting cleanly -- and a pooled worker that never returns
+    starves every probe queued behind it. A daemon thread does neither: it holds
+    up nothing at exit and occupies no shared capacity. A call that never
+    returns simply costs one written-off thread that dies with the process,
+    which is the unavoidable price of a syscall Python cannot cancel.
+    """
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+
+    def _settle(setter: Callable, value: object) -> None:
+        if not future.done():
+            setter(value)
+
+    def _worker() -> None:
+        try:
+            result = func()
+        except BaseException as exc:  # noqa: BLE001 - relayed to the awaiter
+            setter, value = future.set_exception, exc
+        else:
+            setter, value = future.set_result, result
+        with contextlib.suppress(RuntimeError):
+            # RuntimeError: the loop closed while this thread was blocked.
+            loop.call_soon_threadsafe(_settle, setter, value)
+
+    threading.Thread(target=_worker, daemon=True, name="fs-probe").start()
+    return future
 
 
 async def _bounded_probe(func: Callable, *args: object, **kwargs: object) -> object:
@@ -71,16 +103,10 @@ async def _bounded_probe(func: Callable, *args: object, **kwargs: object) -> obj
     whose output is writing perfectly well with no status and no watchdog
     activity until the stall timeout killed it.
     """
-    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="fs-probe")
-    try:
-        return await asyncio.wait_for(
-            asyncio.get_running_loop().run_in_executor(
-                pool, functools.partial(func, *args, **kwargs),
-            ),
-            timeout=_STAT_TIMEOUT,
-        )
-    finally:
-        pool.shutdown(wait=False)
+    return await asyncio.wait_for(
+        _probe_in_daemon_thread(functools.partial(func, *args, **kwargs)),
+        timeout=_STAT_TIMEOUT,
+    )
 
 
 # Bounds on reaping a subprocess: how long to let it exit on its own once its
@@ -495,12 +521,6 @@ class SubprocessRunner:
         rather than a bare "no output" message. Used by nsz, whose ``output_path``
         is the temp file the runner already watches.
         """
-        # A worker dedicated to this run's output-growth probe, and to nothing
-        # else. Per-run so one dead mount cannot starve later jobs of the growth
-        # signal; exclusive to growth probing so a hung input-side stat cannot
-        # either. A wedged probe costs this one thread, abandoned at teardown.
-        growth_pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="growth-probe")
-
         output_dir = os.path.dirname(output_path)
         if output_dir:
             # Bounded like every other filesystem call here: an unresponsive
@@ -681,11 +701,7 @@ class SubprocessRunner:
                         probe_completed = True
                         with contextlib.suppress(Exception):
                             probed_size = size_probe.result()
-                    size_probe = asyncio.ensure_future(
-                        asyncio.get_running_loop().run_in_executor(
-                            growth_pool, _measure_output_sync,
-                        )
-                    )
+                    size_probe = _probe_in_daemon_thread(_measure_output_sync)
                 return probed_size
 
             def _update_output_activity(now: float):
@@ -892,6 +908,12 @@ class SubprocessRunner:
             # before cancellation took effect is reported complete — its output
             # is valid and must not be deleted as a false cancellation.
             if cancelled_by_request:
+                if abandoned_error:
+                    # Reporting a clean CANCELLED would be a lie: the child is
+                    # still running and still holding its output.
+                    raise RuntimeError(
+                        f"Cancellation did not stop {fail_label}. {abandoned_error}"
+                    )
                 raise ConversionCancelled("Conversion cancelled")
 
             # Nothing below can be trusted for an abandoned child: it has no
@@ -928,9 +950,6 @@ class SubprocessRunner:
             self.untrack_pid(process.pid)
             if size_probe is not None and not size_probe.done():
                 size_probe.cancel()
-            # wait=False: never join. A wedged probe thread is abandoned with the
-            # executor rather than holding the job open behind it.
-            growth_pool.shutdown(wait=False)
             if cancel_task:
                 cancel_task.cancel()
                 try:

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -53,7 +53,7 @@ class ConversionCancelled(Exception):
 _STAT_TIMEOUT = 10.0
 
 
-async def _bounded_probe(func, *args, **kwargs):
+async def _bounded_probe(func: Callable, *args: object, **kwargs: object) -> object:
     """Run a one-shot blocking filesystem call with a hard bound.
 
     Raises :class:`asyncio.TimeoutError` if it does not finish within
@@ -85,6 +85,12 @@ async def _bounded_probe(func, *args, **kwargs):
 
 # Bounds on reaping a subprocess: how long to let it exit on its own once its
 # output stream closes, then the SIGTERM and SIGKILL grace periods.
+# How long a stall check will wait for the first growth measurement to land
+# before judging without one. Spans a few read-loop ticks: long enough that
+# probe lag cannot fake a stall, short enough that a probe which never returns
+# cannot disable the watchdog.
+_FIRST_SAMPLE_GRACE = 6.0
+
 _EXIT_GRACE = 60.0
 _TERM_GRACE = 5.0
 _KILL_GRACE = 10.0
@@ -729,13 +735,20 @@ class SubprocessRunner:
                 if stall_timeout <= 0:
                     return False
                 _update_output_activity(now)
-                if not probe_completed:
+                if not probe_completed and now - start < _FIRST_SAMPLE_GRACE:
                     # No growth measurement has landed yet: the probe is off the
                     # event loop and read one tick later, so the very first
-                    # checks have nothing to judge by. Never call a stall on the
+                    # checks have nothing to judge by. Don't call a stall on the
                     # absence of a measurement -- with a stall timeout shorter
                     # than the ~2s probe cadence that would kill a converter
                     # whose output is growing steadily.
+                    #
+                    # Bounded by the grace, though: a probe against a dead mount
+                    # never completes, and waiting on it forever would disable
+                    # the watchdog entirely and hang the queue on exactly the
+                    # storage failure this exists to catch. Past the grace the
+                    # check proceeds without a sample, so an unresponsive output
+                    # still stalls out on schedule.
                     return False
                 if now - last_activity_at < stall_timeout:
                     return False

--- a/app/services/subprocess_runner.py
+++ b/app/services/subprocess_runner.py
@@ -470,6 +470,14 @@ class SubprocessRunner:
         ``mode`` to additionally get a percentage from :data:`SIZE_RATIOS`; a
         mode absent from that table still gets the message, so a new tool needs
         no wiring to be observable and a ratio only sharpens the bar.
+        Updates carry ``"activity": True`` when this tick represented real
+        forward movement -- a parsed percentage that advanced, or the output
+        file growing -- and omit it for keep-alives. It is the same signal the
+        stall watchdog runs on, published so callers judging liveness do not
+        have to re-derive it from a proxy: percentage alone stops moving at the
+        fallback's 95% cap and never moves for a mode with no size ratio, and
+        update arrivals alone count heartbeats as progress (issue #263).
+
         ``initial_progress`` seeds the floor with the caller's preamble (e.g. a
         service's "Starting..." yield at 1/5%) so an early non-parseable line
         cannot drop the bar below it.
@@ -728,6 +736,7 @@ class SubprocessRunner:
                 return {
                     "progress": progress,
                     "message": output_size_message(size, delta_bytes, delta_seconds),
+                    "activity": True,
                 }
 
             async def _check_stall(now: float) -> bool:
@@ -813,14 +822,19 @@ class SubprocessRunner:
                     _record_line(line)
                     now = time.monotonic()
                     progress = parse_progress(line)
+                    advanced = False
                     if progress is not None:
                         saw_native_progress = True
                         if progress > last_progress_value:
                             last_progress_value = progress
                             last_activity_at = now
+                            advanced = True
                     # Clamp to the running floor (incl. initial_progress) so a
                     # parsed value below it can't move the bar backward.
-                    yield {"progress": last_progress_value, "message": line}
+                    update = {"progress": last_progress_value, "message": line}
+                    if advanced:
+                        update["activity"] = True
+                    yield update
                 now = time.monotonic()
                 update = _size_update(now)
                 if update is not None:
@@ -833,12 +847,17 @@ class SubprocessRunner:
                 _record_line(line)
                 now = time.monotonic()
                 progress = parse_progress(line)
+                advanced = False
                 if progress is not None:
                     saw_native_progress = True
                     if progress > last_progress_value:
                         last_progress_value = progress
                         last_activity_at = now
-                yield {"progress": last_progress_value, "message": line}
+                        advanced = True
+                update = {"progress": last_progress_value, "message": line}
+                if advanced:
+                    update["activity"] = True
+                yield update
                 update = _size_update(time.monotonic())
                 if update is not None:
                     yield update
@@ -904,7 +923,7 @@ class SubprocessRunner:
                     )
                 raise RuntimeError(f"{fail_label} produced no output file")
 
-            yield {"progress": 100, "message": complete_message}
+            yield {"progress": 100, "message": complete_message, "activity": True}
         finally:
             self.untrack_pid(process.pid)
             if size_probe is not None and not size_probe.done():

--- a/app/services/tools/chain.py
+++ b/app/services/tools/chain.py
@@ -288,10 +288,17 @@ class ChainTool(BaseTool):
                         caveats.append(last_message)
                     raw = update.get("progress") or 0
                     aggregate = int(round(base + span * (raw / 100.0)))
-                    yield {
+                    step_update = {
                         "progress": min(max(aggregate, 0), 100),
                         "message": f"[{i + 1}/{n}] {last_message}",
                     }
+                    # Forward the runner's liveness signal. A chained job runs
+                    # far longer than a single one, so dropping it here would
+                    # have every chain reported stalled once it passed
+                    # debug_progress_timeout while making steady progress.
+                    if update.get("activity"):
+                        step_update["activity"] = True
+                    yield step_update
                 cumulative += weights[i]
                 current_in = step_out
 

--- a/app/services/z3ds_compress.py
+++ b/app/services/z3ds_compress.py
@@ -15,7 +15,6 @@ from services.chdman import ConversionCancelled
 from services.subprocess_runner import (
     SubprocessRunner,
     ioprio_prefix,
-    output_size_progress,
     verify_timeout,
 )
 
@@ -171,30 +170,14 @@ class Z3DSCompressService:
         """
         decompress = mode == "z3ds_decompress"
         verb = "decompression" if decompress else "compression"
-        verb_ing = "Decompressing" if decompress else "Compressing"
-        # Rough output:input size ratio, only to smooth the size-based progress
-        # bar (z3ds_compressor prints no parseable percent): compressed output is
-        # ~50% of the source, a decompressed ROM ~2x the compressed container.
-        expected_ratio = 2.0 if decompress else 0.5
-        input_size = (
-            os.path.getsize(input_path) if os.path.exists(input_path) else 0
-        )
-        expected_size = max(1, int(input_size * expected_ratio))
-
-        def _size_progress(size: int) -> dict:
-            return {
-                "progress": output_size_progress(size, expected_size),
-                "message": f"{verb_ing}... ({size // (1024 * 1024)} MB)",
-            }
-
         cmd = self._build_command(input_path, output_path, mode)
         yield {"progress": 5, "message": f"Starting 3DS {verb}..."}
 
         # Delegate the streaming spawn / stall / cancel / PID loop to the shared
         # runner. z3ds keeps preexec nice (owner "z3ds") and folds ionice into
         # _build_command, so nice_via_wrapper stays False. parse_progress is a
-        # no-op — there is no parseable percent — so size_progress drives the bar
-        # from the growing output file.
+        # no-op — there is no parseable percent — so the runner's size-growth
+        # fallback drives the bar from the growing output file.
         try:
             async for update in self._runner.run(
                 cmd,
@@ -205,7 +188,7 @@ class Z3DSCompressService:
                 cancel_event=cancel_event,
                 fail_label="z3ds_compressor",
                 complete_message=f"3DS {verb} complete",
-                size_progress=_size_progress,
+                mode=mode,
             ):
                 yield update
         except (ConversionCancelled, RuntimeError, asyncio.CancelledError, GeneratorExit):

--- a/docs/ADDING_PLATFORMS_AND_TOOLS.md
+++ b/docs/ADDING_PLATFORMS_AND_TOOLS.md
@@ -727,6 +727,11 @@ class NszipTool(BaseTool):
     modes to `SIZE_RATIOS` in `services/subprocess_runner.py` (expected output
     size as a multiple of the input — approximate is fine, it only smooths the
     bar). A mode with no row still reports bytes and rate.
+  - `parse_progress` must return **`None`**, never `0`, for a line carrying no
+    percentage. The runner reads "a percent was parsed" as proof the tool
+    reports its own progress and stands the fallback down for the rest of the
+    run, so a `0` sentinel on the first banner line silently disables status
+    reporting entirely. chdman did exactly this.
   - Implement `parse_progress` only if the binary prints a percentage **that
     survives being piped**. Check this against a real conversion rather than
     against `--help`: several of these tools draw a progress bar only on a TTY

--- a/docs/ADDING_PLATFORMS_AND_TOOLS.md
+++ b/docs/ADDING_PLATFORMS_AND_TOOLS.md
@@ -708,11 +708,32 @@ class NszipTool(BaseTool):
 - **Always** support `cancel_event`: spawn a watcher task that
   `process.terminate()`s (then `kill()`s after a timeout), clean up the partial
   output file, and raise `ConversionCancelled`. See `z3ds_compress.py`.
+- **Never wait on a child process unbounded** — not after EOF, not in a
+  `finally`. Use `SubprocessRunner.reap()`, which escalates TERM -> KILL and then
+  gives up. A process blocked in uninterruptible I/O (a stalled mount, a drive
+  that stopped answering) survives SIGKILL, and because `MAX_CONCURRENT_JOBS`
+  defaults to 1 and runs jobs inline in the dispatcher, one unbounded wait
+  freezes the entire queue rather than just its own job (issue #263).
 - **Always** apply a stall timeout via `compute_progress_stall_timeout(...)` so a
   wedged binary can't hang a job forever.
-- **Progress** is a 0 to 100 int. If the binary doesn't report percentages,
-  estimate from output-file growth like z3ds does, or emit an elapsed-seconds
-  heartbeat via the shared `SubprocessRunner` like dolphin does.
+- **Progress** is a 0 to 100 int, and **every tool reports status whether or not
+  its binary cooperates** — you do not implement this, the shared
+  `SubprocessRunner` does. It uses your `parse_progress` whenever that returns a
+  real percent, and otherwise falls back automatically to the output file
+  growing on disk, emitting MB written and a MB/min rate. So:
+  - Doing nothing already gets you bytes + rate. There is no per-tool progress
+    code to write and none to copy.
+  - Pass `mode=` to `run()` to also get a percentage bar, and add a row for your
+    modes to `SIZE_RATIOS` in `services/subprocess_runner.py` (expected output
+    size as a multiple of the input — approximate is fine, it only smooths the
+    bar). A mode with no row still reports bytes and rate.
+  - Implement `parse_progress` only if the binary prints a percentage **that
+    survives being piped**. Check this against a real conversion rather than
+    against `--help`: several of these tools draw a progress bar only on a TTY
+    and go completely silent on a pipe. dolphin-tool does exactly that, which is
+    why it once showed nothing but a spinning elapsed counter (issue #263).
+  - Never hand-roll a size-growth estimator in a service. That logic lives in
+    the runner precisely so all nine tools behave the same way.
 - Respect the shared priority policy via the `services.subprocess_runner`
   helpers (`ioprio_prefix(owner)`, `nice_prefix(owner)`, `apply_nice(owner)`,
   `info_timeout(owner)`, `verify_timeout(owner)`). These read the tool-neutral
@@ -1129,6 +1150,9 @@ SERVICE (app/services/<tool>.py)
 [ ] *_CONVERTIBLE_EXTENSIONS, *_OUTPUT_FORMATS, module-level singleton
 [ ] convert(): exec (no shell), progress yields, cancel_event, stall timeout,
     nice/ionice, PID tracking, ConversionCancelled, final 100%
+[ ] convert(): pass mode= to run() (+ a SIZE_RATIOS row) so the bar has a
+    percentage; status itself is automatic -- never hand-roll size progress
+[ ] no unbounded process.wait() anywhere; reap() owns TERM->KILL->give up
 [ ] verify() + verify_stream(), info(), get_output_path()
 
 PLUGIN (app/services/tools/<tool>.py)

--- a/docs/DESIGN_tool_plugin_architecture.md
+++ b/docs/DESIGN_tool_plugin_architecture.md
@@ -338,7 +338,7 @@ class SubprocessRunner:
     async def run(self, cmd: list[str], *, input_path: str, output_path: str,
                   parse_progress, cancel_event=None, heartbeat=False,
                   fail_label="process", complete_message="Conversion complete",
-                  cwd=None, output_growth_paths=None, size_progress=None,
+                  cwd=None, output_growth_paths=None, mode=None,
                   nice_via_wrapper=False, env=None,
                   require_output=False) -> AsyncGenerator[dict, None]:
         """Spawn cmd, stream stdout, yield {"progress","message"}.
@@ -347,7 +347,8 @@ class SubprocessRunner:
         `_split_stream_lines` so segmentation is a pure function of the byte
         stream, not chunk boundaries -- issue #183),
         stall timeout via compute_progress_stall_timeout, cancel-watcher
-        (terminate->kill), ConversionCancelled, non-zero exit -> RuntimeError(tail),
+        (terminate->kill via the bounded `reap()` ladder), ConversionCancelled,
+        non-zero exit -> RuntimeError(tail),
         final 100%. `parse_progress(line) -> int|None` is the only per-tool knob
         in the common path. `cwd` sets the working directory (romz runs `7z a`
         from the ROM dir).
@@ -356,10 +357,10 @@ class SubprocessRunner:
         - `heartbeat` — dolphin's 2s "Converting... (Ns)" keep-alive.
         - `output_growth_paths()` — widen the stall probe to a set of files whose
           summed size grows even as filenames change mid-run (makeps3iso split).
-        - `size_progress(output_size) -> dict|None` — turn output growth into the
-          emitted progress for tools with no parseable percent (maxcso/nsz/z3ds);
-          see `output_size_progress()` for the shared 5–95% estimate. Also raises
-          the progress floor so a later non-parseable line can't reset the bar.
+        - `mode` — the conversion mode, used to look up an expected output/input
+          size ratio in `SIZE_RATIOS` so the size-growth fallback (below) can
+          emit a percentage as well as a message. Optional: a mode with no row
+          still reports bytes and rate.
         - `nice_via_wrapper` — skip preexec_fn when the caller prefixed cmd with
           nice/ionice command wrappers (maxcso/nsz avoid forking a Python callable
           in this multithreaded process before exec). `env` — forwarded to the
@@ -369,6 +370,17 @@ class SubprocessRunner:
           non-zero-exit path, so a tool that exits 0 without producing output
           still reports the reason it printed first (nsz, whose `output_path` is
           the temp file the runner already watches).
+        """
+
+    async def reap(self, process, *, exit_timeout=_EXIT_GRACE) -> bool:
+        """Bounded teardown for any spawned child. True if reaped, False if
+        abandoned. Escalates: wait exit_timeout for a voluntary exit, then
+        SIGTERM + grace, then SIGKILL + grace, then give up. A child blocked in
+        uninterruptible I/O (D state) survives SIGKILL, so every wait must be
+        bounded -- an unbounded one blocks the job forever and, at
+        MAX_CONCURRENT_JOBS=1 (the default, which runs jobs inline in the
+        dispatcher), every job queued behind it (issue #263). The single
+        teardown path for run(), run_capture() and their finally blocks.
         """
 
     async def run_capture(self, cmd: list[str], *, timeout=None,
@@ -387,11 +399,37 @@ class SubprocessRunner:
 
 Per-tool `convert()` becomes ~15 lines: build argv, then
 `async for u in self._runner.run(cmd, ..., parse_progress=self._parse_progress): yield u`.
-Tools with no parseable percent (maxcso/nsz/z3ds) pass `size_progress=` to drive
-the bar from output growth and `nice_via_wrapper=True` to keep their
-command-wrapper nice; nsz also forwards its keys-home `env=`, sets
-`require_output=True`, and writes into a private work dir, moving the result onto
-`output_path` after `run()` returns.
+Tools with no parseable percent (maxcso/nsz/z3ds) additionally pass
+`nice_via_wrapper=True` to keep their command-wrapper nice; nsz also forwards its
+keys-home `env=`, sets `require_output=True`, and writes into a private work dir,
+moving the result onto `output_path` after `run()` returns.
+
+### Every tool reports status (issue #263)
+
+Progress reporting is **not** a per-tool responsibility, and no tool hand-rolls
+it. The runner owns both signals and picks between them:
+
+1. **Native, preferred.** `parse_progress(line) -> int|None` parses the tool's
+   own percentage. The moment it returns a real percent, that tool is reporting
+   for itself and the fallback stands down for the rest of the run — the two
+   never compete for the message line.
+2. **Output growth, automatic fallback.** When native parsing never yields a
+   percent — the common case, because most of these CLIs draw a TTY bar that
+   goes silent on a pipe — the runner reports from the output file growing on
+   disk: `output_size_message()` emits **MB written and a MB/min rate**. This
+   needs no per-tool wiring at all, so *a tool that does nothing gets it*.
+   Passing `mode` adds a percentage when `SIZE_RATIOS` knows that mode's
+   expected output/input ratio.
+
+The rate matters as much as the byte count: it is what distinguishes a job that
+is merely slow (bytes climbing, MB/min collapsing) from one that has stopped
+dead. Before this, dolphin-tool reported only elapsed seconds against a 0% bar,
+and users could not tell a crawling conversion from a hung one.
+
+**Adding a tool:** do nothing and it already reports bytes + rate. Add a
+`SIZE_RATIOS` row to also get a percentage bar. Implement `parse_progress` if
+the tool prints a percentage that survives being piped — and verify that it
+actually does, because several do not.
 dolphin's heartbeat and the makeps3iso split-stall probe are likewise opt-in
 flags. One-shot subprocess work (info / header / embedded-hash extraction)
 shares `run_capture()` rather than re-implementing the spawn / cancel / timeout /

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,38 @@
 
 ## 4.4.2 (unreleased)
 
+### Fixed
+
+- **Every tool now reports real status, not just a spinning clock.** Dolphin
+  conversions showed `Converting... (1134s)` against a progress bar pinned at
+  0%, because dolphin-tool draws its progress bar only to a terminal and goes
+  silent the moment we capture its output to a pipe. With no signal at all,
+  there was no way to tell a conversion crawling against a busy array from one
+  that had stopped dead — the two looked identical, indefinitely. Progress
+  reporting is now shared infrastructure rather than something each tool wires
+  up for itself: a tool's own percentages are used whenever it prints any, and
+  when it doesn't, status falls back automatically to the output file growing on
+  disk, reporting **MB written and a MB/min rate**. A slow job now visibly reads
+  as slow — bytes climbing, rate collapsing — instead of as a hang. This applies
+  to all nine tools, including the six that previously had no fallback at all.
+- **A slow conversion is no longer mistaken for a stalled one.** The stall
+  watchdog scales with input size (about 19 minutes without output growth for a
+  4.4 GB image). Tools with no parseable progress fed it nothing but the output
+  file, so a genuinely slow conversion could be killed as if it had wedged. The
+  same size-growth signal now feeds the watchdog for every tool.
+- **One wedged conversion can no longer freeze the whole queue.** A process
+  blocked on unresponsive storage survives both `SIGTERM` and `SIGKILL`, and the
+  code waited for it to exit with no time limit. Since jobs run serially by
+  default, that single job never failed, never cancelled — Cancel sat on
+  *Cancelling...* forever — and every job behind it waited with it. All waits on
+  a subprocess are now bounded and escalate to giving up: the stuck job fails
+  with an explanation and the queue carries on.
+- **A wedged job now says so in the log.** Stuck-queue detection only fired when
+  jobs were queued and *none* were processing, so a job frozen mid-conversion —
+  exactly the case above — was the one state it could not see, and the only
+  record of it was logged at debug level where nobody would find it. It is now a
+  warning at the default log level.
+
 The counting half of the fix 4.4.1 started. 4.4.1 stopped a deep queue from
 *deleting* your job history; this one stops the retention cap from *lying* about
 how much work finished, which is what you notice on a run of thousands.

--- a/tests/test_romz_service.py
+++ b/tests/test_romz_service.py
@@ -357,6 +357,7 @@ def stub_runner(monkeypatch):
     async def fake_run(cmd, *, input_path, output_path, parse_progress, mode=None,
                        cancel_event=None, cwd=None, fail_label="",
                        complete_message=""):
+        calls["mode"] = mode
         calls["run_cmd"] = cmd
         calls["output_path"] = output_path
         calls["cwd"] = cwd
@@ -396,6 +397,7 @@ def test_convert_compress_builds_7z_command_and_clears_stale_output(
     # 7z runs from the ROM's directory and adds only the basename, so the
     # archive stores a root-level `Game.gba`, not the absolute volume path.
     assert calls["cwd"] == str(tmp_path)
+    assert calls["mode"] == "romz_7z"
     # The basename is added with a `./` prefix (literal-safe vs 7z's `@`
     # list-file syntax) and never the absolute path.
     assert os.path.join(".", "Game.gba") in cmd and str(rom) not in cmd
@@ -502,6 +504,7 @@ def test_convert_cleans_partial_output_on_failure(tmp_path, monkeypatch):
     async def boom(cmd, *, input_path, output_path, parse_progress, mode=None,
                    cancel_event=None, cwd=None, fail_label="",
                    complete_message=""):
+        assert mode == "romz_7z"
         Path(output_path).write_bytes(b"PARTIAL")
         raise RuntimeError("7z failed")
         yield  # pragma: no cover - makes this an async generator

--- a/tests/test_romz_service.py
+++ b/tests/test_romz_service.py
@@ -354,7 +354,7 @@ def stub_runner(monkeypatch):
     """Replace the service's SubprocessRunner.run/run_capture with recorders."""
     calls: dict[str, object] = {}
 
-    async def fake_run(cmd, *, input_path, output_path, parse_progress,
+    async def fake_run(cmd, *, input_path, output_path, parse_progress, mode=None,
                        cancel_event=None, cwd=None, fail_label="",
                        complete_message=""):
         calls["run_cmd"] = cmd
@@ -499,7 +499,7 @@ def test_convert_cleans_partial_output_on_failure(tmp_path, monkeypatch):
     rom.write_bytes(b"ROM")
     out = tmp_path / "Game.gba.7z"
 
-    async def boom(cmd, *, input_path, output_path, parse_progress,
+    async def boom(cmd, *, input_path, output_path, parse_progress, mode=None,
                    cancel_event=None, cwd=None, fail_label="",
                    complete_message=""):
         Path(output_path).write_bytes(b"PARTIAL")

--- a/tests/test_stalled_job_warning.py
+++ b/tests/test_stalled_job_warning.py
@@ -75,3 +75,4 @@ def test_chdman_parse_progress_returns_none_for_non_progress_lines():
     assert svc._parse_progress("chdman - MAME Compressed Hunks of Data") is None
     assert svc._parse_progress("Compressing, 45.2% complete...") == 45
     assert svc._parse_progress("Compressing, 99.9% complete...") == 99
+

--- a/tests/test_stalled_job_warning.py
+++ b/tests/test_stalled_job_warning.py
@@ -1,0 +1,77 @@
+"""Stalled-job visibility and the native-progress sentinel (issue #263).
+
+Both guards here cover regressions found in review of the #263 fix: a warning
+that only fired when DEBUG logging was on (so nobody ever saw it), and a
+progress parser whose 0-for-no-match sentinel silently disabled the
+size-growth fallback for the whole run.
+"""
+
+import logging
+import time
+
+from app.models import ConversionMode, JobStatus
+from app.services.chdman import ChdmanService
+from app.services.job_manager import JobManager
+
+
+def _processing_job(mgr: JobManager, job_id: str = "job-1"):
+    """Register a PROCESSING conversion job that last reported long ago."""
+    job = mgr.jobs[job_id] = type(
+        "J", (), {
+            "id": job_id,
+            "status": JobStatus.PROCESSING,
+            "mode": ConversionMode.DOLPHIN_RVZ,
+            "progress": 0,
+            "message": "Converting...",
+            "file_path": "/data/in.iso",
+            "output_path": None,
+            "started_at": None,
+        },
+    )()
+    # Idle far longer than debug_progress_timeout (300s default).
+    mgr._last_progress_at[job_id] = time.monotonic() - 100_000
+    return job
+
+
+def test_stalled_job_warns_with_debug_logging_disabled(caplog):
+    """The warning must reach a default-level log.
+
+    It used to sit below `if not logger.isEnabledFor(DEBUG): continue`, so at the
+    default INFO level a wedged job produced no trace at all -- which is why the
+    reporting user's container log looked clean while their queue was frozen.
+    """
+    mgr = JobManager(max_concurrent=1, max_job_history=10)
+    _processing_job(mgr)
+
+    logging.getLogger("chd.job_manager").setLevel(logging.INFO)
+    with caplog.at_level(logging.WARNING):
+        mgr._log_stalled_jobs()
+
+    assert any("Stalled job" in r.message for r in caplog.records)
+
+
+def test_verifying_job_is_not_reported_as_stalled(caplog):
+    """Verification emits no progress and legitimately runs for many minutes."""
+    mgr = JobManager(max_concurrent=1, max_job_history=10)
+    _processing_job(mgr)
+    mgr._verifying.add("job-1")
+
+    with caplog.at_level(logging.WARNING):
+        mgr._log_stalled_jobs()
+
+    assert not [r for r in caplog.records if "Stalled job" in r.message]
+
+
+def test_chdman_parse_progress_returns_none_for_non_progress_lines():
+    """A non-percentage line is None, not 0.
+
+    The runner reads "a percent was parsed" as proof the tool reports its own
+    progress and stands the size-growth fallback down. Returning 0 for a banner
+    line made the very first line of output look like a report, disabling the
+    fallback for the entire run.
+    """
+    svc = ChdmanService()
+
+    assert svc._parse_progress("chdman - MAME Compressed Hunks of Data") is None
+    assert svc._parse_progress("Compressing, 45.2% complete...") == 45
+    assert svc._parse_progress("Compressing, 99.9% complete...") == 99

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -383,13 +383,16 @@ def test_stall_timeout_raises_runtimeerror(tmp_path, monkeypatch):
 
 
 def test_size_progress_emits_from_output_growth(tmp_path):
-    """Progress for a no-parseable-percent tool comes from the size_progress hook.
+    """A tool that prints no percent still reports, from output-file growth.
 
     The child writes the output file then a stdout line each step, so the
     post-line size tick fires without waiting on the read timeout, and the
-    stream ends at the runner's terminal 100%.
+    stream ends at the runner's terminal 100%. ``mode`` supplies the size ratio,
+    so the fallback carries a percentage as well as the bytes/rate message.
     """
     out = tmp_path / "out.bin"
+    src = tmp_path / "in.bin"
+    src.write_bytes(b"s" * 2000)  # cso_compress ratio 0.5 -> expected 1000
     script = (
         "import sys\n"
         f"out = {str(out)!r}\n"
@@ -400,26 +403,20 @@ def test_size_progress_emits_from_output_growth(tmp_path):
     )
     runner = SubprocessRunner(owner="test")
 
-    def _size_progress(size: int) -> dict:
-        return {
-            "progress": runner_module.output_size_progress(size, 1000),
-            "message": f"sz {size}",
-        }
-
     updates = asyncio.run(
         _drain(
             runner.run(
                 _py_cmd(script),
-                input_path=str(tmp_path / "in.bin"),
+                input_path=str(src),
                 output_path=str(out),
                 parse_progress=lambda _line: None,
-                size_progress=_size_progress,
+                mode="cso_compress",
                 fail_label="testproc",
             )
         )
     )
 
-    size_updates = [u for u in updates if u["message"].startswith("sz ")]
+    size_updates = [u for u in updates if "MB written" in u["message"]]
     assert size_updates, "expected at least one size-based progress update"
     # The estimate matches the shared helper (100 B against expected 1000 -> 14%)
     # and the emitted bar never goes backwards.
@@ -514,22 +511,18 @@ def test_initial_progress_floor_keeps_bar_monotonic(tmp_path):
         "    sys.stdout.write('step\\n'); sys.stdout.flush()\n"
     )
     runner = SubprocessRunner(owner="test")
-
-    def _size_progress(size: int) -> dict:
-        return {
-            "progress": runner_module.output_size_progress(size, 1000),
-            "message": f"sz {size}",
-        }
+    src = tmp_path / "in.bin"
+    src.write_bytes(b"s" * 2000)
 
     updates = asyncio.run(
         _drain(
             runner.run(
                 _py_cmd(script),
-                input_path=str(tmp_path / "in.bin"),
+                input_path=str(src),
                 output_path=str(out),
                 parse_progress=lambda _line: None,
                 initial_progress=5,
-                size_progress=_size_progress,
+                mode="cso_compress",
                 fail_label="testproc",
             )
         )
@@ -592,3 +585,94 @@ def test_run_capture_timeout_returns_none_and_terminates():
     )
     assert rc is None
     assert not runner.active_pids()
+
+
+# ---------------------------------------------------------------------------
+# reap()  (bounded teardown -- issue #263)
+# ---------------------------------------------------------------------------
+
+
+class _UnkillableProcess:
+    """A child that ignores every signal, like one wedged in D state.
+
+    A real process in uninterruptible I/O cannot be simulated (SIGKILL always
+    works on a healthy one), so the ladder is exercised against a stand-in that
+    records the signals and never exits.
+    """
+
+    def __init__(self):
+        self.pid = -1
+        self.returncode = None
+        self.signals: list[str] = []
+
+    def terminate(self):
+        self.signals.append("TERM")
+
+    def kill(self):
+        self.signals.append("KILL")
+
+    async def wait(self):
+        await asyncio.sleep(3600)  # never returns; every caller must bound it
+
+
+def test_reap_abandons_a_child_that_survives_sigkill(monkeypatch):
+    """reap() escalates TERM -> KILL and then gives up instead of hanging.
+
+    The regression guard for #263: an unbounded wait here blocked the job
+    forever and, at MAX_CONCURRENT_JOBS=1, every job queued behind it.
+    """
+    monkeypatch.setattr(runner_module, "_TERM_GRACE", 0.01)
+    monkeypatch.setattr(runner_module, "_KILL_GRACE", 0.01)
+    runner = SubprocessRunner(owner="test")
+    process = _UnkillableProcess()
+
+    reaped = asyncio.run(runner.reap(process, exit_timeout=0.01))
+
+    assert reaped is False, "an unkillable child must be abandoned, not waited on"
+    assert process.signals == ["TERM", "KILL"], "expected the full escalation ladder"
+
+
+def test_reap_returns_true_for_an_already_exited_child():
+    """The common case costs nothing: no signals, no waiting."""
+    runner = SubprocessRunner(owner="test")
+    process = _UnkillableProcess()
+    process.returncode = 0
+
+    assert asyncio.run(runner.reap(process)) is True
+    assert process.signals == []
+
+
+def test_native_progress_suppresses_the_size_fallback(tmp_path):
+    """A tool that reports its own percent is left alone.
+
+    Native parsing and the growth fallback must not both drive the message
+    line; once a real percent is parsed the fallback stands down.
+    """
+    out = tmp_path / "out.bin"
+    src = tmp_path / "in.bin"
+    src.write_bytes(b"s" * 2000)
+    script = (
+        "import sys\n"
+        f"out = {str(out)!r}\n"
+        "with open(out, 'wb') as f:\n"
+        "    for pct in (10, 50):\n"
+        "        f.write(b'x' * 100); f.flush()\n"
+        "        sys.stdout.write(f'{pct}%\\n'); sys.stdout.flush()\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    updates = asyncio.run(
+        _drain(
+            runner.run(
+                _py_cmd(script),
+                input_path=str(src),
+                output_path=str(out),
+                parse_progress=_parse_pct,
+                mode="cso_compress",
+                fail_label="testproc",
+            )
+        )
+    )
+
+    assert not [u for u in updates if "MB written" in u["message"]]
+    assert 50 in [u["progress"] for u in updates]

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -12,7 +12,7 @@ import asyncio
 import os
 import re
 import sys
-import time
+import threading
 
 import pytest
 
@@ -708,12 +708,19 @@ def test_bounded_probe_gives_up_instead_of_waiting(monkeypatch):
     fallback rather than the job hanging (issue #263).
     """
     monkeypatch.setattr(runner_module, "_STAT_TIMEOUT", 0.05)
+    # An Event, not a sleep: shutdown(wait=False) cannot stop the worker, and
+    # the interpreter joins it at exit, so an uninterruptible sleep would stall
+    # the whole test process on the way out.
+    release = threading.Event()
 
     async def _go():
-        return await runner_module._bounded_probe(time.sleep, 30)
+        return await runner_module._bounded_probe(release.wait, 30)
 
-    with pytest.raises(asyncio.TimeoutError):
-        asyncio.run(_go())
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(_go())
+    finally:
+        release.set()
 
 
 def test_bounded_probe_returns_the_value_when_it_lands():

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -704,32 +704,20 @@ def test_bounded_probe_gives_up_instead_of_waiting(monkeypatch):
     """A filesystem probe that never returns must not hold the caller.
 
     Stands in for a `stat` wedged on an unresponsive mount, which cannot be
-    cancelled -- the thread is written off and the caller continues without the
-    measurement rather than hanging the job (issue #263).
+    cancelled -- the thread is written off and the caller decides its own
+    fallback rather than the job hanging (issue #263).
     """
-    from concurrent.futures import ThreadPoolExecutor
-
     monkeypatch.setattr(runner_module, "_STAT_TIMEOUT", 0.05)
-    pool = ThreadPoolExecutor(max_workers=1)
 
     async def _go():
-        return await runner_module._bounded_probe(pool, time.sleep, 30)
+        return await runner_module._bounded_probe(time.sleep, 30)
 
-    try:
-        assert asyncio.run(_go()) is None
-    finally:
-        pool.shutdown(wait=False)
+    with pytest.raises(asyncio.TimeoutError):
+        asyncio.run(_go())
 
 
 def test_bounded_probe_returns_the_value_when_it_lands():
-    from concurrent.futures import ThreadPoolExecutor
-
-    pool = ThreadPoolExecutor(max_workers=1)
-
     async def _go():
-        return await runner_module._bounded_probe(pool, len, "abcd")
+        return await runner_module._bounded_probe(len, "abcd")
 
-    try:
-        assert asyncio.run(_go()) == 4
-    finally:
-        pool.shutdown(wait=False)
+    assert asyncio.run(_go()) == 4

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -820,3 +820,46 @@ def test_activity_flag_marks_real_movement_only(tmp_path):
     assert heartbeats, "expected the keep-alive to fire during the silent stretch"
     assert not any(u.get("activity") for u in heartbeats)
     assert growth and all(u.get("activity") for u in growth)
+
+
+def test_stall_timeout_is_clamped_to_the_sampling_floor(tmp_path, monkeypatch):
+    """A sub-cadence stall timeout must not kill a converter that is writing.
+
+    Growth is sampled every couple of seconds, so a shorter window cannot tell a
+    stalled child from an unsampled one. The timeout is raised to the floor
+    rather than believed.
+    """
+    monkeypatch.setattr(
+        runner_module, "compute_progress_stall_timeout", lambda **_: 1,
+    )
+    out = tmp_path / "out.bin"
+    src = tmp_path / "in.bin"
+    src.write_bytes(b"s" * 2000)
+    # Writes and prints every 100ms: continuously alive, but between samples the
+    # last-known size is stale, which a 1s window would misread as a stall.
+    script = (
+        "import sys, time\n"
+        f"out = {str(out)!r}\n"
+        "with open(out, 'wb') as f:\n"
+        "    for i in range(80):\n"
+        "        f.write(b'x' * 4096); f.flush()\n"
+        "        sys.stdout.write(f'chunk {i}\\n'); sys.stdout.flush()\n"
+        "        time.sleep(0.1)\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    updates = asyncio.run(
+        _drain(
+            runner.run(
+                _py_cmd(script),
+                input_path=str(src),
+                output_path=str(out),
+                parse_progress=lambda _line: None,
+                mode="cso_compress",
+                fail_label="testproc",
+            )
+        )
+    )
+
+    assert updates[-1]["progress"] == 100
+    assert not runner.active_pids()

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -56,7 +56,8 @@ def test_happy_path_streams_progress_then_final_100(tmp_path):
 
     progresses = [u["progress"] for u in updates]
     assert progresses[:3] == [10, 50, 90]
-    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert updates[-1]["progress"] == 100
+    assert updates[-1]["message"] == "Conversion complete"
     assert not runner.active_pids()
 
 
@@ -146,7 +147,8 @@ def test_require_output_present_completes(tmp_path):
         )
     )
 
-    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert updates[-1]["progress"] == 100
+    assert updates[-1]["message"] == "Conversion complete"
     assert out.exists()
     assert not runner.active_pids()
 
@@ -349,7 +351,8 @@ def test_cancel_racing_clean_exit_reports_success(tmp_path, monkeypatch):
         )
     )
 
-    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert updates[-1]["progress"] == 100
+    assert updates[-1]["message"] == "Conversion complete"
     assert not runner.active_pids()
 
 
@@ -428,7 +431,8 @@ def test_size_progress_emits_from_output_growth(tmp_path):
     assert max(u["progress"] for u in size_updates) >= 14
     progresses = [u["progress"] for u in updates]
     assert progresses == sorted(progresses)
-    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert updates[-1]["progress"] == 100
+    assert updates[-1]["message"] == "Conversion complete"
     assert not runner.active_pids()
 
 
@@ -494,7 +498,8 @@ def test_nice_via_wrapper_omits_preexec_fn(tmp_path, monkeypatch):
 
     assert captured.get("preexec_fn") is None
     assert 50 in [u["progress"] for u in updates]
-    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert updates[-1]["progress"] == 100
+    assert updates[-1]["message"] == "Conversion complete"
     assert not runner.active_pids()
 
 
@@ -767,5 +772,51 @@ def test_growing_output_is_not_killed_by_a_short_stall_timeout(tmp_path, monkeyp
         )
     )
 
-    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert updates[-1]["progress"] == 100
+    assert updates[-1]["message"] == "Conversion complete"
     assert not runner.active_pids()
+
+
+def test_activity_flag_marks_real_movement_only(tmp_path):
+    """Keep-alives are not activity; output growth is.
+
+    The job manager judges liveness off this flag, so a heartbeat must not
+    refresh its clock (that made a hung job look alive) and growth must, even
+    once the size estimate pins at its 95% cap (that made a healthy job look
+    stalled).
+    """
+    out = tmp_path / "out.bin"
+    src = tmp_path / "in.bin"
+    src.write_bytes(b"s" * 2000)
+    # Writes once immediately, then goes silent. The first tick has no sample
+    # yet so a heartbeat fires; the growth sample lands a tick later; the rest
+    # of the silence produces heartbeats against an unchanging file.
+    script = (
+        "import time\n"
+        f"out = {str(out)!r}\n"
+        "with open(out, 'wb') as f:\n"
+        "    f.write(b'x' * 4096); f.flush()\n"
+        "time.sleep(4.5)\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    updates = asyncio.run(
+        _drain(
+            runner.run(
+                _py_cmd(script),
+                input_path=str(src),
+                output_path=str(out),
+                parse_progress=lambda _line: None,
+                mode="cso_compress",
+                heartbeat=True,
+                fail_label="testproc",
+            )
+        )
+    )
+
+    heartbeats = [u for u in updates if u["message"].startswith("Converting...")]
+    growth = [u for u in updates if "MB written" in u["message"]]
+
+    assert heartbeats, "expected the keep-alive to fire during the silent stretch"
+    assert not any(u.get("activity") for u in heartbeats)
+    assert growth and all(u.get("activity") for u in growth)

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -680,3 +680,20 @@ def test_native_progress_suppresses_the_size_fallback(tmp_path):
 
     assert not [u for u in updates if "MB written" in u["message"]]
     assert 50 in [u["progress"] for u in updates]
+
+
+def test_size_message_rate_reflects_the_current_window_not_the_average():
+    """A job that was fast and is now crawling must report the crawl.
+
+    Guards the distinction the status line exists to make: with a cumulative
+    average, an early fast phase keeps advertising a high rate long after the
+    conversion has slowed to nothing.
+    """
+    mb = 1024 * 1024
+    # Same 2 GB written in both cases; only the most recent window differs.
+    fast = runner_module.output_size_message(2000 * mb, 500 * mb, 60.0)
+    crawling = runner_module.output_size_message(2000 * mb, 1 * mb, 60.0)
+
+    assert "2,000 MB written" in fast and "2,000 MB written" in crawling
+    assert "500.0 MB/min" in fast
+    assert "1.0 MB/min" in crawling

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -12,6 +12,7 @@ import asyncio
 import os
 import re
 import sys
+import time
 
 import pytest
 
@@ -697,3 +698,38 @@ def test_size_message_rate_reflects_the_current_window_not_the_average():
     assert "2,000 MB written" in fast and "2,000 MB written" in crawling
     assert "500.0 MB/min" in fast
     assert "1.0 MB/min" in crawling
+
+
+def test_bounded_probe_gives_up_instead_of_waiting(monkeypatch):
+    """A filesystem probe that never returns must not hold the caller.
+
+    Stands in for a `stat` wedged on an unresponsive mount, which cannot be
+    cancelled -- the thread is written off and the caller continues without the
+    measurement rather than hanging the job (issue #263).
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    monkeypatch.setattr(runner_module, "_STAT_TIMEOUT", 0.05)
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    async def _go():
+        return await runner_module._bounded_probe(pool, time.sleep, 30)
+
+    try:
+        assert asyncio.run(_go()) is None
+    finally:
+        pool.shutdown(wait=False)
+
+
+def test_bounded_probe_returns_the_value_when_it_lands():
+    from concurrent.futures import ThreadPoolExecutor
+
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    async def _go():
+        return await runner_module._bounded_probe(pool, len, "abcd")
+
+    try:
+        assert asyncio.run(_go()) == 4
+    finally:
+        pool.shutdown(wait=False)

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -721,3 +721,44 @@ def test_bounded_probe_returns_the_value_when_it_lands():
         return await runner_module._bounded_probe(len, "abcd")
 
     assert asyncio.run(_go()) == 4
+
+
+def test_growing_output_is_not_killed_by_a_short_stall_timeout(tmp_path, monkeypatch):
+    """A converter that is writing must never be stalled out by probe lag.
+
+    The growth probe runs off the event loop and is read a tick later, so the
+    first checks have no measurement to judge by. With a stall timeout shorter
+    than the probe cadence, treating "no sample yet" as "no growth" would kill a
+    child whose output is growing steadily.
+    """
+    monkeypatch.setattr(
+        runner_module, "compute_progress_stall_timeout", lambda **_: 1,
+    )
+    out = tmp_path / "out.bin"
+    src = tmp_path / "in.bin"
+    src.write_bytes(b"s" * 2000)
+    script = (
+        "import sys, time\n"
+        f"out = {str(out)!r}\n"
+        "with open(out, 'wb') as f:\n"
+        "    for _ in range(40):\n"          # ~4s of steady writing, silent stdout
+        "        f.write(b'x' * 4096); f.flush()\n"
+        "        time.sleep(0.1)\n"
+    )
+    runner = SubprocessRunner(owner="test")
+
+    updates = asyncio.run(
+        _drain(
+            runner.run(
+                _py_cmd(script),
+                input_path=str(src),
+                output_path=str(out),
+                parse_progress=lambda _line: None,
+                mode="cso_compress",
+                fail_label="testproc",
+            )
+        )
+    )
+
+    assert updates[-1] == {"progress": 100, "message": "Conversion complete"}
+    assert not runner.active_pids()

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -393,13 +393,17 @@ def test_size_progress_emits_from_output_growth(tmp_path):
     out = tmp_path / "out.bin"
     src = tmp_path / "in.bin"
     src.write_bytes(b"s" * 2000)  # cso_compress ratio 0.5 -> expected 1000
+    # The growth probe runs in a worker thread and is read one tick later, so
+    # the child pauses between steps to let each measurement land -- mirroring a
+    # real conversion, where ticks are seconds apart.
     script = (
-        "import sys\n"
+        "import sys, time\n"
         f"out = {str(out)!r}\n"
         "with open(out, 'wb') as f:\n"
         "    for i in range(3):\n"
         "        f.write(b'x' * 100); f.flush()\n"
         "        sys.stdout.write(f'step {i}\\n'); sys.stdout.flush()\n"
+        "        time.sleep(0.2)\n"
     )
     runner = SubprocessRunner(owner="test")
 


### PR DESCRIPTION
Fixes the queue freeze reported in #263. Three separate gaps, all in shared infrastructure rather than in any one tool.

## What happened

A Dolphin queue on Unraid stopped on one file and never recovered. From the reporter's `docker top`, dolphin-tool was alive with **10 seconds of CPU time after ~27 minutes** — not compressing, blocked on storage. The UI read `Converting... (1134s)` against a progress bar pinned at 0%, and Cancel sat on *Cancelling...* forever.

The reporter's own conclusion was the most useful part of the thread: *"it might just be running EXTREMELY slow."* He was probably right — and the fact that neither he nor we could tell that apart from a hang is the actual defect.

## Every tool reports status

dolphin-tool draws its progress bar only on a TTY and goes completely silent when its output is captured to a pipe, so `parse_progress` never fired and the only signal was an elapsed-seconds heartbeat. A crawling conversion and a dead one looked identical, indefinitely.

Progress reporting is now shared infrastructure instead of a per-tool responsibility. The runner owns both signals and chooses:

1. **Native, preferred** — `parse_progress` wins whenever the tool prints a real percent. Once it does, the fallback stops writing the status line, so the two never compete for it.
2. **Output growth, automatic** — otherwise status comes from the output file growing on disk: **MB written and a MB/min rate**, measured between consecutive samples rather than as a cumulative average. Needs no per-tool wiring, so a tool that does nothing still reports. Passing `mode=` adds a percentage from the shared `SIZE_RATIOS` table.

The rate is the part that matters: bytes climbing with MB/min collapsing reads as *slow*, which a byte count alone does not. Six of the nine tools previously had no fallback at all.

This also deletes the three hand-rolled copies of that estimator in `maxcso`/`nsz`/`z3ds` — one implementation, one ratio table, no per-tool progress code.

## A slow job is no longer killed as a stalled one

The stall watchdog scales with input size (~19 min without output growth for a 4.4 GB image; the reported freeze happened at 1134s ≈ the 1125s timeout plus the 5s SIGTERM grace). Tools with no parseable progress fed it nothing but the output file, so a genuinely slow conversion could be terminated as if it had wedged. The same growth signal now feeds the watchdog for every tool.

Growth is sampled on a two-second clock rather than per stdout chunk, so a chatty converter cannot set the probe rate against the very mount whose responsiveness is in question. Because the detector cannot resolve a window shorter than a few sample periods, a configured stall timeout below that floor is raised to it with a warning rather than believed — otherwise "no growth observed" would mean only "not sampled recently" and would kill a converter that is writing steadily.

## No unbounded wait on a child process

A process blocked in uninterruptible I/O survives `SIGTERM` and `SIGKILL` alike. Three sites waited for one to exit with no time limit — after stream EOF, and in two `finally` blocks. Because `MAX_CONCURRENT_JOBS` defaults to 1 and runs jobs inline in the dispatcher, one such wait froze the entire queue rather than just its own job, and Cancel walked into the same dead end.

All three now route through a single bounded `reap()` ladder — wait, `SIGTERM` + grace, `SIGKILL` + grace, then abandon — so the job fails with an explanation and the queue continues. A cancel or stall skips the voluntary-exit grace (the child was already signalled), a child already known to be unkillable is not put through the ladder again at teardown, and both the cancel and stall paths report abandonment rather than a clean stop, since the process is still running and still holding its output.

**Every filesystem call on the spawn path is bounded**, for the same reason: a `stat` on a dead mount blocks in uninterruptible I/O and cannot be cancelled. `os.makedirs`, the adaptive-timeout sizing and the expected-output estimate each get a hard time limit, degrading to a failed job / the baseline timeout / no percentage respectively. Probes run on daemon threads rather than a pool: a pooled worker that never returns starves everything behind it, and `ThreadPoolExecutor` joins its workers at interpreter shutdown, which would stop the container restarting cleanly. Measured with a probe deliberately wedged for 20s, the interpreter now exits in 0.28s. A call that never returns costs one written-off thread — the floor for a syscall Python cannot cancel.

## That state is now visible

`is_stuck()` only fires when jobs are queued and *none* are processing, so a job wedged mid-conversion is precisely the case it cannot see. The one trace of it was logged at debug level *below* a `if not logger.isEnabledFor(DEBUG): continue` gate, which is why the reporter's container log looked clean. The scan is now its own method, runs above that gate at the default log level, touches no filesystem, and exempts the verify phase (which emits no progress and legitimately runs for many minutes).

Liveness is no longer inferred. The runner publishes `"activity": True` on updates that represent real forward movement — a parsed percentage that advanced, or the output file growing — and omits it for keep-alives; the job manager's clock reads that alone, and `ChainTool` forwards it through composite conversions. Deriving it from a proxy failed in both directions: counting update arrivals made a heartbeating-but-hung job look alive, and counting percentage changes made a healthy job look stalled once the size estimate pinned at its 95% cap, when its mode had no size ratio, or when a native tool sat on one integer percentage.

## Notes

- Not addressed here: the underlying reason dolphin-tool stalls at ~0% CPU on that host, which looks like array/share I/O rather than anything in this codebase. These changes make it diagnosable and stop it from taking the queue down.
- Deferred to follow-up issues, all pre-existing and none blocking this fix:
  - the verify stage is unbounded by default (`COMPRESSATORIUM_TOOL_VERIFY_TIMEOUT=0`) with no `cancel_event` threaded into `registry...verify()`;
  - partial-output cleanup in the tool wrappers is unbounded, so a completely dead output mount can still hold the queue slot after the child is abandoned (touches five services);
  - `run_capture` collapses an unkillable child into its ordinary `(None, b"", b"")` timeout result, so a metadata scan keeps walking and can strand a verifier per file (changing that contract touches every capture caller).
- `app/routes/files.py` carries one unrelated one-line change: a stale `match_extension` import, the only ruff error in the tree, removed so `ruff check .` is clean.

## Testing

- `PYTHONPATH=app python -m pytest -q tests` — **1475 passed, 1 skipped**.
- `ruff check .` — **clean**.
- New tests: the `reap()` escalation ladder and its give-up path (against a stand-in child that ignores every signal, since a real D-state process cannot be simulated); native progress suppressing the fallback status line; the interval rate reporting a crawl rather than an early fast average; the bounded probe giving up instead of waiting; a continuously-writing child surviving a sub-cadence stall timeout, and another surviving the clamp path; the activity flag marking growth but not keep-alives; the stalled-job warning firing with DEBUG logging off; and the verify-phase exemption. The two existing size-growth tests were migrated to the new API.
- Three of those regressions — the stall-freshness guard, the activity flag, and the timeout clamp — were each verified to **fail** against the preceding commit, not merely to pass against the fix.

## Docs

- `docs/DESIGN_tool_plugin_architecture.md` — the progress contract and the `reap()` ladder.
- `docs/ADDING_PLATFORMS_AND_TOOLS.md` — what a new tool must do (nothing, to get bytes + rate), that `parse_progress` must return `None` and never `0` for a non-progress line, a warning to verify a tool's percentages actually survive being piped, and never to wait on a child unbounded. Checklist updated.
- `docs/RELEASE_NOTES.md` — 4.4.2.

No UI surfaces changed, so no screenshot refresh is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gnBnXnmHKzFTgAb4g5p1G