### PR TITLE
fix(docker): install dolphin-emu on arm64 too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -223,13 +223,10 @@ RUN apt-get update -o Acquire::Retries=3 && \
       libdeflate0 \
       zlib1g \
       ca-certificates && \
-    # Install dolphin-emu only where available/practical (non-fatal)
-    if [ "$TARGETARCH" = "amd64" ]; then \
-      apt-get install -y --no-install-recommends dolphin-emu || \
-        echo "WARNING: dolphin-emu install failed on amd64; continuing without it"; \
-    else \
-      echo "Skipping dolphin-emu on ${TARGETARCH}"; \
-    fi && \
+    # Install dolphin-emu (packaged for both amd64 and arm64 on trixie; kept
+    # non-fatal in case a future/unsupported TARGETARCH has no build)
+    (apt-get install -y --no-install-recommends dolphin-emu || \
+      echo "WARNING: dolphin-emu install failed on ${TARGETARCH}; continuing without it") && \
     # --- Install pinned mame-tools from snapshot ---
     MAME_DEB="mame-tools_${MAME_TOOLS_VERSION}_${TARGETARCH}.deb" && \
     if [ "$TARGETARCH" = "amd64" ]; then \

--- a/docs/ADDING_PLATFORMS_AND_TOOLS.md
+++ b/docs/ADDING_PLATFORMS_AND_TOOLS.md
@@ -489,8 +489,9 @@ for the stage list). Pick the one that fits:
 
 - **Distro package** (chdman via `mame-tools`, pinned to a `snapshot.debian.org`
   `.deb` with per-arch SHA256 checks).
-- **Distro package, best-effort** (dolphin-emu, amd64-only, non-fatal). A wrapper
-  script at `/usr/local/bin/dolphin-tool` is created only if the binary exists.
+- **Distro package, best-effort** (dolphin-emu, amd64+arm64, non-fatal). A
+  wrapper script at `/usr/local/bin/dolphin-tool` is created only if the
+  binary exists.
 - **Build from source in the `builder` stage** (z3ds), then copy the artifact
   into the runtime image.
 


### PR DESCRIPTION
## Summary
- `Dockerfile` gated `dolphin-emu` install to `amd64` only, silently skipping it (and the `dolphin-tool` wrapper) on `arm64`.
- Debian trixie has shipped an arm64 build of `dolphin-emu` (`2503+dfsg-1+deb13u1`, confirmed via https://packages.debian.org/trixie/arm64/dolphin-emu) since before this gate was added, so the exclusion is no longer necessary.
- Drop the `amd64`-only check and attempt the install unconditionally, keeping the existing non-fatal fallback (via an explicit `(... || echo WARNING ...)` subshell, so the `&&` chain always continues regardless of arch) in case a future/unsupported `TARGETARCH` has no build.
- Updated `docs/ADDING_PLATFORMS_AND_TOOLS.md`'s reference to the old "amd64-only" behavior.

## Test plan
- [x] `bash -n` syntax-check on the extracted `RUN` shell script (no docker daemon available in this environment to run an actual multi-arch build)
- [x] Confirmed via Debian's package page that `dolphin-emu` ships an arm64 build on trixie
- [ ] CI's multi-arch Docker build (`linux/amd64` + `linux/arm64`) on this PR

Fixes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HP54zxNsWhK8d5hziBq1MP

---
_Generated by [Claude Code](https://claude.ai/code/session_01HP54zxNsWhK8d5hziBq1MP)_