### PR TITLE
Fix Docker workflow push failure when target branch diverges

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -108,7 +108,12 @@ jobs:
             # password), not a Bearer token.
             ENCODED_AUTH="$(printf 'x-access-token:%s' "${VERSION_SYNC_TOKEN}" | base64 -w0)"
             echo "::add-mask::${ENCODED_AUTH}"
-            git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${ENCODED_AUTH}" \
+            AUTH_HEADER="http.https://github.com/.extraheader=AUTHORIZATION: basic ${ENCODED_AUTH}"
+            # Rebase onto the target branch in case it moved since the release
+            # tag was created (e.g. a PR merged between tagging and this job).
+            git -c "${AUTH_HEADER}" fetch origin "${TARGET_COMMITISH}"
+            git rebase "origin/${TARGET_COMMITISH}"
+            git -c "${AUTH_HEADER}" \
               push origin "HEAD:${TARGET_COMMITISH}"
           fi
 


### PR DESCRIPTION
## Summary

- Fixes the "Build and Push Docker Image" workflow failing when the `latest` branch has moved since the release tag was created (e.g. a PR merged between tagging and the workflow running).
- The version-sync step now fetches and rebases onto the target branch before pushing, so the version-bump commit always fast-forwards.

## What changed

**`.github/workflows/docker-image.yml`**
- Before the `git push`, added `git fetch origin "${TARGET_COMMITISH}"` and `git rebase "origin/${TARGET_COMMITISH}"` using the same auth header.
- Extracted the auth header into a variable (`AUTH_HEADER`) to avoid repeating it across fetch and push.

## Context

The v4.5.0-beta-2 release build [failed](https://github.com/pacnpal/compressatorium/actions/runs/32176614959/job/95840008877) because PR #276 merged into `latest` between the release tag creation and the Docker workflow's push, causing a non-fast-forward rejection.

## Test plan

- [ ] Re-run the v4.5.0-beta-2 release workflow — the version sync step should now succeed
- [ ] Verify the rebase produces a clean fast-forward when `latest` has moved ahead

---
_Generated by [Claude Code](https://claude.ai/code/session_01Msu16rYSEHXt1FHiBaxTSs)_