### PR TITLE
Strip roms/ prefix from RomM paths when subdirectory is absent

### DIFF
--- a/app/services/romm/client.py
+++ b/app/services/romm/client.py
@@ -398,6 +398,13 @@ class RommClient:
         folder ourselves, and so sidesteps ``platform_slug`` vs
         ``platform_fs_slug`` diverging when the operator overrides folder names.
 
+        When ``library_root`` points directly at the ROM content (no ``roms/``
+        subdirectory on disk), the ``roms/`` prefix in ``full_path`` causes every
+        path to miss.  The method therefore tries both the original relative path
+        and, when it starts with ``roms/``, the stripped variant — returning
+        whichever exists on disk, or the first contained candidate when neither
+        does (so diagnostics can report the attempted path).
+
         Returns None when the record has no usable path, or when the path tries
         to escape the library root.  The escape check is a trust boundary: the
         value is supplied by a remote service, and the caller turns the result
@@ -417,19 +424,36 @@ class RommClient:
         # container bind mount, and a symlinked component would otherwise make
         # a contained path look like an escape (or the reverse).
         root_abs = os.path.realpath(root)
-        # No lstrip("/"): an absolute value is malformed coming from RomM (its
-        # own validate_path rejects one), and stripping the slash would silently
-        # rehome "/etc/passwd" inside the library instead of refusing it.
-        # os.path.join lets an absolute component win, so the containment check
-        # below catches it.
-        candidate = os.path.realpath(os.path.join(root_abs, rel))
-        # realpath collapses any ".." *and* resolves symlinks before this
-        # compares, so neither a traversing full_path nor a symlink planted
-        # inside the library can point the result outside it.
-        if candidate != root_abs and not candidate.startswith(root_abs + os.sep):
-            logger.warning("romm: rejecting out-of-library path %r", rel)
-            return None
-        return candidate
+
+        # RomM's full_path always starts with "roms/" (its standard library
+        # layout).  When library_root already points at the content directory
+        # (no roms/ subdirectory on disk), we need the stripped variant.  Try
+        # the original first so existing setups keep working.
+        candidates = [rel]
+        if rel.startswith("roms/"):
+            candidates.append(rel[len("roms/"):])
+
+        first_valid = None
+        for r in candidates:
+            # No lstrip("/"): an absolute value is malformed coming from RomM
+            # (its own validate_path rejects one), and stripping the slash
+            # would silently rehome "/etc/passwd" inside the library instead
+            # of refusing it.  os.path.join lets an absolute component win, so
+            # the containment check below catches it.
+            resolved = os.path.realpath(os.path.join(root_abs, r))
+            # realpath collapses any ".." *and* resolves symlinks before this
+            # compares, so neither a traversing full_path nor a symlink
+            # planted inside the library can point the result outside it.
+            if resolved == root_abs or not resolved.startswith(root_abs + os.sep):
+                if first_valid is None:
+                    logger.warning("romm: rejecting out-of-library path %r", r)
+                continue
+            if first_valid is None:
+                first_valid = resolved
+            if os.path.exists(resolved):
+                return resolved
+
+        return first_valid
 
 
 def _encode_multipart(fields: dict) -> tuple[bytes, str]:

--- a/app/services/romm/client.py
+++ b/app/services/romm/client.py
@@ -400,10 +400,10 @@ class RommClient:
 
         When ``library_root`` points directly at the ROM content (no ``roms/``
         subdirectory on disk), the ``roms/`` prefix in ``full_path`` causes every
-        path to miss.  The method therefore tries both the original relative path
-        and, when it starts with ``roms/``, the stripped variant — returning
-        whichever exists on disk, or the first contained candidate when neither
-        does (so diagnostics can report the attempted path).
+        path to miss.  The decision is made at the directory level — if
+        ``<root>/roms/`` does not exist as a directory, the prefix is stripped —
+        so a single stale file cannot cause a per-file fallback to an unrelated
+        same-named file under a different layout.
 
         Returns None when the record has no usable path, or when the path tries
         to escape the library root.  The escape check is a trust boundary: the
@@ -426,34 +426,28 @@ class RommClient:
         root_abs = os.path.realpath(root)
 
         # RomM's full_path always starts with "roms/" (its standard library
-        # layout).  When library_root already points at the content directory
-        # (no roms/ subdirectory on disk), we need the stripped variant.  Try
-        # the original first so existing setups keep working.
-        candidates = [rel]
-        if rel.startswith("roms/"):
-            candidates.append(rel[len("roms/"):])
+        # layout).  When library_root points directly at the content (no
+        # roms/ subdirectory on disk), strip the prefix.  The check is
+        # directory-level so a stale individual file cannot trigger a
+        # per-file fallback to an unrelated same-named file.
+        if rel.startswith("roms/") and not os.path.isdir(
+            os.path.join(root_abs, "roms")
+        ):
+            rel = rel[len("roms/"):]
 
-        first_valid = None
-        for r in candidates:
-            # No lstrip("/"): an absolute value is malformed coming from RomM
-            # (its own validate_path rejects one), and stripping the slash
-            # would silently rehome "/etc/passwd" inside the library instead
-            # of refusing it.  os.path.join lets an absolute component win, so
-            # the containment check below catches it.
-            resolved = os.path.realpath(os.path.join(root_abs, r))
-            # realpath collapses any ".." *and* resolves symlinks before this
-            # compares, so neither a traversing full_path nor a symlink
-            # planted inside the library can point the result outside it.
-            if resolved == root_abs or not resolved.startswith(root_abs + os.sep):
-                if first_valid is None:
-                    logger.warning("romm: rejecting out-of-library path %r", r)
-                continue
-            if first_valid is None:
-                first_valid = resolved
-            if os.path.exists(resolved):
-                return resolved
-
-        return first_valid
+        # No lstrip("/"): an absolute value is malformed coming from RomM
+        # (its own validate_path rejects one), and stripping the slash would
+        # silently rehome "/etc/passwd" inside the library instead of
+        # refusing it.  os.path.join lets an absolute component win, so the
+        # containment check below catches it.
+        candidate = os.path.realpath(os.path.join(root_abs, rel))
+        # realpath collapses any ".." *and* resolves symlinks before this
+        # compares, so neither a traversing full_path nor a symlink planted
+        # inside the library can point the result outside it.
+        if candidate != root_abs and not candidate.startswith(root_abs + os.sep):
+            logger.warning("romm: rejecting out-of-library path %r", rel)
+            return None
+        return candidate
 
 
 def _encode_multipart(fields: dict) -> tuple[bytes, str]:

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -179,9 +179,9 @@ it or moving the schedule clock. Sections are newest-first.
 - **RomM path resolution: strip the `roms/` prefix automatically.** RomM's
   `full_path` always starts with `roms/` (its standard library layout), but
   many deployments mount the ROM content directly — no `roms/` subdirectory on
-  disk.  `local_path()` now tries both the original path and the stripped
-  variant, returning whichever exists.  Existing setups where `roms/` is on
-  disk are unaffected (the original path is tried first).
+  disk.  `local_path()` now detects the layout at the directory level: when
+  `<root>/roms/` does not exist as a directory, the `roms/` prefix is stripped
+  from all paths.  Existing setups where `roms/` is on disk are unaffected.
 
 - **The Hasheous lookup timeout now really is a whole-request timeout.** It
   bounded the response, but every phase before TLS existed had its own budget:

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -176,6 +176,13 @@ it or moving the schedule clock. Sections are newest-first.
 
 ### Fixed
 
+- **RomM path resolution: strip the `roms/` prefix automatically.** RomM's
+  `full_path` always starts with `roms/` (its standard library layout), but
+  many deployments mount the ROM content directly — no `roms/` subdirectory on
+  disk.  `local_path()` now tries both the original path and the stripped
+  variant, returning whichever exists.  Existing setups where `roms/` is on
+  disk are unaffected (the original path is tried first).
+
 - **The Hasheous lookup timeout now really is a whole-request timeout.** It
   bounded the response, but every phase before TLS existed had its own budget:
   `socket.create_connection` gives each address a host resolves to the *full*

--- a/tests/test_romm.py
+++ b/tests/test_romm.py
@@ -146,15 +146,18 @@ def test_local_path_strips_roms_prefix(tmp_path: Path) -> None:
     assert got == str(tmp_path / "snes" / "Game.sfc")
 
 
-def test_local_path_no_file_returns_first_candidate(tmp_path: Path) -> None:
-    """When neither candidate exists, return the first valid path for diagnostics."""
+def test_local_path_no_roms_dir_strips_prefix(tmp_path: Path) -> None:
+    """When roms/ directory is absent, the prefix is stripped even if the
+    file itself doesn't exist (for diagnostics the stripped path is returned)."""
     client = RommClient(base_url="http://romm:8080")
     with patch.object(RommClient, "library_root", str(tmp_path)):
         got = client.local_path({"full_path": "roms/snes/Game.sfc"})
-    assert got == str(tmp_path / "roms" / "snes" / "Game.sfc")
+    assert got == str(tmp_path / "snes" / "Game.sfc")
 
 
 def test_local_path_falls_back_to_fs_path_and_name(tmp_path: Path) -> None:
+    """When full_path is absent, fs_path/fs_name are used instead."""
+    (tmp_path / "roms" / "gc").mkdir(parents=True)
     client = RommClient(base_url="http://romm:8080")
     with patch.object(RommClient, "library_root", str(tmp_path)):
         got = client.local_path({"fs_path": "roms/gc", "fs_name": "Game.iso"})

--- a/tests/test_romm.py
+++ b/tests/test_romm.py
@@ -126,6 +126,28 @@ def test_roms_pages_until_short_page(client: RommClient) -> None:
 
 
 def test_local_path_joins_full_path(tmp_path: Path) -> None:
+    """When the roms/ subdirectory exists, local_path uses the full path."""
+    (tmp_path / "roms" / "snes").mkdir(parents=True)
+    (tmp_path / "roms" / "snes" / "Game.sfc").touch()
+    client = RommClient(base_url="http://romm:8080")
+    with patch.object(RommClient, "library_root", str(tmp_path)):
+        got = client.local_path({"full_path": "roms/snes/Game.sfc"})
+    assert got == str(tmp_path / "roms" / "snes" / "Game.sfc")
+
+
+def test_local_path_strips_roms_prefix(tmp_path: Path) -> None:
+    """When library_root points directly at the content (no roms/ on disk),
+    the roms/ prefix from RomM's full_path is stripped automatically."""
+    (tmp_path / "snes").mkdir()
+    (tmp_path / "snes" / "Game.sfc").touch()
+    client = RommClient(base_url="http://romm:8080")
+    with patch.object(RommClient, "library_root", str(tmp_path)):
+        got = client.local_path({"full_path": "roms/snes/Game.sfc"})
+    assert got == str(tmp_path / "snes" / "Game.sfc")
+
+
+def test_local_path_no_file_returns_first_candidate(tmp_path: Path) -> None:
+    """When neither candidate exists, return the first valid path for diagnostics."""
     client = RommClient(base_url="http://romm:8080")
     with patch.object(RommClient, "library_root", str(tmp_path)):
         got = client.local_path({"full_path": "roms/snes/Game.sfc"})


### PR DESCRIPTION
## Summary

- Fixes RomM library view showing "No matching ROMs on this volume" when the library root points directly at the ROM content (no `roms/` subdirectory on disk).
- RomM's `full_path` always starts with `roms/` (e.g. `roms/3do/Game.chd`), but many deployments mount content directly at the library root. `local_path()` now detects the layout at the directory level: when `<root>/roms/` does not exist as a directory, the `roms/` prefix is stripped from all paths.
- Existing setups where `roms/` is on disk are unaffected.

## What changed

**`app/services/romm/client.py`**
- `local_path()` uses `os.path.isdir(<root>/roms)` to decide whether to strip the `roms/` prefix. When the directory is absent, the prefix is stripped for all paths; when it exists, paths are used as-is.
- Path traversal protection via `os.path.realpath()` containment check.

**`tests/test_romm.py`**
- 9 tests covering `local_path()` behavior: with `roms/` directory present, without it, fallback fields, path traversal rejection, and empty/missing inputs.

**`docs/RELEASE_NOTES.md`**
- Added release note under "### Fixed" in 4.5.0-beta-1 section.

## Test plan

- [x] All 9 local_path tests pass
- [x] `ruff check` clean
- [ ] Deploy with `ROMM_LIBRARY_ROOT=/data/games` where files are at `/data/games/3do/...` — ROMs should now resolve
- [ ] Deploy with `ROMM_LIBRARY_ROOT=/data/games` where files are at `/data/games/roms/3do/...` — should still work

---
_Generated by [Claude Code](https://claude.ai/code/session_01Msu16rYSEHXt1FHiBaxTSs)_